### PR TITLE
Replaces the primeng select button with a new component that extends …

### DIFF
--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.html
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.html
@@ -56,7 +56,10 @@
       <div class="col-6">
         <div class="field">
           <label for="report_type_category">TIME PERIOD</label>
-          <p-selectButton [options]="getReportTypeCategories()" formControlName="report_type_category"></p-selectButton>
+          <app-selectButton
+            [options]="getReportTypeCategories()"
+            formControlName="report_type_category"
+          ></app-selectButton>
           <app-error-messages fieldName="report_type_category" [formSubmitted]="formSubmitted"></app-error-messages>
         </div>
       </div>

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.html
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.html
@@ -56,10 +56,10 @@
       <div class="col-6">
         <div class="field">
           <label for="report_type_category">TIME PERIOD</label>
-          <app-selectButton
+          <app-select-button
             [options]="getReportTypeCategories()"
             formControlName="report_type_category"
-          ></app-selectButton>
+          ></app-select-button>
           <app-error-messages fieldName="report_type_category" [formSubmitted]="formSubmitted"></app-error-messages>
         </div>
       </div>

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.spec.ts
@@ -18,6 +18,7 @@ import { CreateF3XStep1Component, F3xReportTypeCategories } from './create-f3x-s
 import { selectUserLoginData } from 'app/store/login.selectors';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
 import { F3xCoverageDates } from '../../../shared/models/f3x-summary.model';
