### PR TITLE
Patch/always negative amount

### DIFF
--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.html
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.html
@@ -40,6 +40,7 @@
       <div class="field">
         <label for="contribution_amount">AMOUNT</label>
         <p-inputNumber
+          #amountInput
           inputId="contribution_amount"
           formControlName="contribution_amount"
           mode="currency"
@@ -47,6 +48,7 @@
           locale="en-US"
           [readonly]="contributionAmountReadOnly"
           inputStyleClass="{{ contributionAmountInputStyleClass }}"
+          (onInput)="onInputAmount($event)"
         ></p-inputNumber>
         <app-error-messages
           [form]="form"

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.spec.ts
@@ -31,4 +31,18 @@ describe('AmountInputComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should not call updateInput when negativeAmountValueOnly is false', () => {
+    component.negativeAmountValueOnly = false;
+    const updateInputMethodFalse = spyOn(component.amountInput, 'updateInput');
+    component.onInputAmount(new KeyboardEvent('1', undefined));
+    expect(updateInputMethodFalse).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call updateInput when negativeAmountValueOnly is true', () => {
+    component.negativeAmountValueOnly = true;
+    const updateInputMethodTrue = spyOn(component.amountInput, 'updateInput');
+    component.onInputAmount(new KeyboardEvent('1', undefined));
+    expect(updateInputMethodTrue).toHaveBeenCalled();
+  });
 });

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -11,6 +11,8 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
   @Input() contributionAmountReadOnly = false;
   @Input() memoItemHelpText =
     'The dollar amount in a memo item is not incorporated into the total figure for the schedule.';
+  @Input() negativeAmountValueOnly = false;
+
   @ViewChild('amountInput') amountInput!: InputNumber;
 
   contributionAmountInputStyleClass = '';
@@ -22,10 +24,12 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
   }
 
   onInputAmount($event: KeyboardEvent) {
-    const inputValue = this.amountInput.input.nativeElement.value;
-    if (inputValue.startsWith('$')) {
-      const value = Number(parseFloat(inputValue.slice(1)).toFixed(2));
-      this.amountInput.updateModel({}, -1 * value);
+    if (this.negativeAmountValueOnly) {
+      const inputValue = this.amountInput.input.nativeElement.value;
+      if (inputValue.startsWith('$')) {
+        const value = Number(parseFloat(inputValue.slice(1)).toFixed(2));
+        this.amountInput.updateModel({}, -1 * value);
+      }
     }
   }
 }

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -23,11 +23,13 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
     }
   }
 
