### PR TITLE
Bug/415 Rearrange transaction routing to accomodate report left nav actions

### DIFF
--- a/front-end/src/app/layout/sidebar/menu-report/menu-report.component.spec.ts
+++ b/front-end/src/app/layout/sidebar/menu-report/menu-report.component.spec.ts
@@ -34,7 +34,7 @@ describe('MenuReportComponent', () => {
         SharedModule,
         PanelMenuModule,
         BrowserAnimationsModule,
-        RouterTestingModule.withRoutes([{ path: 'reports/f3x/create/step3/999', redirectTo: '' }]),
+        RouterTestingModule.withRoutes([{ path: 'transactions/report/999/list', redirectTo: '' }]),
       ],
     }).compileComponents();
   });
@@ -51,23 +51,23 @@ describe('MenuReportComponent', () => {
   });
 
   it('should navigate to menu', () => {
-    router.navigateByUrl('/reports/f3x/create/step3/999');
+    router.navigateByUrl('/transactions/report/999/list');
     expect(component.activeReport?.id).toBe(999);
   });
 
   it('should determine an active url', () => {
-    const urlMatch: RegExp[] = [/\/report\/999/];
+    const urlMatch: RegExp[] = [/\/report\/999\/list/];
     let url = 'no-match';
     expect(component.isActive(urlMatch, url)).toBe(false);
 
-    url = '/report/999';
+    url = '/report/999/list';
     expect(component.isActive(urlMatch, url)).toBe(true);
   });
 
   it('should process a NavigationEnd event', () => {
     component.items = [];
     component.currentReportId = 888;
-    component.handleNavigationEvent({ url: '/reports/f3x/create/step3/999' } as NavigationEnd);
+    component.handleNavigationEvent({ url: '/transactions/report/999/list' } as NavigationEnd);
     expect(component.items.length).toBe(3);
   });
 });

