### PR TITLE
Patch 145 disable edit of contact type

### DIFF
--- a/front-end/src/app/contacts/contact-detail/contact-detail.component.html
+++ b/front-end/src/app/contacts/contact-detail/contact-detail.component.html
@@ -22,6 +22,7 @@
               inputId="type"
               formControlName="type"
               [options]="contactTypeOptions"
+              [disabled]="!isNewContact"
               optionLabel="name"
               optionValue="code"
             ></p-dropdown>

--- a/front-end/src/app/contacts/contact-detail/contact-detail.component.html
+++ b/front-end/src/app/contacts/contact-detail/contact-detail.component.html
@@ -1,7 +1,7 @@
 <p-dialog
   [(visible)]="detailVisible"
   [style]="{ width: '90%' }"
-  [header]="detailTitle"
+  [header]="isNewContact ? 'Add Contact' : 'Edit Contact'"
   [modal]="true"
   styleClass="p-fluid"
   (onShow)="onOpenDetail()"

--- a/front-end/src/app/contacts/contact-detail/contact-detail.component.ts
+++ b/front-end/src/app/contacts/contact-detail/contact-detail.component.ts
@@ -13,7 +13,7 @@ import { LabelUtils, PrimeOptions, StatesCodeLabels, CountryCodeLabels } from 'a
 export class ContactDetailComponent implements OnInit {
   @Input() contact: Contact = new Contact();
   @Input() detailVisible: boolean = false;
-  @Input() detailTitle: string = 'Add Contact';
+  @Input() isNewContact: boolean = false;
   @Output() detailVisibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() loadTableItems: EventEmitter<any> = new EventEmitter<any>();
 

--- a/front-end/src/app/contacts/contact-list/contact-list.component.html
+++ b/front-end/src/app/contacts/contact-list/contact-list.component.html
@@ -101,7 +101,7 @@
 <app-contact-detail
   [contact]="this.item"
   [(detailVisible)]="detailVisible"
-  [detailTitle]="detailTitle"
+  [isNewContact]="isNewContact"
   (loadTableItems)="loadTableItems($event)"
 ></app-contact-detail>
 

--- a/front-end/src/app/contacts/contact-list/contact-list.component.ts
+++ b/front-end/src/app/contacts/contact-list/contact-list.component.ts
@@ -34,11 +34,11 @@ export class ContactListComponent extends TableListBaseComponent<Contact> implem
 
   public override addItem() {
     super.addItem();
-    this.detailTitle = 'Add Contact';
+    this.isNewContact = true;
   }
 
   public override editItem(item: Contact) {
     super.editItem(item);
-    this.detailTitle = 'Edit Contact';
+    this.isNewContact = false;
   }
 }

--- a/front-end/src/app/shared/components/table-list-base.component.ts
+++ b/front-end/src/app/shared/components/table-list-base.component.ts
@@ -15,7 +15,7 @@ export abstract class TableListBaseComponent<T> {
   selectAll: boolean = false;
   selectedItems: T[] = [];
   detailVisible: boolean = false;
-  detailTitle: string = 'Add Item';
+  isNewContact: boolean = true;
   protected itemService!: TableListService<T>;
 
   constructor(protected messageService: MessageService, protected confirmationService: ConfirmationService) {}
@@ -77,13 +77,13 @@ export abstract class TableListBaseComponent<T> {
   public addItem() {
     this.item = this.getEmptyItem();
     this.detailVisible = true;
-    this.detailTitle = 'Add Item';
+    this.isNewContact = true;
   }
 
   public editItem(item: T) {
     this.item = item;
     this.detailVisible = true;
-    this.detailTitle = 'Edit Item';
+    this.isNewContact = false;
   }
 
   public deleteItem(item: T) {


### PR DESCRIPTION
#145 
When editing an existing contact, the type field is disabled

### Testing
open the contacts page
click the "new +" button to create a new contact.
you should be able to change the contact type in this modal
save the contact
find the contact in the contacts list and click the edit ✏️ button
you should NOT be able to change the contact type in this modal