### PR TITLE
Temporarily turn off deploy dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,4 @@ workflows:
       - lint
       - test
       - dependendency-check
-      - deploy:
-          requires:
-            - test
-            - dependendency-check
+      - deploy


### PR DESCRIPTION
There are blocking issues with the unit tests so temporarily turning off the deployment dependencies until the blocker is resolved.