### PR TITLE
Defect/173 report coverage date overlap

### DIFF
--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { AbstractControl, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
@@ -185,9 +185,34 @@ describe('CreateF3XStep1Component', () => {
     ).toBe(false);
   });
 
+  it('setCoverageOverlapError should set an error', ()=>{
+    const formValue: AbstractControl = component.form.controls['coverage_from_date'];
+    const overlap: F3xCoverageDates = F3xCoverageDates.fromJSON({
+      coverage_from_date: "10/10/2010",
+      coverage_through_date: "11/10/2010",
+    });
+    component.setCoverageOverlapError(formValue, overlap);
+    expect(component.form.controls['coverage_from_date'].errors).not.toBe(null);
+  });
+
   it('The coverage date validator does not explode if passed an AbstractControl instead of a FormGroup', ()=>{
     const validatorFn = component.buildCoverageDatesValidator();
     const field = component.form.controls['coverage_from_date'];
     expect(validatorFn(field)).toBe(null);
+
+  });
+
+  it('Should catch an overlap in dates with the constructed validator function', ()=>{
+    const validatorFn = component.buildCoverageDatesValidator();
+    component.form.controls['coverage_from_date'].setValue(new Date("12/15/2010"));
+    component.form.controls['coverage_through_date'].setValue(new Date("1/01/2011"));
+    component.f3xCoverageDatesList = [F3xCoverageDates.fromJSON({
+      coverage_from_date: new Date("12/01/2010"),
+      coverage_through_date: new Date("12/31/2010"),
+    })];
+
+    validatorFn(component.form);
+    expect(component.form.controls['coverage_from_date'].errors).not.toEqual(null);
+   
   });
 });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -163,4 +163,14 @@ describe('CreateF3XStep1Component', () => {
       component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
     ).toBe(false);
   });