+import { AppSelectButtonComponent } from '../../../shared/components/app-selectbutton';
 
 describe('CreateF3XStep1Component', () => {
   let component: CreateF3XStep1Component;
@@ -48,7 +49,7 @@ describe('CreateF3XStep1Component', () => {
         ReactiveFormsModule,
         RouterTestingModule.withRoutes([]),
       ],
-      declarations: [CreateF3XStep1Component, LabelPipe],
+      declarations: [CreateF3XStep1Component, LabelPipe, AppSelectButtonComponent],
       providers: [
         F3xSummaryService,
         FormBuilder,
@@ -114,105 +115,91 @@ describe('CreateF3XStep1Component', () => {
     expect(navigateSpy).toHaveBeenCalledWith('/reports');
   });
 
-  it('should catch date overlaps', ()=>{
+  it('should catch date overlaps', () => {
     //New dates inside of existing report
-    const fromDate = new Date("12/01/2012");
-    const throughDate = new Date("12/31/2012");
+    const fromDate = new Date('12/01/2012');
+    const throughDate = new Date('12/31/2012');
     let fieldDate = fromDate;
     let targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("11/01/2012"),
-      "coverage_through_date": new Date("1/01/2013"),
+      coverage_from_date: new Date('11/01/2012'),
+      coverage_through_date: new Date('1/01/2013'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(true);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(true);
 
     //New dates start inside of existing report - FromDate
     targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("11/01/2012"),
-      "coverage_through_date": new Date("12/15/2012"),
+      coverage_from_date: new Date('11/01/2012'),
+      coverage_through_date: new Date('12/15/2012'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(true);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(true);
 
     //New dates start inside of existing report - ThroughDate
     fieldDate = throughDate;
     targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("11/01/2012"),
-      "coverage_through_date": new Date("12/15/2012"),
+      coverage_from_date: new Date('11/01/2012'),
+      coverage_through_date: new Date('12/15/2012'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(false);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(false);
 
     //New dates end inside of existing report - FromDate
     fieldDate = fromDate;
     targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("12/15/2012"),
-      "coverage_through_date": new Date("1/15/2013"),
+      coverage_from_date: new Date('12/15/2012'),
+      coverage_through_date: new Date('1/15/2013'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(false);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(false);
 
     //New dates end inside of existing report - ThroughDate
     fieldDate = throughDate;
     targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("12/15/2012"),
-      "coverage_through_date": new Date("1/15/2013"),
+      coverage_from_date: new Date('12/15/2012'),
+      coverage_through_date: new Date('1/15/2013'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(true);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(true);
 
     //New dates encompass existing report
     targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("12/05/2012"),
-      "coverage_through_date": new Date("12/25/2012"),
+      coverage_from_date: new Date('12/05/2012'),
+      coverage_through_date: new Date('12/25/2012'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(true);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(true);
 
     //New dates do not overlap with existing report
     targetDate = F3xCoverageDates.fromJSON({
-      "coverage_from_date": new Date("12/05/2015"),
-      "coverage_through_date": new Date("12/25/2015"),
+      coverage_from_date: new Date('12/05/2015'),
+      coverage_through_date: new Date('12/25/2015'),
     });
-    expect(
-      component.checkForDateOverlap(fieldDate,fromDate,throughDate,targetDate)
-    ).toBe(false);
+    expect(component.checkForDateOverlap(fieldDate, fromDate, throughDate, targetDate)).toBe(false);
   });
 
-  it('setCoverageOverlapError should set an error', ()=>{
+  it('setCoverageOverlapError should set an error', () => {
     const formValue: AbstractControl = component.form.controls['coverage_from_date'];
     const overlap: F3xCoverageDates = F3xCoverageDates.fromJSON({
-      coverage_from_date: "10/10/2010",
-      coverage_through_date: "11/10/2010",
+      coverage_from_date: '10/10/2010',
+      coverage_through_date: '11/10/2010',
     });
     component.setCoverageOverlapError(formValue, overlap);
     expect(component.form.controls['coverage_from_date'].errors).not.toBe(null);
   });
 
-  it('The coverage date validator does not explode if passed an AbstractControl instead of a FormGroup', ()=>{
+  it('The coverage date validator does not explode if passed an AbstractControl instead of a FormGroup', () => {
     const validatorFn = component.buildCoverageDatesValidator();
     const field = component.form.controls['coverage_from_date'];
     expect(validatorFn(field)).toBe(null);
-
   });
 
-  it('Should catch an overlap in dates with the constructed validator function', ()=>{
+  it('Should catch an overlap in dates with the constructed validator function', () => {
     const validatorFn = component.buildCoverageDatesValidator();
-    component.form.controls['coverage_from_date'].setValue(new Date("12/15/2010"));
-    component.form.controls['coverage_through_date'].setValue(new Date("1/01/2011"));
-    component.f3xCoverageDatesList = [F3xCoverageDates.fromJSON({
-      coverage_from_date: new Date("12/01/2010"),
-      coverage_through_date: new Date("12/31/2010"),
-    })];
+    component.form.controls['coverage_from_date'].setValue(new Date('12/15/2010'));
+    component.form.controls['coverage_through_date'].setValue(new Date('1/01/2011'));
+    component.f3xCoverageDatesList = [
+      F3xCoverageDates.fromJSON({
+        coverage_from_date: new Date('12/01/2010'),
+        coverage_through_date: new Date('12/31/2010'),
+      }),
+    ];
 
     validatorFn(component.form);
     expect(component.form.controls['coverage_from_date'].errors).not.toEqual(null);
-   
   });
 });

--- a/front-end/src/app/reports/reports.module.ts
+++ b/front-end/src/app/reports/reports.module.ts
@@ -33,6 +33,7 @@ import { TestDotFecComponent } from './f3x/test-dot-fec-workflow/test-dot-fec.co
 import { ReportListComponent } from './report-list/report-list.component';
 import { ReportsRoutingModule } from './reports-routing.module';
 import { CashOnHandComponent } from './f3x/create-workflow/cash-on-hand.component';
+import { AppSelectButton } from '../shared/components/app-selectbutton';
 import { InputNumberModule } from 'primeng/inputnumber';
 
 @NgModule({
@@ -49,6 +50,7 @@ import { InputNumberModule } from 'primeng/inputnumber';
     ReportWebPrintComponent,
     TestDotFecComponent,
     CashOnHandComponent,
+    AppSelectButton,
   ],
   imports: [
     CommonModule,

--- a/front-end/src/app/reports/reports.module.ts
+++ b/front-end/src/app/reports/reports.module.ts
@@ -33,7 +33,7 @@ import { TestDotFecComponent } from './f3x/test-dot-fec-workflow/test-dot-fec.co
 import { ReportListComponent } from './report-list/report-list.component';
 import { ReportsRoutingModule } from './reports-routing.module';
 import { CashOnHandComponent } from './f3x/create-workflow/cash-on-hand.component';
-import { AppSelectButton } from '../shared/components/app-selectbutton';
+import { AppSelectButtonComponent } from '../shared/components/app-selectbutton';
 import { InputNumberModule } from 'primeng/inputnumber';
 
 @NgModule({
@@ -50,7 +50,7 @@ import { InputNumberModule } from 'primeng/inputnumber';
     ReportWebPrintComponent,
     TestDotFecComponent,
     CashOnHandComponent,
-    AppSelectButton,
+    AppSelectButtonComponent,
   ],
   imports: [
     CommonModule,

--- a/front-end/src/app/shared/components/app-selectbutton.ts
+++ b/front-end/src/app/shared/components/app-selectbutton.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, forwardRef, ViewEncapsulation } from '@angular/core'
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { SelectButton } from 'primeng/selectbutton'
+
+export const SELECTBUTTON_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => AppSelectButton),
+  multi: true
+};
+
+
+@Component({
+    selector: 'app-selectButton',
+    template: `
+        <div [ngClass]="'p-selectbutton p-buttonset p-component'" [ngStyle]="style" [class]="styleClass"  role="group">
+            <div *ngFor="let option of options; let i = index" #btn class="p-button p-component" [class]="option.styleClass" role="button" [attr.aria-pressed]="isSelected(option)"
+                [ngClass]="{'p-highlight':isSelected(option),
+                        'p-disabled': disabled || isOptionDisabled(option),
+                        'p-button-icon-only': (option.icon && !getOptionLabel(option))}"
+                (click)="onItemClick($event,option,i)" (keydown.enter)="onItemClick($event,option,i)"
+                [attr.title]="option.title" [attr.aria-label]="option.label" (blur)="onBlur()" [attr.tabindex]="disabled ? null : tabindex" pRipple>
+                <ng-container *ngIf="!itemTemplate else customcontent">
+                    <span [ngClass]="'p-button-icon p-button-icon-left'" [class]="option.icon" *ngIf="option.icon"></span>
+                    <span class="p-button-label">{{getOptionLabel(option)}}</span>
+                </ng-container>
+                <ng-template #customcontent>
+                    <ng-container *ngTemplateOutlet="itemTemplate; context: {$implicit: option, index: i}"></ng-container>
+                </ng-template>
+            </div>
+        </div>
+    `,
+    providers: [SELECTBUTTON_VALUE_ACCESSOR],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None,
+    host: {
+        'class': 'p-element'
+    }
+})
+export class AppSelectButton extends SelectButton {
+
+}

--- a/front-end/src/app/shared/components/app-selectbutton.ts
+++ b/front-end/src/app/shared/components/app-selectbutton.ts
@@ -1,41 +1,52 @@
-import { ChangeDetectionStrategy, Component, forwardRef, ViewEncapsulation } from '@angular/core'
+import { ChangeDetectionStrategy, Component, forwardRef, ViewEncapsulation } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { SelectButton } from 'primeng/selectbutton'
+import { SelectButton } from 'primeng/selectbutton';
 
-export const SELECTBUTTON_VALUE_ACCESSOR: any = {
+export const SELECTBUTTON_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => AppSelectButton),
-  multi: true
+  useExisting: forwardRef(() => AppSelectButtonComponent),
+  multi: true,
 };
 
-
 @Component({
-    selector: 'app-selectButton',
-    template: `
-        <div [ngClass]="'p-selectbutton p-buttonset p-component'" [ngStyle]="style" [class]="styleClass"  role="group">
-            <div *ngFor="let option of options; let i = index" #btn class="p-button p-component" [class]="option.styleClass" role="button" [attr.aria-pressed]="isSelected(option)"
-                [ngClass]="{'p-highlight':isSelected(option),
-                        'p-disabled': disabled || isOptionDisabled(option),
-                        'p-button-icon-only': (option.icon && !getOptionLabel(option))}"
-                (click)="onItemClick($event,option,i)" (keydown.enter)="onItemClick($event,option,i)"
-                [attr.title]="option.title" [attr.aria-label]="option.label" (blur)="onBlur()" [attr.tabindex]="disabled ? null : tabindex" pRipple>
-                <ng-container *ngIf="!itemTemplate else customcontent">
-                    <span [ngClass]="'p-button-icon p-button-icon-left'" [class]="option.icon" *ngIf="option.icon"></span>
-                    <span class="p-button-label">{{getOptionLabel(option)}}</span>
-                </ng-container>
-                <ng-template #customcontent>
-                    <ng-container *ngTemplateOutlet="itemTemplate; context: {$implicit: option, index: i}"></ng-container>
-                </ng-template>
-            </div>
-        </div>
-    `,
-    providers: [SELECTBUTTON_VALUE_ACCESSOR],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None,
-    host: {
-        'class': 'p-element'
-    }
+  selector: 'app-select-button',
+  template: `
+    <div [ngClass]="'p-selectbutton p-buttonset p-component'" [ngStyle]="style" [class]="styleClass" role="group">
+      <div
+        *ngFor="let option of options; let i = index"
+        #btn
+        class="p-button p-component"
+        [class]="option.styleClass"
+        role="button"
+        [attr.aria-pressed]="isSelected(option)"
+        [ngClass]="{
+          'p-highlight': isSelected(option),
+          'p-disabled': disabled || isOptionDisabled(option),
+          'p-button-icon-only': option.icon && !getOptionLabel(option)
+        }"
+        (click)="onItemClick($event, option, i)"
+        (keydown.enter)="onItemClick($event, option, i)"
+        [attr.title]="option.title"
+        [attr.aria-label]="option.label"
+        (blur)="onBlur()"
+        [attr.tabindex]="disabled ? null : tabindex"
+        pRipple
+      >
+        <ng-container *ngIf="!itemTemplate; else customcontent">
+          <span [ngClass]="'p-button-icon p-button-icon-left'" [class]="option.icon" *ngIf="option.icon"></span>
+          <span class="p-button-label">{{ getOptionLabel(option) }}</span>
+        </ng-container>
+        <ng-template #customcontent>
+          <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: option, index: i }"></ng-container>
+        </ng-template>
+      </div>
+    </div>
+  `,
+  providers: [SELECTBUTTON_VALUE_ACCESSOR],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'p-element',
+  },
 })
-export class AppSelectButton extends SelectButton {
-
-}
+export class AppSelectButtonComponent extends SelectButton {}


### PR DESCRIPTION
#443 

Replaces the primeng select button with a new component that extends it, only changing the template to no longer include `aria-labelledby`

The unit tests failing are the ones effected by the unfixed race condition.
The one linting error is that the AppSelectButtonComponent uses the "host" property, and CircleCI's linting really doesn't like that.  I can't figure out a way to make @HostBinding solve this problem, and seeing as how PrimeNG used the [host property](https://github.com/primefaces/primeng/blob/master/src/app/components/selectbutton/selectbutton.ts), I'm not too worried about it.