-  onInputAmount($event: KeyboardEvent) {
+  // prettier-ignore
+  onInputAmount($event: KeyboardEvent) { // eslint-disable-line @typescript-eslint/no-unused-vars
     if (this.negativeAmountValueOnly) {
+      // Automatically convert the amount value to a negative dollar amount.
       const inputValue = this.amountInput.input.nativeElement.value;
       if (inputValue.startsWith('$')) {
-        const value = Number(parseInt(inputValue.slice(1)).toFixed(2));
+        const value = Number(parseInt(inputValue.slice(1)));
         this.amountInput.updateInput(-1 * value, undefined, undefined, undefined);
       }
     }

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -11,7 +11,7 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
   @Input() contributionAmountReadOnly = false;
   @Input() memoItemHelpText =
     'The dollar amount in a memo item is not incorporated into the total figure for the schedule.';
-  @Input() negativeAmountValueOnly = false;
+  @Input() negativeAmountValueOnly = true;
 
   @ViewChild('amountInput') amountInput!: InputNumber;
 
@@ -27,8 +27,8 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
     if (this.negativeAmountValueOnly) {
       const inputValue = this.amountInput.input.nativeElement.value;
       if (inputValue.startsWith('$')) {
-        const value = Number(parseFloat(inputValue.slice(1)).toFixed(2));
-        this.amountInput.updateModel({}, -1 * value);
+        const value = Number(parseInt(inputValue.slice(1)).toFixed(2));
+        this.amountInput.updateInput(-1 * value, undefined, undefined, undefined);
       }
     }
   }

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { BaseInputComponent } from '../base-input.component';
+import { InputNumber } from 'primeng/inputnumber';
 
 @Component({
   selector: 'app-amount-input',
@@ -10,12 +11,21 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
   @Input() contributionAmountReadOnly = false;
   @Input() memoItemHelpText =
     'The dollar amount in a memo item is not incorporated into the total figure for the schedule.';
+  @ViewChild('amountInput') amountInput!: InputNumber;
 
   contributionAmountInputStyleClass = '';
 
   ngOnInit(): void {
     if (this.contributionAmountReadOnly) {
       this.contributionAmountInputStyleClass = 'readonly';
+    }
+  }
+
+  onInputAmount($event: KeyboardEvent) {
+    const inputValue = this.amountInput.input.nativeElement.value;
+    if (inputValue.startsWith('$')) {
+      const value = Number(parseFloat(inputValue.slice(1)).toFixed(2));
+      this.amountInput.updateModel({}, -1 * value);
     }
   }
 }

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -11,7 +11,7 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
   @Input() contributionAmountReadOnly = false;
   @Input() memoItemHelpText =
     'The dollar amount in a memo item is not incorporated into the total figure for the schedule.';
-  @Input() negativeAmountValueOnly = true;
+  @Input() negativeAmountValueOnly = false;
 
   @ViewChild('amountInput') amountInput!: InputNumber;
 

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -28,7 +28,7 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit {
       const inputValue = this.amountInput.input.nativeElement.value;
       if (inputValue.startsWith('$')) {
         const value = Number(parseInt(inputValue.slice(1)).toFixed(2));
-        this.amountInput.updateInput(-1 * value, undefined, undefined, undefined);
+        this.amountInput.updateInput(-1 * value, undefined, 'insert', undefined);
       }
     }
   }

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -35,6 +35,7 @@ export abstract class TransactionTypeBaseComponent implements OnInit, OnDestroy 
   formSubmitted = false;
   memoItemHelpText = 'The dollar amount in a memo item is not incorporated into the total figure for the schedule.';
   contributionPurposeDescriptionLabel = '';
+  negativeAmountValueOnly = false;
 
   form: FormGroup = this.fb.group({});
 
@@ -135,6 +136,7 @@ export abstract class TransactionTypeBaseComponent implements OnInit, OnDestroy 
 
     const contribution_amount_schema = this.transactionType?.schema.properties['contribution_amount'];
     if (contribution_amount_schema?.exclusiveMaximum === 0) {
+      this.negativeAmountValueOnly = true;
       form
         .get('contribution_amount')
         ?.valueChanges.pipe(takeUntil(this.destroy$))

--- a/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.html
+++ b/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.html
@@ -31,6 +31,7 @@
         [form]="form"
         [formSubmitted]="formSubmitted"
         [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+        [negativeAmountValueOnly]="negativeAmountValueOnly"
       ></app-amount-input>
       <p-divider></p-divider>
       <h3>Additional Information</h3>

--- a/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.ts
+++ b/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.ts
@@ -1,13 +1,15 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormBuilder } from '@angular/forms';
+import { FormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TransactionTypeBaseComponent } from 'app/shared/components/transaction-type-base/transaction-type-base.component';
+import { TransactionType } from 'app/shared/models/transaction-types/transaction-type.model';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
 import { ContactService } from 'app/shared/services/contact.service';
 import { TransactionService } from 'app/shared/services/transaction.service';
 import { ValidateService } from 'app/shared/services/validate.service';
 import { LabelUtils, PrimeOptions } from 'app/shared/utils/label.utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
+import { Subject } from 'rxjs';
 import { ContactTypeLabels, ContactTypes } from '../../shared/models/contact.model';
 
 @Component({
@@ -60,5 +62,16 @@ export class TransactionGroupAComponent extends TransactionTypeBaseComponent imp
       router,
       fecDatePipe
     );
+  }
+
+  override doInit(
+    form: FormGroup<any>,
+    validateService: ValidateService,
+    transactionType: TransactionType | undefined,
+    contactId$: Subject<string>
+  ): void {
+    super.doInit(form, validateService, transactionType, contactId$);
+
+    this.form.controls['contribution_amount'];
   }
 }

--- a/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.ts
+++ b/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.ts
@@ -1,15 +1,13 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
+import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TransactionTypeBaseComponent } from 'app/shared/components/transaction-type-base/transaction-type-base.component';
-import { TransactionType } from 'app/shared/models/transaction-types/transaction-type.model';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
 import { ContactService } from 'app/shared/services/contact.service';
 import { TransactionService } from 'app/shared/services/transaction.service';
 import { ValidateService } from 'app/shared/services/validate.service';
 import { LabelUtils, PrimeOptions } from 'app/shared/utils/label.utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { Subject } from 'rxjs';
 import { ContactTypeLabels, ContactTypes } from '../../shared/models/contact.model';
 
 @Component({

--- a/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.ts
+++ b/front-end/src/app/transactions/transaction-group-a/transaction-group-a.component.ts
@@ -63,15 +63,4 @@ export class TransactionGroupAComponent extends TransactionTypeBaseComponent imp
       fecDatePipe
     );
   }
