### PR TITLE
Patch/463 correct transfer name

### DIFF
--- a/front-end/cypress/support/transaction_nav_trees.spec.ts
+++ b/front-end/cypress/support/transaction_nav_trees.spec.ts
@@ -22,7 +22,7 @@ export type SchATransactionName =
   | 'Earmark Receipt'
   | 'Business/Labor Organization Receipt - Non-Contribution Account'
   | 'Individual Receipt - Non-Contribution Account'
-  | 'Joint Fundraising Transfer - National Party Recount Account'
+  | 'Joint Fundraising Transfer - National Party Recount/Legal Proceedings Account'
   | 'Joint Fundraising Transfer - National Party Pres. Nominating Convention Account';
 
 export type ChildTransactionName =

--- a/front-end/src/app/shared/models/scha-transaction.model.ts
+++ b/front-end/src/app/shared/models/scha-transaction.model.ts
@@ -208,7 +208,7 @@ export const ScheduleATransactionTypeLabels: LabelList = [
   [ScheduleATransactionTypes.IN_KIND_TRANSFER_FEA, 'In-Kind Transfer - Federal Election Activity'],
   [
     ScheduleATransactionTypes.JF_TRANSFER_NATIONAL_PARTY_RECOUNT_ACCOUNT,
-    'Joint Fundraising Transfer - National Party Recount Account',
+    'Joint Fundraising Transfer - National Party Recount/Legal Proceedings Account',
   ],
   [
     ScheduleATransactionTypes.JF_TRANSFER_NATIONAL_PARTY_CONVENTION_ACCOUNT,

--- a/front-end/src/app/shared/models/scha-transaction.model.ts
+++ b/front-end/src/app/shared/models/scha-transaction.model.ts
@@ -262,10 +262,22 @@ export const ScheduleATransactionTypeLabels: LabelList = [
   [ScheduleATransactionTypes.PARTY_RECOUNT_RECEIPT, 'Party Recount Receipt'],
   [ScheduleATransactionTypes.PAC_RECOUNT_RECEIPT, 'PAC Recount Receipt'],
   [ScheduleATransactionTypes.TRIBAL_RECOUNT_RECEIPT, 'Tribal Recount Receipt'],
-  [ScheduleATransactionTypes.INDIVIDUAL_NATIONAL_PARTY_RECOUNT_ACCOUNT, 'Individual National Party Recount Account'],
-  [ScheduleATransactionTypes.PARTY_NATIONAL_PARTY_RECOUNT_ACCOUNT, 'Party National Party Recount Account'],
-  [ScheduleATransactionTypes.PAC_NATIONAL_PARTY_RECOUNT_ACCOUNT, 'PAC National Party Recount Account'],
-  [ScheduleATransactionTypes.TRIBAL_NATIONAL_PARTY_RECOUNT_ACCOUNT, 'Tribal National Party Recount Account'],
+  [
+    ScheduleATransactionTypes.INDIVIDUAL_NATIONAL_PARTY_RECOUNT_ACCOUNT,
+    'Individual National Party Recount/Legal Proceedings Account',
+  ],
+  [
+    ScheduleATransactionTypes.PARTY_NATIONAL_PARTY_RECOUNT_ACCOUNT,
+    'Party National Party Recount/Legal Proceedings Account',
+  ],
+  [
+    ScheduleATransactionTypes.PAC_NATIONAL_PARTY_RECOUNT_ACCOUNT,
+    'PAC National Party Recount/Legal Proceedings Account',
+  ],
+  [
+    ScheduleATransactionTypes.TRIBAL_NATIONAL_PARTY_RECOUNT_ACCOUNT,
+    'Tribal National Party Recount/Legal Proceedings Account',
+  ],
   [
     ScheduleATransactionTypes.INDIVIDUAL_NATIONAL_PARTY_HEADQUARTERS_BUILDINGS_ACCOUNT,
     'Individual National Party Headquarters Buildings Account',


### PR DESCRIPTION
updates label and e2e test for https://github.com/fecgov/fecfile-web-app/issues/463

~Meeting with Mitchell soon to clarify that child names are already correct~
updated non-related labels of national party recount account types to avoid confusion