### PR TITLE
Feature/31 replace api key

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -11,7 +11,7 @@ FECFILE_FEC_WEBSITE_API_KEY=
 ```
 Notes:
 * There is no default FECFILE_FEC_WEBSITE_API_KEY, you must obtain and set this yourself
-* that the FECFILE_DB_HOST is different here than what you need for your docker-compose configuration.
+* The FECFILE_DB_HOST value here is different than what you need for your local docker-compose configuration.
 
 # Using CircleCI local CLI 
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -7,8 +7,11 @@ FECFILE_DB_HOST=localhost
 FECFILE_DB_USERNAME=postgres 
 FECFILE_DB_PASSWORD=postgres 
 FECFILE_DB_NAME=postgres 
+FECFILE_FEC_WEBSITE_API_KEY=
 ```
-NOTE that the FECFILE_DB_HOST is different here than what you need for your docker-compose configuration.
+Notes:
+* There is no default FECFILE_FEC_WEBSITE_API_KEY, you must obtain and set this yourself
+* that the FECFILE_DB_HOST is different here than what you need for your docker-compose configuration.
 
 # Using CircleCI local CLI 
 

--- a/django-backend/fecfiler/core/aggregation_helper.py
+++ b/django-backend/fecfiler/core/aggregation_helper.py
@@ -1,6 +1,7 @@
 import logging
 import datetime
 import requests
+import fecfiler.settings
 
 # from functools import lru_cache
 from django.db import connection