-
-  override doInit(
-    form: FormGroup<any>,
-    validateService: ValidateService,
-    transactionType: TransactionType | undefined,
-    contactId$: Subject<string>
-  ): void {
-    super.doInit(form, validateService, transactionType, contactId$);
-
-    this.form.controls['contribution_amount'];
-  }
 }

--- a/front-end/src/app/transactions/transaction-group-ag/transaction-group-ag.component.html
+++ b/front-end/src/app/transactions/transaction-group-ag/transaction-group-ag.component.html
@@ -41,6 +41,7 @@
             [form]="form"
             [formSubmitted]="formSubmitted"
             [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+            [negativeAmountValueOnly]="negativeAmountValueOnly"
           ></app-amount-input>
           <p-divider></p-divider>
           <h3>Additional Information</h3>
@@ -113,6 +114,7 @@
             [formSubmitted]="formSubmitted"
             [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType?.childTransactionType)"
             [contributionAmountReadOnly]="true"
+            [negativeAmountValueOnly]="negativeAmountValueOnly"
           ></app-amount-input>
           <p-divider></p-divider>
           <h3>Additional Information</h3>

--- a/front-end/src/app/transactions/transaction-group-b/transaction-group-b.component.html
+++ b/front-end/src/app/transactions/transaction-group-b/transaction-group-b.component.html
@@ -39,6 +39,7 @@
         [form]="form"
         [formSubmitted]="formSubmitted"
         [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+        [negativeAmountValueOnly]="negativeAmountValueOnly"
       ></app-amount-input>
       <p-divider></p-divider>
       <h3>Additional Information</h3>

--- a/front-end/src/app/transactions/transaction-group-c/transaction-group-c.component.html
+++ b/front-end/src/app/transactions/transaction-group-c/transaction-group-c.component.html
@@ -43,6 +43,7 @@
         [form]="form"
         [formSubmitted]="formSubmitted"
         [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+        [negativeAmountValueOnly]="negativeAmountValueOnly"
       ></app-amount-input>
       <p-divider></p-divider>
       <h3>Additional Information</h3>

--- a/front-end/src/app/transactions/transaction-group-d/transaction-group-d.component.html
+++ b/front-end/src/app/transactions/transaction-group-d/transaction-group-d.component.html
@@ -34,6 +34,7 @@
         [form]="form"
         [formSubmitted]="formSubmitted"
         [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+        [negativeAmountValueOnly]="negativeAmountValueOnly"
       ></app-amount-input>
       <p-divider></p-divider>
       <h3>Additional Information</h3>

--- a/front-end/src/app/transactions/transaction-group-e/transaction-group-e.component.html
+++ b/front-end/src/app/transactions/transaction-group-e/transaction-group-e.component.html
@@ -35,6 +35,7 @@
         [form]="form"
         [formSubmitted]="formSubmitted"
         [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+        [negativeAmountValueOnly]="negativeAmountValueOnly"
       ></app-amount-input>
       <p-divider></p-divider>
       <h3>Additional Information</h3>

--- a/front-end/src/app/transactions/transaction-group-f/transaction-group-f.component.html
+++ b/front-end/src/app/transactions/transaction-group-f/transaction-group-f.component.html
@@ -35,6 +35,7 @@
         [form]="form"
         [formSubmitted]="formSubmitted"
         [memoCodeReadOnly]="isMemoCodeReadOnly(transactionType)"
+        [negativeAmountValueOnly]="negativeAmountValueOnly"
       ></app-amount-input>
       <p-divider></p-divider>
       <h3>Additional Information</h3>


### PR DESCRIPTION
On receipts where the contribution amount can only negative, the users input is overwritten to be negative as they're typing it in.