### PR TITLE
Change schema url location to http from https to fix failing unit test

### DIFF
--- a/front-end/src/app/shared/components/error-messages/error-messages.component.spec.ts
+++ b/front-end/src/app/shared/components/error-messages/error-messages.component.spec.ts
@@ -11,7 +11,7 @@ describe('ErrorMessagesComponent', () => {
   let validateService: ValidateService;
 
   const testSchema: JsonSchema = {
-    $schema: 'https://json-schema.org/draft-07/schema#',
+    $schema: 'http://json-schema.org/draft-07/schema#',
     $id: 'https://unit-test',
     type: 'object',
     required: [],


### PR DESCRIPTION
The Ajv schema library requires schema urls to resolve to http not https