+
+  it('Tests the getCoverageDatesValidator() method', ()=>{
+    const dates = F3xCoverageDates.fromJSON({
+      coverage_from_date: '10/10/2010',
+      coverage_through_date: '11/10/2010'
+    });
+
+    expect(component.getCoverageDatesValidator(dates)).toBeTruthy();
+    expect(component.getCoverageDatesValidator(undefined)).not.toBeTruthy();
+  })
 });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -116,9 +116,9 @@ describe('CreateF3XStep1Component', () => {
 
   it('should catch date overlaps', ()=>{
     //New dates inside of existing report
-    const fieldDate = new Date("12/01/2012");
     const fromDate = new Date("12/01/2012");
     const throughDate = new Date("12/31/2012");
+    let fieldDate = fromDate;
     let targetDate = F3xCoverageDates.fromJSON({
       "coverage_from_date": new Date("11/01/2012"),
       "coverage_through_date": new Date("1/01/2013"),
@@ -127,7 +127,7 @@ describe('CreateF3XStep1Component', () => {
       component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
     ).toBe(true);
 
-    //New dates start inside of existing report
+    //New dates start inside of existing report - FromDate
     targetDate = F3xCoverageDates.fromJSON({
       "coverage_from_date": new Date("11/01/2012"),
       "coverage_through_date": new Date("12/15/2012"),
@@ -136,7 +136,28 @@ describe('CreateF3XStep1Component', () => {
       component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
     ).toBe(true);
 
-    //New dates end inside of existing report
+    //New dates start inside of existing report - ThroughDate
+    fieldDate = throughDate;
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("11/01/2012"),
+      "coverage_through_date": new Date("12/15/2012"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(false);
+
+    //New dates end inside of existing report - FromDate
+    fieldDate = fromDate;
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("12/15/2012"),
+      "coverage_through_date": new Date("1/15/2013"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(false);
+
+    //New dates end inside of existing report - ThroughDate
+    fieldDate = throughDate;
     targetDate = F3xCoverageDates.fromJSON({
       "coverage_from_date": new Date("12/15/2012"),
       "coverage_through_date": new Date("1/15/2013"),
@@ -164,13 +185,9 @@ describe('CreateF3XStep1Component', () => {
     ).toBe(false);
   });
 
-  it('Tests the getCoverageDatesValidator() method', ()=>{
-    const dates = F3xCoverageDates.fromJSON({
-      coverage_from_date: '10/10/2010',
-      coverage_through_date: '11/10/2010'
-    });
-
-    expect(component.getCoverageDatesValidator(dates)).toBeTruthy();
-    expect(component.getCoverageDatesValidator()).not.toBeTruthy();
-  })
+  it('The coverage date validator does not explode if passed an AbstractControl instead of a FormGroup', ()=>{
+    const validatorFn = component.buildCoverageDatesValidator();
+    const field = component.form.controls['coverage_from_date'];
+    expect(validatorFn(field)).toBe(null);
+  });
 });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -171,6 +171,6 @@ describe('CreateF3XStep1Component', () => {
     });
 
     expect(component.getCoverageDatesValidator(dates)).toBeTruthy();
-    expect(component.getCoverageDatesValidator(undefined)).not.toBeTruthy();
+    expect(component.getCoverageDatesValidator()).not.toBeTruthy();
   })
 });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -27,6 +27,7 @@ describe('CreateF3XStep1Component', () => {
   const f3x: F3xSummary = F3xSummary.fromJSON({
     id: 999,
     coverage_from_date: '2022-05-25',
+    coverage_through_date: '2022-06-25',
     form_type: 'F3XN',
     report_code: 'Q1',
   });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -17,6 +17,7 @@ import { SelectButtonModule } from 'primeng/selectbutton';
 import { CreateF3XStep1Component, F3xReportTypeCategories } from './create-f3x-step1.component';
 import { selectUserLoginData } from 'app/store/login.selectors';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
+import { F3xCoverageDates } from '../../../shared/models/f3x-summary.model';
 
 describe('CreateF3XStep1Component', () => {
   let component: CreateF3XStep1Component;
@@ -110,5 +111,60 @@ describe('CreateF3XStep1Component', () => {
     const navigateSpy = spyOn(router, 'navigateByUrl');
     component.goBack();
     expect(navigateSpy).toHaveBeenCalledWith('/reports');
+  });
+
+  it('should catch date overlaps', ()=>{
+    let fieldDate: Date;
+    let fromDate: Date;
+    let throughDate: Date;
+    let targetDate: F3xCoverageDates
+
+    //New dates inside of existing report
+    fieldDate = new Date("12/01/2012");
+    fromDate = new Date("12/01/2012");
+    throughDate = new Date("12/31/2012");
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("11/01/2012"),
+      "coverage_through_date": new Date("1/01/2013"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(true);
+
+    //New dates start inside of existing report
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("11/01/2012"),
+      "coverage_through_date": new Date("12/15/2012"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(true);
+
+    //New dates end inside of existing report
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("12/15/2012"),
+      "coverage_through_date": new Date("1/15/2013"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(true);
+
+    //New dates encompass existing report
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("12/05/2012"),
+      "coverage_through_date": new Date("12/25/2012"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(true);
+
+    //New dates do not overlap with existing report
+    targetDate = F3xCoverageDates.fromJSON({
+      "coverage_from_date": new Date("12/05/2015"),
+      "coverage_through_date": new Date("12/25/2015"),
+    });
+    expect(
+      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
+    ).toBe(false);
   });
 });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -114,16 +114,11 @@ describe('CreateF3XStep1Component', () => {
   });
 
   it('should catch date overlaps', ()=>{
-    let fieldDate: Date;
-    let fromDate: Date;
-    let throughDate: Date;
-    let targetDate: F3xCoverageDates
-
     //New dates inside of existing report
-    fieldDate = new Date("12/01/2012");
-    fromDate = new Date("12/01/2012");
-    throughDate = new Date("12/31/2012");
-    targetDate = F3xCoverageDates.fromJSON({
+    const fieldDate = new Date("12/01/2012");
+    const fromDate = new Date("12/01/2012");
+    const throughDate = new Date("12/31/2012");
+    let targetDate = F3xCoverageDates.fromJSON({
       "coverage_from_date": new Date("11/01/2012"),
       "coverage_through_date": new Date("1/01/2013"),
     });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -109,6 +109,8 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
     // Initialize validation tracking of current JSON schema and form data
     this.validateService.formValidatorSchema = f3xSchema;
     this.validateService.formValidatorForm = this.form;
+
+    //Re-checks the validators on the coverage date fields every second
     setInterval(()=>{
       this.autoValidateCoverageDates(this.form.controls);
     }, 1000);
@@ -127,10 +129,13 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
             f3xCoverageDate.coverage_from_date &&
             f3xCoverageDate.coverage_through_date &&
             (
+              //The form's date is between another report's from/through date
               ( formValue >= f3xCoverageDate.coverage_from_date &&
               formValue <= f3xCoverageDate.coverage_through_date ) ||
+              //Another report's from date is inside the form's dates
               ( fromDate <= f3xCoverageDate.coverage_from_date && 
                 throughDate >= f3xCoverageDate.coverage_from_date) ||
+              //Another report's through date is inside the form's dates
               ( fromDate <= f3xCoverageDate.coverage_through_date && 
                 throughDate >= f3xCoverageDate.coverage_through_date)
             )
@@ -162,6 +167,10 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
     return retval;
   }
 
+  /**
+   * Runs the validators on the from/through date fields
+   * @param controls this.form.controls
+   */
   autoValidateCoverageDates(controls: { [key: string]: AbstractControl; }){
     controls['coverage_from_date'].updateValueAndValidity();
     controls['coverage_through_date'].updateValueAndValidity();

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -146,7 +146,7 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
         //Another report's through date is inside the form's dates
         ( fromDate <= targetDate.coverage_through_date && 
           throughDate >= targetDate.coverage_through_date)
-      ) as boolean
+      )
     ) as boolean;
   }
 

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import {
@@ -101,10 +101,14 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
     this.f3xSummaryService.getF3xCoverageDates().subscribe((dates) => {
       this.f3xCoverageDatesList = dates;
     });
-    this.form.controls['coverage_from_date'].addValidators(this.buildCoverageDatesValidator('coverage_from_date'));
-    this.form.controls['coverage_through_date'].addValidators(
-      this.buildCoverageDatesValidator('coverage_through_date')
-    );
+    this.form.controls['coverage_from_date'].addValidators([
+        this.buildCoverageDatesValidator('coverage_from_date'),
+        Validators.required
+      ]);
+    this.form.controls['coverage_through_date'].addValidators([
+      this.buildCoverageDatesValidator('coverage_through_date'),
+      Validators.required
+    ]);
 
     // Initialize validation tracking of current JSON schema and form data
     this.validateService.formValidatorSchema = f3xSchema;

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import {
@@ -162,7 +162,7 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
     return retval;
   }
 
-  autoValidateCoverageDates(controls: any){
+  autoValidateCoverageDates(controls: { [key: string]: AbstractControl; }){
     controls['coverage_from_date'].updateValueAndValidity();
     controls['coverage_through_date'].updateValueAndValidity();
   }

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -120,10 +120,10 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
    * Checks if a field's date is within another report's dates or if 
    * another report's dates fall within the form's "from" and "through" dates
    * 
-   * @param fieldDate the date of the field being checked
-   * @param fromDate the form's "from" date
-   * @param throughDate the form's "through" date
-   * @param targetDate the object whose date is being checked for an overlap
+   * @param fieldDate {Date} the date of the field being checked
+   * @param fromDate {Date} the form's "from" date
+   * @param throughDate {Date} the form's "through" date
+   * @param targetDate {F3xCoverageDates} the object whose date is being checked for an overlap
    * @returns true if there is an overlap in dates
    */
   checkForDateOverlap(

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import {
@@ -158,7 +158,7 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
         const fromDate = group.controls['coverage_from_date'];
         const throughDate = group.controls['coverage_through_date'];
         if (this.f3xCoverageDatesList) {
-          for (let formValue of [fromDate, throughDate]){
+          for (const formValue of [fromDate, throughDate]){
             const overlap = this.f3xCoverageDatesList.find((f3xCoverageDate) => {
               return this.checkForDateOverlap(formValue.value, fromDate.value, throughDate.value, f3xCoverageDate);
             });

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -109,6 +109,9 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
     // Initialize validation tracking of current JSON schema and form data
     this.validateService.formValidatorSchema = f3xSchema;
     this.validateService.formValidatorForm = this.form;
+    setInterval(()=>{
+      this.autoValidateCoverageDates(this.form.controls);
+    }, 1000);
   }
 
   buildCoverageDatesValidator(valueFormControlName: string): ValidatorFn {
@@ -157,6 +160,11 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
       };
     }
     return retval;
+  }
+
+  autoValidateCoverageDates(controls: any){
+    controls['coverage_from_date'].updateValueAndValidity();
+    controls['coverage_through_date'].updateValueAndValidity();
   }
 
   ngOnDestroy(): void {

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -115,14 +115,22 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
     return (): ValidationErrors | null => {
       let result: ValidationErrors | null = null;
       const formValue: Date = this.form?.get(valueFormControlName)?.value;
+      const fromDate: Date = this.form?.get("coverage_from_date")?.value;
+      const throughDate: Date = this.form?.get("coverage_through_date")?.value;
       if (this.f3xCoverageDatesList && formValue) {
         const retval = this.f3xCoverageDatesList.find((f3xCoverageDate) => {
           return (
             f3xCoverageDate &&
             f3xCoverageDate.coverage_from_date &&
             f3xCoverageDate.coverage_through_date &&
-            formValue >= f3xCoverageDate.coverage_from_date &&
-            formValue <= f3xCoverageDate.coverage_through_date
+            (
+              ( formValue >= f3xCoverageDate.coverage_from_date &&
+              formValue <= f3xCoverageDate.coverage_through_date ) ||
+              ( fromDate <= f3xCoverageDate.coverage_from_date && 
+                throughDate >= f3xCoverageDate.coverage_from_date) ||
+              ( fromDate <= f3xCoverageDate.coverage_through_date && 
+                throughDate >= f3xCoverageDate.coverage_through_date)
+            )
           );
         });
         result = this.getCoverageDatesValidator(retval);

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.ts
@@ -48,7 +48,7 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
   form: FormGroup = this.fb.group(this.validateService.getFormGroupFields(this.formProperties));
 
   readonly F3xReportTypeCategories = F3xReportTypeCategories;
-  private f3xCoverageDatesList: F3xCoverageDates[] | undefined;
+  public f3xCoverageDatesList: F3xCoverageDates[] | undefined;
 
   public f3xReportCodeDetailedLabels: LabelList = f3xReportCodeDetailedLabels;
 
@@ -69,7 +69,7 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
       .select(selectCommitteeAccount)
       .pipe(takeUntil(this.destroy$))
       .subscribe((committeeAccount) => {
-        const filingFrequency = this.userCanSetFilingFrequency ? 'Q' : committeeAccount.filing_frequency;
+        const filingFrequency = this.userCanSetFilingFrequency ? 'Q' : committeeAccount?.filing_frequency;
         this.form.addControl('filing_frequency', new FormControl());
         this.form.addControl('report_type_category', new FormControl());
         this.form?.patchValue({ filing_frequency: filingFrequency, form_type: 'F3XN' });
@@ -159,10 +159,12 @@ export class CreateF3XStep1Component implements OnInit, OnDestroy {
         const throughDate = group.controls['coverage_through_date'];
         if (this.f3xCoverageDatesList) {
           for (const formValue of [fromDate, throughDate]){
+            console.log("Formvalue:", formValue);
             const overlap = this.f3xCoverageDatesList.find((f3xCoverageDate) => {
               return this.checkForDateOverlap(formValue.value, fromDate.value, throughDate.value, f3xCoverageDate);
             });
             if (overlap){
+              console.log("OVERLAP!");
               this.setCoverageOverlapError(formValue, overlap);
             } else {
               formValue.setErrors(null);

--- a/front-end/src/app/reports/f3x/report-level-memo/report-level-memo.component.ts
+++ b/front-end/src/app/reports/f3x/report-level-memo/report-level-memo.component.ts
@@ -67,7 +67,7 @@ export class ReportLevelMemoComponent implements OnInit, OnDestroy {
     this.store
       .select(selectCommitteeAccount)
       .pipe(takeUntil(this.destroy$))
-      .subscribe((committeeAccount) => (this.committeeAccountId = committeeAccount.committee_id));
+      .subscribe((committeeAccount) => (this.committeeAccountId = committeeAccount?.committee_id));
     this.report = this.activatedRoute.snapshot.data['report'];
     if (this.report && this.report.id) {
       this.memoTextService.getForReportId(this.report.id).subscribe((memoTextList) => {


### PR DESCRIPTION
API Ticket [173](https://app.zenhub.com/workspaces/fecfile-online-619e578e68408b001c831251/issues/fecgov/fecfile-web-api/173)

Updates the coverage date overlap checking to catch an edge case where a new report is created whose dates entirely encompass another report's dates.  Adds unit tests to verify that the edge case has been caught.