### PR TITLE
Fix textarea required message and form refresh issues

### DIFF
--- a/front-end/src/app/shared/interfaces/transaction-meta.interface.ts
+++ b/front-end/src/app/shared/interfaces/transaction-meta.interface.ts
@@ -11,5 +11,6 @@ export interface TransactionMeta {
   title: string;
   contributionPurposeDescripReadonly: (...params: any) => string; // eslint-disable-line @typescript-eslint/no-explicit-any
   schema: JsonSchema;
-  transaction: Transaction;
+  factory: () => Transaction;
+  transaction: Transaction | null;
 }

--- a/front-end/src/app/shared/resolvers/transaction.resolver.ts
+++ b/front-end/src/app/shared/resolvers/transaction.resolver.ts
@@ -21,6 +21,7 @@ export class TransactionResolver implements Resolve<TransactionMeta | undefined>
     if (transactionType) {
       // This is a new transaction
       tm = TransactionUtils.getMeta(transactionType);
+      tm.transaction = tm.factory();
       tm.transaction.report_id = Number(reportId);
       return of(tm);
     }

--- a/front-end/src/app/shared/utils/transaction.utils.ts
+++ b/front-end/src/app/shared/utils/transaction.utils.ts
@@ -13,10 +13,11 @@ const meta: { [transaction_type_identifier: string]: TransactionMeta } = {
     title: 'Offsets to Operating Expenditures',
     contributionPurposeDescripReadonly: () => '',
     schema: OFFSET_TO_OPEX,
-    transaction: SchATransaction.fromJSON({
+    factory: () => SchATransaction.fromJSON({
       form_type: 'SA15',
       transaction_type_identifier: 'OFFSET_TO_OPEX',
     }),
+    transaction: null,
   },
 };
 

--- a/front-end/src/app/transactions/transaction-group-b/transaction-group-b.component.html
+++ b/front-end/src/app/transactions/transaction-group-b/transaction-group-b.component.html
@@ -251,6 +251,11 @@
             [autoResize]="true"
             formControlName="contribution_purpose_descrip"
           ></textarea>
+          <app-error-messages
+            [form]="form"
+            fieldName="contribution_purpose_descrip"
+            [formSubmitted]="formSubmitted"
+          ></app-error-messages>
         </div>
       </div>
     </div>
@@ -266,6 +271,11 @@
             [autoResize]="true"
             formControlName="memo_text_description"
           ></textarea>
+          <app-error-messages
+            [form]="form"
+            fieldName="memo_text_description"
+            [formSubmitted]="formSubmitted"
+          ></app-error-messages>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Addresses QA issues found in #230 

- Form not clearing when opening a new Group B transaction
- Over 100 character error message for text areas on Group B form