### PR TITLE
Updates columns on the manage transaction page

### DIFF
--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step3.component.html
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step3.component.html
@@ -79,10 +79,10 @@
           {{ item.contribution_aggregate | currency }}
         </td>
 				<td>
-					{{ item.id }}
+					{{ item.transaction_id }}
 				</td>
 				<td>
-					{{ item.parent_transaction_id }}
+					{{ item.back_reference_tran_id_number }}
 				</td>
         <td>
           <p-button pRipple icon="pi pi-ellipsis-v" styleClass="p-button-text" ariaLabel="action"></p-button>


### PR DESCRIPTION
Updates the transactions page to `display transaction_id` and `back_reference_trans_id_number` per API ticket 124.

Paired with this [branch's](https://github.com/fecgov/fecfile-web-api/tree/feature/124-transaction-uuid-field) PR