### PR TITLE
Feature/343 Periodic 500 err fix on legacy logout

### DIFF
--- a/front-end/src/app/store/login.reducer.ts
+++ b/front-end/src/app/store/login.reducer.ts
@@ -6,7 +6,7 @@ export const initialState: UserLoginData = {
   committee_id: '',
   email: '',
   is_allowed: false,
-  login_dot_gov: true,
+  login_dot_gov: false,
 };
 
 export const loginReducer = createReducer(


### PR DESCRIPTION
The 500 was occurring from these steps
1) login via legacy form
2) close browser
3) open a new one and go to localhost fecfile app
4) logout

you should see a 500 error and the browser being redirected to /oidc/logout (which is the endpoint to logout of login.gov).

This is occurring because the initialState is created in login reducer when the application is loaded.  since the login_dot_gov flag is defaulted to true, the browser is trying to logout from login.gov on step 4. 

Note: the  login_dot_gov flag was added 12/2022 only for e2e testing purposes and this change shouldn't break functionality.  This should probably be removed completely (along with all the legacy login code) once we no longer need it.