### PR TITLE
fix periodic 400 on logout

### DIFF
--- a/front-end/src/app/store/login.effects.ts
+++ b/front-end/src/app/store/login.effects.ts
@@ -14,8 +14,9 @@ export class LoginEffects {
       this.actions$.pipe(
         ofType(userLoggedOutAction.type),
         tap(() => {
-          this.apiService.get('/auth/logout').subscribe();
-          this.router.navigate(['/']);
+          this.apiService.get('/auth/logout').subscribe(() => {
+            this.router.navigate(['/']);
+          });
         })
       ),
     { dispatch: false }


### PR DESCRIPTION
Wanted to get this in before I forgot the fix.  This was to address the periodic 400 error Shelly has been reporting on logout.  There wasn't a ticket created for this yet.

There is a race condition that is occurring when our database sessionid is deleted after this login/authenticate GET starts (due to the navigate('/')).  This causes the request to throw a 400 when it doesn't find the session to update expiry for.