### PR TITLE
Adding manifest files for prod and stage

### DIFF
--- a/deploy-config/fecfile-web-app-prod-manifest.yml
+++ b/deploy-config/fecfile-web-app-prod-manifest.yml
@@ -1,0 +1,11 @@
+applications:
+  - name: fecfile-web-app
+    instances: 1
+    memory: 128M
+    buildpack: nginx_buildpack
+
+    routes:
+      - route:  fecfile-web-app-prod.app.cloud.gov
+
+    env:
+      EXAMPLE: example

--- a/deploy-config/fecfile-web-app-stage-manifest.yml
+++ b/deploy-config/fecfile-web-app-stage-manifest.yml
@@ -1,0 +1,11 @@
+applications:
+  - name: fecfile-web-app
+    instances: 1
+    memory: 128M
+    buildpack: nginx_buildpack
+
+    routes:
+      - route:  fecfile-web-app-stage.app.cloud.gov
+
+    env:
+      EXAMPLE: example


### PR DESCRIPTION
When updating and testing the acceptance criteria for the issue, I saw that we will have to actually deploy to Stage and Prod for this to be testable.  In doing that testing, I saw that the stage and prod manifest files were not yet created.  This follow up PR adds them in to the repo with the same defaults (other than route) as the development manifest.