### PR TITLE
Every time the contribution aggregate changes, the validation rules f…

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -95,6 +95,15 @@ export abstract class TransactionTypeBaseComponent implements OnInit, OnDestroy 
           this.form.get('contributor_occupation')?.reset();
         }
       });
+
+      this.form
+        ?.get('contribution_aggregate')
+        ?.valueChanges.pipe(takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.form.get("contributor_employer")?.updateValueAndValidity();
+          this.form.get("contributor_occupation")?.updateValueAndValidity();
+        });
+
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
#276

This corrects an error where on receipts where there can be multiple values for entity_type, contributor_employer and contributor_occupation are not set as required unless the value for entity_type is updated *after* contribution_aggregate has been set.

This error is solved by rechecking the validation rules for contributor_employer and contributor_occupation whenever the value of contribution_aggregate updates.