@@ -911,8 +912,8 @@ def get_election_year(office_sought, election_state, election_district):
         election_year_list = []
         while True:
             ab = requests.get(
-                "https://api.open.fec.gov/v1/election-dates/?sort=-election_date&api_key=50nTHLLMcu3XSSzLnB0hax2Jg5LFniladU5Yf25j&page={}&per_page=100&sort_hide_null=false&sort_nulls_last=false{}".format(
-                    i, param_string
+                "https://api.open.fec.gov/v1/election-dates/?sort=-election_date&api_key={}&page={}&per_page=100&sort_hide_null=false&sort_nulls_last=false{}".format(
+                    fecfiler.settings.FECFILE_FEC_WEBSITE_API_KEY, i, param_string
                 )
             )
             results = results + ab.json()["results"]

--- a/django-backend/fecfiler/core/tests.py
+++ b/django-backend/fecfiler/core/tests.py
@@ -1,3 +1,13 @@
 from django.test import TestCase
+from fecfiler.core.aggregation_helper import get_election_year
 
-# Create your tests here.
+
+class SimpleTest(TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_election_year(self):
+        result = get_election_year("H", "NJ", "01")
+        self.assertGreater(len(result), 0, "did not get expected number of results from get_election_year")
+        self.assertGreater(result[0], 1776, "Invalid election year - too long ago")
+

--- a/django-backend/fecfiler/core/tests.py
+++ b/django-backend/fecfiler/core/tests.py
@@ -10,4 +10,3 @@ class SimpleTest(TestCase):
         result = get_election_year("H", "NJ", "01")
         self.assertGreater(len(result), 0, "did not get expected number of results from get_election_year")
         self.assertGreater(result[0], 1776, "Invalid election year - too long ago")
-

--- a/django-backend/fecfiler/forms/views.py
+++ b/django-backend/fecfiler/forms/views.py
@@ -898,7 +898,8 @@ def get_rad_analyst_info(request):
     if request.method == 'GET':
         try:
             if get_comittee_id(request.user.username):
-                ab = requests.get('https://api.open.fec.gov/v1/rad-analyst/?page=1&per_page=20&api_key=50nTHLLMcu3XSSzLnB0hax2Jg5LFniladU5Yf25j&committee_id=' + get_comittee_id(request.user.username) + '&sort_hide_null=false&sort_null_only=false')
+                url = 'https://api.open.fec.gov/v1/rad-analyst/?page=1&per_page=20&api_key={}&committee_id='.format(settings.FECFILE_FEC_WEBSITE_API_KEY) + get_comittee_id(request.user.username) + '&sort_hide_null=false&sort_null_only=false'
+                ab = requests.get(url)
                 return JsonResponse({"response": ab.json()['results']})
             else:
                 return JsonResponse({"ERROR": "You must be logged in  for this operation."})

--- a/django-backend/fecfiler/sched_F/tests.py
+++ b/django-backend/fecfiler/sched_F/tests.py
@@ -1,3 +1,13 @@
 from django.test import TestCase
+from fecfiler.sched_F.views import get_election_year
 
-# Create your tests here.
+
+class SimpleTest(TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_election_year(self):
+        result = get_election_year("H", "NJ", "01")
+        self.assertGreater(len(result), 0, "did not get expected number of results from get_election_year")
+        self.assertGreater(result[0], 1776, "Invalid election year - too long ago")
+

--- a/django-backend/fecfiler/sched_F/tests.py
+++ b/django-backend/fecfiler/sched_F/tests.py
@@ -10,4 +10,3 @@ class SimpleTest(TestCase):
         result = get_election_year("H", "NJ", "01")
         self.assertGreater(len(result), 0, "did not get expected number of results from get_election_year")
         self.assertGreater(result[0], 1776, "Invalid election year - too long ago")
-

--- a/django-backend/fecfiler/sched_F/views.py
+++ b/django-backend/fecfiler/sched_F/views.py
@@ -1103,11 +1103,12 @@ def get_election_year(office_sought, election_state, election_district):
         results = []
         election_year_list = []
         while True:
-            ab = requests.get(
-                "https://api.open.fec.gov/v1/election-dates/?sort=-election_date&api_key=50nTHLLMcu3XSSzLnB0hax2Jg5LFniladU5Yf25j&page={}&per_page=100&sort_hide_null=false&sort_nulls_last=false{}".format(
-                    i, param_string
-                )
-            )
+            url = ( "https://api.open.fec.gov/v1/election-dates/?" +
+                    "sort=-election_date&api_key={}".format(settings.FECFILE_FEC_WEBSITE_API_KEY) +
+                    "&page={}".format(i) +
+                    "&per_page=100&sort_hide_null=false&sort_nulls_last=false{}".format(param_string))
+
+            ab = requests.get(url)
             results = results + ab.json()["results"]
             if (
                 i == ab.json()["pagination"]["pages"]

--- a/django-backend/fecfiler/sched_F/views.py
+++ b/django-backend/fecfiler/sched_F/views.py
@@ -1103,10 +1103,10 @@ def get_election_year(office_sought, election_state, election_district):
         results = []
         election_year_list = []
         while True:
-            url = ( "https://api.open.fec.gov/v1/election-dates/?" +
-                    "sort=-election_date&api_key={}".format(settings.FECFILE_FEC_WEBSITE_API_KEY) +
-                    "&page={}".format(i) +
-                    "&per_page=100&sort_hide_null=false&sort_nulls_last=false{}".format(param_string))
+            url = ("https://api.open.fec.gov/v1/election-dates/?"
+                   + "sort=-election_date&api_key={}".format(settings.FECFILE_FEC_WEBSITE_API_KEY)
+                   + "&page={}".format(i)
+                   + "&per_page=100&sort_hide_null=false&sort_nulls_last=false{}".format(param_string))
 
             ab = requests.get(url)
             results = results + ab.json()["results"]

--- a/django-backend/fecfiler/settings.py
+++ b/django-backend/fecfiler/settings.py
@@ -59,6 +59,7 @@ API_PASSWORD = os.environ.get('API_PASSWORD', None)
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '!0)(sp6(&$=_70&+_(zogh24=)@5&smwtuwq@t*v88tn-#m=)z'
 
+FECFILE_FEC_WEBSITE_API_KEY = os.environ.get('FECFILE_FEC_WEBSITE_API_KEY')
 
 ROOT_URLCONF = 'fecfiler.urls'
 WSGI_APPLICATION = 'fecfiler.wsgi.application'


### PR DESCRIPTION
* Added FECFILE_FEC_WEBSITE_API_KEY to fecfiler.settings
* Configure FECFILE_FEC_WEBSITE_API_KEY by reading environment
* Modified URLs that had a hard coded API key
* Added unit tests for 2 out of 3 places where key was used. (last one requires better test data or significant mocking and is out of scope at this time)
* Added a note in .circleci README.md documenting the new environment variable.