--- a/front-end/src/app/layout/sidebar/menu-report/menu-report.component.ts
+++ b/front-end/src/app/layout/sidebar/menu-report/menu-report.component.ts
@@ -30,7 +30,7 @@ export class MenuReportComponent implements OnInit, OnDestroy {
   // because the order determines the expanded menu item group in the panal menu:
   // 'Enter A Transaction', 'Review A Report', and 'Submit Your Report'.
   urlMatch: RegExp[] = [
-    /^\/reports\/f3x\/create\/step3\/\d+/, // Enter a transaction group
+    /^\/transactions\/report\/\d+\/list/, // Enter a transaction group
     /^\/transactions\/report\/\d+\/create/, // Enter a transaction group
     /^\/reports\/f3x\/summary\/\d+/, // Review a report group
     /^\/reports\/f3x\/detailed-summary\/\d+/, // Review a report group
@@ -77,7 +77,7 @@ export class MenuReportComponent implements OnInit, OnDestroy {
             items: [
               {
                 label: 'Manage your transactions',
-                routerLink: [`/reports/f3x/create/step3/${this.currentReportId}`],
+                routerLink: [`/transactions/report/${this.currentReportId}/list`],
               },
               {
                 label: 'Add a receipt',

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step2.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step2.component.spec.ts
@@ -113,7 +113,7 @@ describe('CreateF3xStep2Component', () => {
     );
     expect(req.request.method).toEqual('PUT');
     req.flush(component.report);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/create/step3/999');
+    expect(navigateSpy).toHaveBeenCalledWith('/transactions/report/999/list');
   });
 
   it('#save should not save when form data invalid', () => {

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step2.component.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step2.component.ts
@@ -93,7 +93,7 @@ export class CreateF3xStep2Component implements OnInit, OnDestroy {
 
     this.f3xSummaryService.update(payload, this.formProperties).subscribe(() => {
       if (jump === 'continue' && this.report?.id) {
-        this.router.navigateByUrl(`/reports/f3x/create/step3/${this.report.id}`);
+        this.router.navigateByUrl(`/transactions/report/${this.report.id}/list`);
       }
       if (jump === 'back' && this.report?.id) {
         this.router.navigateByUrl('/reports');

--- a/front-end/src/app/reports/report-list/report-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/report-list.component.spec.ts
@@ -69,7 +69,7 @@ describe('ReportListComponent', () => {
     expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/create/step2/999');
 
     component.editItem({ id: 999, change_of_address: true } as F3xSummary);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/create/step3/999');
+    expect(navigateSpy).toHaveBeenCalledWith('/transactions/report/999/list');
   });
 
   it('#displayName should display the item form_type code', () => {

--- a/front-end/src/app/reports/report-list/report-list.component.ts
+++ b/front-end/src/app/reports/report-list/report-list.component.ts
@@ -51,7 +51,7 @@ export class ReportListComponent extends TableListBaseComponent<Report> implemen
     if ((item as F3xSummary).change_of_address === null) {
       this.router.navigateByUrl(`/reports/f3x/create/step2/${item.id}`);
     } else {
-      this.router.navigateByUrl(`/reports/f3x/create/step3/${item.id}`);
+      this.router.navigateByUrl(`/transactions/report/${item.id}/list`);
     }
   }
 

--- a/front-end/src/app/reports/reports-routing.module.ts
+++ b/front-end/src/app/reports/reports-routing.module.ts
@@ -3,7 +3,6 @@ import { Routes, RouterModule } from '@angular/router';
 import { ReportListComponent } from './report-list/report-list.component';
 import { CreateF3XStep1Component } from './f3x/create-workflow/create-f3x-step1.component';
 import { CreateF3xStep2Component } from './f3x/create-workflow/create-f3x-step2.component';
-import { CreateF3xStep3Component } from './f3x/create-workflow/create-f3x-step3.component';
 import { ReportSummaryComponent } from './f3x/report-summary/report-summary.component';
 import { ReportDetailedSummaryComponent } from './f3x/report-detailed-summary/report-detailed-summary.component';
 import { ReportResolver } from 'app/shared/resolvers/report.resolver';
@@ -31,11 +30,6 @@ const routes: Routes = [
   {
     path: 'f3x/create/step2/:reportId',
     component: CreateF3xStep2Component,
-    resolve: { report: ReportResolver },
-  },
-  {
-    path: 'f3x/create/step3/:reportId',
-    component: CreateF3xStep3Component,
     resolve: { report: ReportResolver },
   },
   {

--- a/front-end/src/app/reports/reports.module.ts
+++ b/front-end/src/app/reports/reports.module.ts
@@ -18,10 +18,10 @@ import { TableModule } from 'primeng/table';
 import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
 import { TooltipModule } from 'primeng/tooltip';
+
 import { SharedModule } from '../../app/shared/shared.module';
 import { CreateF3XStep1Component } from './f3x/create-workflow/create-f3x-step1.component';
 import { CreateF3xStep2Component } from './f3x/create-workflow/create-f3x-step2.component';
-import { CreateF3xStep3Component, MemoCodePipe } from './f3x/create-workflow/create-f3x-step3.component';
 import { ReportDetailedSummaryComponent } from './f3x/report-detailed-summary/report-detailed-summary.component';
 import { ReportLevelMemoComponent } from './f3x/report-level-memo/report-level-memo.component';
 import { ReportSummaryComponent } from './f3x/report-summary/report-summary.component';
@@ -32,17 +32,13 @@ import { TestDotFecComponent } from './f3x/test-dot-fec-workflow/test-dot-fec.co
 import { ReportListComponent } from './report-list/report-list.component';
 import { ReportsRoutingModule } from './reports-routing.module';
 
-
-
 @NgModule({
   declarations: [
     ReportListComponent,
     CreateF3XStep1Component,
     CreateF3xStep2Component,
-    CreateF3xStep3Component,
     SubmitF3xStep1Component,
     SubmitF3xStep2Component,
-    MemoCodePipe,
     ReportSummaryComponent,
     ReportDetailedSummaryComponent,
     ReportLevelMemoComponent,

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
@@ -43,6 +43,17 @@ const userLoginData: UserLoginData = {
   token: 'jwttokenstring',
 };
 
+const testTransaction = {
+  id: 123,
+  report_id: 999,
+  form_type: null,
+  filer_committee_id_number: null,
+  transaction_id: null,
+  transaction_type_identifier: 'test',
+  contribution_purpose_descrip: null,
+  parent_transaction_id: null,
+};
+
 describe('TransactionTypeBaseComponent', () => {
   let component: TestTransactionTypeBaseComponent;
   let fixture: ComponentFixture<TestTransactionTypeBaseComponent>;
@@ -153,14 +164,15 @@ describe('TransactionTypeBaseComponent', () => {
     const testTransactionId = 1;
     const testTransactionTypeToAdd = 'testTransactionTypeToAdd';
 
+    component.transaction = testTransaction;
+
     const expectedMessage: Message = {
       severity: 'success',
       summary: 'Successful',
       detail: 'Parent Transaction Saved',
       life: 3000,
     };
-    const expectedRoute =
-      `transactions/edit/` + `${testTransactionId}/create-sub-transaction/${testTransactionTypeToAdd}`;
+    const expectedRoute = `/transactions/report/999/list/edit/${testTransactionId}/create-sub-transaction/${testTransactionTypeToAdd}`;
 
     const messageServiceAddSpy = spyOn(testMessageService, 'add');
     const routerNavigateByUrlSpy = spyOn(testRouter, 'navigateByUrl');
@@ -182,7 +194,7 @@ describe('TransactionTypeBaseComponent', () => {
       parent_transaction_id: null,
     };
     component.transaction = testTransaction;
-    const expectedRoute = `/reports/f3x/create/step3/${testTransaction.report_id}`;
+    const expectedRoute = `/transactions/report/${testTransaction.report_id}/list`;
     const routerNavigateByUrlSpy = spyOn(testRouter, 'navigateByUrl');
     component.navigateTo('list');
     expect(routerNavigateByUrlSpy).toHaveBeenCalledOnceWith(expectedRoute);

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
@@ -93,7 +93,7 @@ describe('TransactionTypeBaseComponent', () => {
   });
 
   it('#save should navigate for create', () => {
-    const testTransaction: Transaction = {
+    const testTransaction1: Transaction = {
       id: null,
       report_id: null,
       form_type: null,
@@ -103,7 +103,7 @@ describe('TransactionTypeBaseComponent', () => {
       contribution_purpose_descrip: null,
       parent_transaction_id: null,
     };
-    spyOn(testTransactionService, 'create').and.returnValue(of(testTransaction));
+    spyOn(testTransactionService, 'create').and.returnValue(of(testTransaction1));
     const componentNavigateToSpy = spyOn(component, 'navigateTo');
     component.transaction = {
       id: null,
@@ -121,7 +121,7 @@ describe('TransactionTypeBaseComponent', () => {
   });
 
   it('#save should navigate for update', () => {
-    const testTransaction: Transaction = {
+    const testTransaction2: Transaction = {
       id: 123,
       report_id: null,
       form_type: null,
@@ -131,7 +131,7 @@ describe('TransactionTypeBaseComponent', () => {
       contribution_purpose_descrip: null,
       parent_transaction_id: null,
     };
-    spyOn(testTransactionService, 'update').and.returnValue(of(testTransaction));
+    spyOn(testTransactionService, 'update').and.returnValue(of(testTransaction2));
     const componentNavigateToSpy = spyOn(component, 'navigateTo');
     component.transaction = {
       id: 123,
@@ -183,7 +183,7 @@ describe('TransactionTypeBaseComponent', () => {
   });
 
   it("#navigateTo 'list' should navigate", () => {
-    const testTransaction: Transaction = {
+    const testTransaction3: Transaction = {
       id: 123,
       report_id: 99,
       form_type: null,
@@ -193,8 +193,33 @@ describe('TransactionTypeBaseComponent', () => {
       contribution_purpose_descrip: null,
       parent_transaction_id: null,
     };
+    component.transaction = testTransaction3;
+    const expectedRoute = `/transactions/report/${testTransaction3.report_id}/list`;
+    const routerNavigateByUrlSpy = spyOn(testRouter, 'navigateByUrl');
+    component.navigateTo('list');
+    expect(routerNavigateByUrlSpy).toHaveBeenCalledOnceWith(expectedRoute);
+  });
+
+  it("#navigateTo 'add-sub-tran' should navigate", () => {
     component.transaction = testTransaction;
-    const expectedRoute = `/transactions/report/${testTransaction.report_id}/list`;
+    const expectedRoute = '/transactions/report/999/list/edit/123/create-sub-transaction/INDV_REC';
+    const routerNavigateByUrlSpy = spyOn(testRouter, 'navigateByUrl');
+    component.navigateTo('add-sub-tran', 123, 'INDV_REC');
+    expect(routerNavigateByUrlSpy).toHaveBeenCalledOnceWith(expectedRoute);
+  });
+
+  it("#navigateTo 'to-parent' should navigate", () => {
+    component.transaction = { ...testTransaction };
+    component.transaction.parent_transaction_id = 333;
+    const expectedRoute = '/transactions/report/999/list/edit/333';
+    const routerNavigateByUrlSpy = spyOn(testRouter, 'navigateByUrl');
+    component.navigateTo('to-parent');
+    expect(routerNavigateByUrlSpy).toHaveBeenCalledOnceWith(expectedRoute);
+  });
+
+  it('#navigateTo default should navigate', () => {
+    component.transaction = testTransaction;
+    const expectedRoute = '/transactions/report/999/list';
     const routerNavigateByUrlSpy = spyOn(testRouter, 'navigateByUrl');
     component.navigateTo('list');
     expect(routerNavigateByUrlSpy).toHaveBeenCalledOnceWith(expectedRoute);

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -134,12 +134,14 @@ export abstract class TransactionTypeBaseComponent implements OnInit, OnDestroy 
         life: 3000,
       });
       this.router.navigateByUrl(
-        `transactions/edit/` + `${transactionId}/create-sub-transaction/${transactionTypeToAdd}`
+        `/transactions/report/${this.transaction?.report_id}/list/edit/${transactionId}/create-sub-transaction/${transactionTypeToAdd}`
       );
     } else if (navigateTo === 'to-parent') {
-      this.router.navigateByUrl(`/transactions/edit/${this.transaction?.parent_transaction_id}`);
+      this.router.navigateByUrl(
+        `/transactions/report/${this.transaction?.report_id}/list/edit/${this.transaction?.parent_transaction_id}`
+      );
     } else {
-      this.router.navigateByUrl(`/reports/f3x/create/step3/${this.transaction?.report_id}`);
+      this.router.navigateByUrl(`/transactions/report/${this.transaction?.report_id}/list`);
     }
   }
 

--- a/front-end/src/app/shared/services/validate.service.spec.ts
+++ b/front-end/src/app/shared/services/validate.service.spec.ts
@@ -83,7 +83,6 @@ describe('ValidateService', () => {
     let result: ValidationErrors | null = validator(
       service.formValidatorForm.get('L6a_cash_on_hand_jan_1_ytd') as FormControl
     );
-    expect(result).not.toBe(null);
     if (result) {
       expect(result['max'].max).toBe(999999999.99);
     }

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.html
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.html
@@ -53,15 +53,15 @@
         <th pSortableColumn="contribution_aggregate" id="contribution-aggregate-column" role="columnheader">
           Contribution aggregate <p-sortIcon field="contribution_aggregate"></p-sortIcon>
         </th>
-				<th id="transaction_id" role="columnheader">Transaction ID</th>
-				<th id="transaction_parent" role="columnheader">Associated With</th>
+        <th id="transaction_id" role="columnheader">Transaction ID</th>
+        <th id="transaction_parent" role="columnheader">Associated With</th>
         <th id="buttons" role="columnheader">Actions</th>
       </tr>
     </ng-template>
     <ng-template pTemplate="body" let-item>
       <tr role="row">
         <td>
-          <a [routerLink]="['/transactions/edit/', item?.id]">{{ item.transaction_type_identifier }}</a>
+          <a [routerLink]="['edit', item?.id]">{{ item.transaction_type_identifier }}</a>
         </td>
         <td>
           {{ item.contributor_organization_name || item.contributor_last_name + ', ' + item.contributor_first_name }}
@@ -78,12 +78,12 @@
         <td>
           {{ item.contribution_aggregate | currency }}
         </td>
-				<td>
-					{{ item.id }}
-				</td>
-				<td>
-					{{ item.parent_transaction_id }}
-				</td>
+        <td>
+          {{ item.id }}
+        </td>
+        <td>
+          {{ item.parent_transaction_id }}
+        </td>
         <td>
           <p-button pRipple icon="pi pi-ellipsis-v" styleClass="p-button-text" ariaLabel="action"></p-button>
         </td>

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -14,7 +14,7 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { TableModule } from 'primeng/table';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { TransactionListComponent } from './transaction-list.component';
+import { TransactionListComponent, MemoCodePipe } from './transaction-list.component';
 
 describe('CreateF3xStep4Component', () => {
   let component: TransactionListComponent;
@@ -82,5 +82,13 @@ describe('CreateF3xStep4Component', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should memoCode transform', () => {
+    const pipe = new MemoCodePipe();
+    let result = pipe.transform(true);
+    expect(result).toBe('Y');
+    result = pipe.transform(false);
+    expect(result).toBe('-');
   });
 });

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -14,11 +14,11 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { TableModule } from 'primeng/table';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { CreateF3xStep3Component } from './create-f3x-step3.component';
+import { TransactionListComponent } from './transaction-list.component';
 
 describe('CreateF3xStep4Component', () => {
-  let component: CreateF3xStep3Component;
-  let fixture: ComponentFixture<CreateF3xStep3Component>;
+  let component: TransactionListComponent;
+  let fixture: ComponentFixture<TransactionListComponent>;
   const committeeAccount: CommitteeAccount = CommitteeAccount.fromJSON({});
 
   beforeEach(async () => {
@@ -30,7 +30,7 @@ describe('CreateF3xStep4Component', () => {
     };
     await TestBed.configureTestingModule({
       imports: [ToolbarModule, TableModule, RouterTestingModule],
-      declarations: [CreateF3xStep3Component],
+      declarations: [TransactionListComponent],
       providers: [
         MessageService,
         ConfirmationService,
@@ -75,7 +75,7 @@ describe('CreateF3xStep4Component', () => {
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(CreateF3xStep3Component);
+    fixture = TestBed.createComponent(TransactionListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
@@ -7,10 +7,10 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { TransactionService } from 'app/shared/services/transaction.service';
 
 @Component({
-  selector: 'app-create-f3x-step3',
-  templateUrl: './create-f3x-step3.component.html',
+  selector: 'app-transaction-list',
+  templateUrl: './transaction-list.component.html',
 })
-export class CreateF3xStep3Component extends TableListBaseComponent<Transaction> implements OnInit {
+export class TransactionListComponent extends TableListBaseComponent<Transaction> implements OnInit {
   report: F3xSummary | undefined;
 
   constructor(

--- a/front-end/src/app/transactions/transactions-routing.module.ts
+++ b/front-end/src/app/transactions/transactions-routing.module.ts
@@ -4,8 +4,14 @@ import { ReportResolver } from 'app/shared/resolvers/report.resolver';
 import { TransactionTypeResolver } from 'app/shared/resolvers/transaction-type.resolver';
 import { TransactionContainerComponent } from './transaction-container/transaction-container.component';
 import { TransactionTypePickerComponent } from './transaction-type-picker/transaction-type-picker.component';
+import { TransactionListComponent } from './transaction-list/transaction-list.component';
 
 const routes: Routes = [
+  {
+    path: 'report/:reportId/list',
+    component: TransactionListComponent,
+    resolve: { report: ReportResolver },
+  },
   {
     path: 'report/:reportId/create',
     component: TransactionTypePickerComponent,
@@ -21,14 +27,14 @@ const routes: Routes = [
     },
   },
   {
-    path: 'edit/:transactionId',
+    path: 'report/:reportId/list/edit/:transactionId',
     component: TransactionContainerComponent,
     resolve: {
       transactionType: TransactionTypeResolver,
     },
   },
   {
-    path: 'edit/:parentTransactionId/create-sub-transaction/:transactionType',
+    path: 'report/:reportId/list/edit/:parentTransactionId/create-sub-transaction/:transactionType',
     component: TransactionContainerComponent,
     resolve: {
       transactionType: TransactionTypeResolver,

--- a/front-end/src/app/transactions/transactions.module.ts
+++ b/front-end/src/app/transactions/transactions.module.ts
@@ -12,6 +12,9 @@ import { CheckboxModule } from 'primeng/checkbox';
 import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { ToastModule } from 'primeng/toast';
+import { ToolbarModule } from 'primeng/toolbar';
+import { TableModule } from 'primeng/table';
+import { InputNumberModule } from 'primeng/inputnumber';
 
 import { SharedModule } from '../shared/shared.module';
 import { TransactionsRoutingModule } from './transactions-routing.module';
@@ -23,12 +26,14 @@ import { TransactionGroupDComponent } from './transaction-group-d/transaction-gr
 import { TransactionGroupEComponent } from './transaction-group-e/transaction-group-e.component';
 import { TransactionGroupFComponent } from './transaction-group-f/transaction-group-f.component';
 import { TransactionTypePickerComponent } from './transaction-type-picker/transaction-type-picker.component';
-import { InputNumberModule } from 'primeng/inputnumber';
+import { TransactionListComponent, MemoCodePipe } from './transaction-list/transaction-list.component';
 
 @NgModule({
   declarations: [
     TransactionContainerComponent,
     TransactionTypePickerComponent,
+    TransactionListComponent,
+    MemoCodePipe,
     TransactionGroupAComponent,
     TransactionGroupBComponent,
     TransactionGroupCComponent,
@@ -51,6 +56,8 @@ import { InputNumberModule } from 'primeng/inputnumber';
     InputNumberModule,
     CalendarModule,
     ToastModule,
+    ToolbarModule,
+    TableModule,
     SharedModule,
   ],
 })


### PR DESCRIPTION
To solve this I did not move the transactions module into the reports module, afterall. Instead, the report step 3 component was moved from the reports module to the transactions module and renamed transaction-list component

#415 