### PR TITLE
Removes extra paren

### DIFF
--- a/front-end/src/app/shared/utils/label.utils.ts
+++ b/front-end/src/app/shared/utils/label.utils.ts
@@ -225,7 +225,7 @@ export const f3xReportCodeDetailedLabels: LabelList = [
   [F3xReportCodes.M2, 'FEBRUARY 20 MONTHLY REPORT (M2)'],
   [F3xReportCodes.M3, 'MARCH 20 MONTHLY REPORT (M3)'],
   [F3xReportCodes.M4, 'APRIL 20 MONTHLY REPORT (M4)'],
-  [F3xReportCodes.M5, 'MAY 20 MONTHLY REPORT (M5))'],
+  [F3xReportCodes.M5, 'MAY 20 MONTHLY REPORT (M5)'],
   [F3xReportCodes.M6, 'JUNE 20 MONTHLY REPORT (M6)'],
   [F3xReportCodes.M7, 'JULY 20 MONTHLY REPORT (M7)'],
   [F3xReportCodes.M8, 'AUGUST 20 MONTHLY REPORT (M8)'],


### PR DESCRIPTION
#438 

Removes an extra parenthesis in order to correct a typo.