### PR TITLE
Feature/591 force itemize/unitemize transactions

### DIFF
--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -73,7 +73,7 @@
           <app-table-actions-button
             [tableActions]="rowActions"
             [actionItem]="item"
-            [onTableActionClick]="onRowActionClick"
+            [tableActionClick]="onRowActionClick"
             buttonIcon="pi pi-ellipsis-v"
             buttonStyleClass="flex justify-content-center p-button-rounded p-button-primary  p-button-text mr-2"
             [buttonAriaLabel]="'edit ' + displayName(item)"

--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -70,32 +70,14 @@
         <td>{{ item.form_type | label : f3xFormVerionLabels }}</td>
         <td>{{ item.upload_submission?.created | fecDate }}</td>
         <td>
-          <p-overlayPanel #op [styleClass]="'action-options'">
-            <ng-template pTemplate>
-              <ul>
-                <li *ngFor="let action of rowActions">
-                  <button
-                    *ngIf="!action.isAvailable || action.isAvailable(item)"
-                    pButton
-                    pRipple
-                    type="button"
-                    class="p-button-secondary p-button-text"
-                    id="one"
-                    (click)="onRowActionClick(action, item)"
-                  >
-                    {{ action.label }}
-                  </button>
-                </li>
-              </ul>
-            </ng-template>
-          </p-overlayPanel>
-          <p-button
-            pRipple
-            icon="pi pi-ellipsis-v"
-            styleClass="flex justify-content-center p-button-rounded p-button-primary  p-button-text mr-2"
-            (onClick)="op.toggle($event)"
-            [ariaLabel]="'edit ' + displayName(item)"
-          ></p-button>
+          <app-table-actions-button
+            [tableActions]="rowActions"
+            [actionItem]="item"
+            [onTableActionClick]="onRowActionClick"
+            buttonIcon="pi pi-ellipsis-v"
+            buttonStyleClass="flex justify-content-center p-button-rounded p-button-primary  p-button-text mr-2"
+            [buttonAriaLabel]="'edit ' + displayName(item)"
+          ></app-table-actions-button>
         </td>
       </tr>
     </ng-template>

--- a/front-end/src/app/reports/reports.module.ts
+++ b/front-end/src/app/reports/reports.module.ts
@@ -9,10 +9,9 @@ import { CheckboxModule } from 'primeng/checkbox';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DividerModule } from 'primeng/divider';
 import { DropdownModule } from 'primeng/dropdown';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
-import { ListboxModule } from 'primeng/listbox';
 import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
+import { ListboxModule } from 'primeng/listbox';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { RadioButtonModule } from 'primeng/radiobutton';
 import { SelectButtonModule } from 'primeng/selectbutton';
@@ -21,23 +20,23 @@ import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
 import { TooltipModule } from 'primeng/tooltip';
 
+import { DialogModule } from 'primeng/dialog';
+import { InputNumberModule } from 'primeng/inputnumber';
 import { SharedModule } from '../../app/shared/shared.module';
+import { AppSelectButtonComponent } from '../shared/components/app-selectbutton.component';
+import { CashOnHandComponent } from './f3x/create-workflow/cash-on-hand.component';
 import { CreateF3XStep1Component } from './f3x/create-workflow/create-f3x-step1.component';
 import { ReportDetailedSummaryComponent } from './f3x/report-detailed-summary/report-detailed-summary.component';
 import { ReportLevelMemoComponent } from './f3x/report-level-memo/report-level-memo.component';
 import { ReportSummaryComponent } from './f3x/report-summary/report-summary.component';
+import { ReportWebPrintComponent } from './f3x/report-web-print/report-web-print.component';
 import { ReportSubmissionStatusComponent } from './f3x/submission-workflow/submit-f3x-status.component';
 import { SubmitF3xStep1Component } from './f3x/submission-workflow/submit-f3x-step1.component';
 import { SubmitF3xStep2Component } from './f3x/submission-workflow/submit-f3x-step2.component';
-import { ReportWebPrintComponent } from './f3x/report-web-print/report-web-print.component';
 import { TestDotFecComponent } from './f3x/test-dot-fec-workflow/test-dot-fec.component';
+import { FormTypeDialogComponent } from './form-type-dialog/form-type-dialog.component';
 import { ReportListComponent } from './report-list/report-list.component';
 import { ReportsRoutingModule } from './reports-routing.module';
-import { CashOnHandComponent } from './f3x/create-workflow/cash-on-hand.component';
-import { AppSelectButtonComponent } from '../shared/components/app-selectbutton.component';
-import { InputNumberModule } from 'primeng/inputnumber';
-import { FormTypeDialogComponent } from './form-type-dialog/form-type-dialog.component';
-import { DialogModule } from 'primeng/dialog';
 
 @NgModule({
   declarations: [
@@ -66,7 +65,6 @@ import { DialogModule } from 'primeng/dialog';
     DividerModule,
     DialogModule,
     DropdownModule,
-    OverlayPanelModule,
     ListboxModule,
     RadioButtonModule,
     CheckboxModule,
@@ -83,4 +81,4 @@ import { DialogModule } from 'primeng/dialog';
     InputNumberModule,
   ],
 })
-export class ReportsModule {}
+export class ReportsModule { }

--- a/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.html
+++ b/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.html
@@ -1,0 +1,30 @@
+<ng-container>
+  <p-overlayPanel #op [styleClass]="'action-options'">
+    <ng-template pTemplate>
+      <ul>
+        <li *ngFor="let action of tableActions">
+          <button
+            *ngIf="!action.isAvailable || action.isAvailable(actionItem)"
+            [disabled]="!action.isEnabled(actionItem)"
+            pButton
+            pRipple
+            type="button"
+            class="p-button-secondary p-button-text"
+            id="one"
+            (click)="onTableActionClick(action, actionItem)"
+          >
+            {{ action.label }}
+          </button>
+        </li>
+      </ul>
+    </ng-template>
+  </p-overlayPanel>
+  <p-button
+    pRipple
+    [icon]="buttonIcon"
+    [label]="buttonLabel"
+    [styleClass]="buttonStyleClass"
+    [ariaLabel]="buttonAriaLabel"
+    (onClick)="op.toggle($event)"
+  ></p-button>
+</ng-container>

--- a/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.html
+++ b/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.html
@@ -11,7 +11,7 @@
             type="button"
             class="p-button-secondary p-button-text"
             id="one"
-            (click)="onTableActionClick(action, actionItem)"
+            (click)="tableActionClick(action, actionItem)"
           >
             {{ action.label }}
           </button>

--- a/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.spec.ts
+++ b/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { TableActionsButtonComponent } from './table-actions-button.component';
+
+describe('TableActionsButtonComponent', () => {
+  let component: TableActionsButtonComponent;
+  let fixture: ComponentFixture<TableActionsButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        OverlayPanelModule,
+      ],
+      declarations: [TableActionsButtonComponent],
+      providers: [],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableActionsButtonComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+});

--- a/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.ts
+++ b/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { TableAction } from '../table-list-base/table-list-base.component';
+
+@Component({
+  selector: 'app-table-actions-button',
+  templateUrl: './table-actions-button.component.html',
+})
+export class TableActionsButtonComponent {
+  @Input() tableActions: TableAction[] = [];
+  @Input() actionItem: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  @Input() onTableActionClick: (action: TableAction, actionItem: any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+    void = (() => { return });
+  @Input() buttonIcon = '';
+  @Input() buttonLabel = '';
+  @Input() buttonStyleClass = '';
+  @Input() buttonAriaLabel = '';
+}

--- a/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.ts
+++ b/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.ts
@@ -8,7 +8,7 @@ import { TableAction } from '../table-list-base/table-list-base.component';
 export class TableActionsButtonComponent {
   @Input() tableActions: TableAction[] = [];
   @Input() actionItem: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  @Input() onTableActionClick: (action: TableAction, actionItem: any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+  @Input() tableActionClick: (action: TableAction, actionItem: any) => // eslint-disable-line @typescript-eslint/no-explicit-any
     void = (() => { return });
   @Input() buttonIcon = '';
   @Input() buttonLabel = '';

--- a/front-end/src/app/shared/models/transaction.model.ts
+++ b/front-end/src/app/shared/models/transaction.model.ts
@@ -24,6 +24,7 @@ export abstract class Transaction extends BaseModel {
 
   transaction_type_identifier: string | undefined;
   itemized: boolean | undefined;
+  force_itemized: boolean | undefined;
 
   parent_transaction: Transaction | undefined;
   parent_transaction_id: string | undefined; // Foreign key to the parent transaction db record

--- a/front-end/src/app/shared/shared.module.ts
+++ b/front-end/src/app/shared/shared.module.ts
@@ -3,36 +3,38 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { ButtonModule } from 'primeng/button';
+import { CalendarModule } from 'primeng/calendar';
+import { CheckboxModule } from 'primeng/checkbox';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
 import { DividerModule } from 'primeng/divider';
 import { DropdownModule } from 'primeng/dropdown';
+import { InputNumberModule } from 'primeng/inputnumber';
 import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
-import { CheckboxModule } from 'primeng/checkbox';
-import { InputNumberModule } from 'primeng/inputnumber';
-import { CalendarModule } from 'primeng/calendar';
+import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { TooltipModule } from 'primeng/tooltip';
 import { ContactFormComponent } from './components/contact-form/contact-form.component';
 import { ContactLookupComponent } from './components/contact-lookup/contact-lookup.component';
 import { ErrorMessagesComponent } from './components/error-messages/error-messages.component';
 import { FecInternationalPhoneInputComponent } from './components/fec-international-phone-input/fec-international-phone-input.component';
-import { AddressInputComponent } from './components/inputs/address-input/address-input.component';
-import { NameInputComponent } from './components/inputs/name-input/name-input.component';
-import { EmployerInputComponent } from './components/inputs/employer-input/employer-input.component';
-import { CommitteeInputComponent } from './components/inputs/committee-input/committee-input.component';
-import { AmountInputComponent } from './components/inputs/amount-input/amount-input.component';
 import { AdditionalInfoInputComponent } from './components/inputs/additional-info-input/additional-info-input.component';
+import { AddressInputComponent } from './components/inputs/address-input/address-input.component';
+import { AmountInputComponent } from './components/inputs/amount-input/amount-input.component';
+import { CommitteeInputComponent } from './components/inputs/committee-input/committee-input.component';
 import { ElectionInputComponent } from './components/inputs/election-input/election-input.component';
+import { EmployerInputComponent } from './components/inputs/employer-input/employer-input.component';
+import { NameInputComponent } from './components/inputs/name-input/name-input.component';
+import { NavigationControlBarComponent } from './components/navigation-control-bar/navigation-control-bar.component';
+import { NavigationControlComponent } from './components/navigation-control/navigation-control.component';
+import { TableActionsButtonComponent } from './components/table-actions-button/table-actions-button.component';
+import { TransactionContactLookupComponent } from './components/transaction-contact-lookup/transaction-contact-lookup.component';
 import { DefaultZeroPipe } from './pipes/default-zero.pipe';
 import { FecDatePipe } from './pipes/fec-date.pipe';
 import { HighlightTermsPipe } from './pipes/highlight-terms.pipe';
-import { ReportCodeLabelPipe } from './utils/report-code.utils';
 import { LabelPipe } from './pipes/label.pipe';
 import { LongDatePipe } from './pipes/long-date.pipe';
-import { NavigationControlComponent } from './components/navigation-control/navigation-control.component';
-import { NavigationControlBarComponent } from './components/navigation-control-bar/navigation-control-bar.component';
-import { TransactionContactLookupComponent } from './components/transaction-contact-lookup/transaction-contact-lookup.component';
-import { TooltipModule } from 'primeng/tooltip';
+import { ReportCodeLabelPipe } from './utils/report-code.utils';
 
 @NgModule({
   imports: [
@@ -51,6 +53,7 @@ import { TooltipModule } from 'primeng/tooltip';
     DialogModule,
     DividerModule,
     ConfirmDialogModule,
+    OverlayPanelModule,
   ],
   declarations: [
     LabelPipe,
@@ -75,6 +78,7 @@ import { TooltipModule } from 'primeng/tooltip';
     ElectionInputComponent,
     NavigationControlComponent,
     NavigationControlBarComponent,
+    TableActionsButtonComponent,
   ],
   exports: [
     FecDatePipe,
@@ -97,7 +101,8 @@ import { TooltipModule } from 'primeng/tooltip';
     AmountInputComponent,
     AdditionalInfoInputComponent,
     ElectionInputComponent,
+    TableActionsButtonComponent,
   ],
   providers: [DatePipe],
 })
-export class SharedModule {}
+export class SharedModule { }

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.html
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.html
@@ -3,34 +3,15 @@
     <ng-template pTemplate="left">Transactions</ng-template>
 
     <ng-template pTemplate="right">
-      <p-overlayPanel #op [styleClass]="'action-options'">
-        <ng-template pTemplate>
-          <ul>
-            <li *ngFor="let action of tableActions">
-              <button
-                *ngIf="!action.isAvailable || action.isAvailable(report)"
-                [disabled]="!action.isEnabled(report)"
-                pButton
-                pRipple
-                type="button"
-                class="p-button-secondary p-button-text"
-                id="one"
-                (click)="onTableActionClick(action, report)"
-              >
-                {{ action.label }}
-              </button>
-            </li>
-          </ul>
-        </ng-template>
-      </p-overlayPanel>
-      <p-button
-        pRipple
-        icon="pi pi-plus"
-        label="Add new transaction"
-        styleClass="p-button-success mr-2"
-        (onClick)="op.toggle($event)"
-        ariaLabel="Add a Transaction"
-      ></p-button>
+      <app-table-actions-button
+        [tableActions]="tableActions"
+        [actionItem]="report"
+        [onTableActionClick]="onTableActionClick"
+        buttonIcon="pi pi-plus"
+        buttonLabel="Add new transaction"
+        buttonStyleClass="p-button-success mr-2"
+        buttonAriaLabel="Add a Transaction"
+      ></app-table-actions-button>
     </ng-template>
   </p-toolbar>
 
@@ -111,32 +92,14 @@
           {{ item.parent_transaction?.transaction_id }}
         </td>
         <td>
-          <p-overlayPanel #op [styleClass]="'action-options'">
-            <ng-template pTemplate>
-              <ul>
-                <li *ngFor="let action of rowActions">
-                  <button
-                    *ngIf="!action.isAvailable || action.isAvailable(item)"
-                    pButton
-                    pRipple
-                    type="button"
-                    class="p-button-secondary p-button-text"
-                    id="one"
-                    (click)="onRowActionClick(action, item)"
-                  >
-                    {{ action.label }}
-                  </button>
-                </li>
-              </ul>
-            </ng-template>
-          </p-overlayPanel>
-          <p-button 
-            pRipple 
-            icon="pi pi-ellipsis-v" 
-            styleClass="p-button-text"
-            (onClick)="op.toggle($event)"
-            ariaLabel="action"
-          ></p-button>
+          <app-table-actions-button
+            [tableActions]="rowActions"
+            [actionItem]="item"
+            [onTableActionClick]="onRowActionClick"
+            buttonIcon="pi pi-ellipsis-v"
+            buttonStyleClass="p-button-text"
+            buttonAriaLabel="action"
+          ></app-table-actions-button>
           <!-- <em class="pi pi-trash" (click)="deleteItem(item)"></em> -->
         </td>
       </tr>

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.html
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.html
@@ -111,7 +111,32 @@
           {{ item.parent_transaction?.transaction_id }}
         </td>
         <td>
-          <p-button pRipple icon="pi pi-ellipsis-v" styleClass="p-button-text" ariaLabel="action"></p-button>
+          <p-overlayPanel #op [styleClass]="'action-options'">
+            <ng-template pTemplate>
+              <ul>
+                <li *ngFor="let action of rowActions">
+                  <button
+                    *ngIf="!action.isAvailable || action.isAvailable(item)"
+                    pButton
+                    pRipple
+                    type="button"
+                    class="p-button-secondary p-button-text"
+                    id="one"
+                    (click)="onRowActionClick(action, item)"
+                  >
+                    {{ action.label }}
+                  </button>
+                </li>
+              </ul>
+            </ng-template>
+          </p-overlayPanel>
+          <p-button 
+            pRipple 
+            icon="pi pi-ellipsis-v" 
+            styleClass="p-button-text"
+            (onClick)="op.toggle($event)"
+            ariaLabel="action"
+          ></p-button>
           <!-- <em class="pi pi-trash" (click)="deleteItem(item)"></em> -->
         </td>
       </tr>

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.html
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.html
@@ -6,7 +6,7 @@
       <app-table-actions-button
         [tableActions]="tableActions"
         [actionItem]="report"
-        [onTableActionClick]="onTableActionClick"
+        [tableActionClick]="onTableActionClick"
         buttonIcon="pi pi-plus"
         buttonLabel="Add new transaction"
         buttonStyleClass="p-button-success mr-2"
@@ -95,7 +95,7 @@
           <app-table-actions-button
             [tableActions]="rowActions"
             [actionItem]="item"
-            [onTableActionClick]="onRowActionClick"
+            [tableActionClick]="onRowActionClick"
             buttonIcon="pi pi-ellipsis-v"
             buttonStyleClass="p-button-text"
             buttonAriaLabel="action"

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -99,7 +99,7 @@ describe('TransactionListComponent', () => {
     component.onTableActionClick(component.tableActions[3], { id: '999' } as F3xSummary);
     expect(navigateSpy).toHaveBeenCalledWith(`/transactions/report/999/select/other-transactions`);
   });
-  it('should show the correct acitons', () => {
+  it('should show the correct table actions', () => {
     expect(component.tableActions[0].isAvailable({ report_status: 'In-Progress' })).toEqual(true);
     expect(component.tableActions[1].isAvailable({ report_status: 'In-Progress' })).toEqual(true);
     expect(component.tableActions[2].isAvailable({ report_status: 'In-Progress' })).toEqual(true);
@@ -108,6 +108,15 @@ describe('TransactionListComponent', () => {
     expect(component.tableActions[1].isEnabled({})).toEqual(true);
     expect(component.tableActions[2].isEnabled({})).toEqual(false);
     expect(component.tableActions[3].isEnabled({})).toEqual(false);
+  });
+
+  it('should show the correct row actions', () => {
+    expect(component.rowActions[0].isAvailable()).toEqual(true);
+    expect(component.rowActions[1].isAvailable({ itemized: false })).toEqual(true);
+    expect(component.rowActions[2].isAvailable({ itemized: true })).toEqual(true);
+    expect(component.rowActions[0].isEnabled({})).toEqual(true);
+    expect(component.rowActions[1].isEnabled({})).toEqual(true);
+    expect(component.rowActions[2].isEnabled({})).toEqual(true);
   });
 
   it('test forceItemize', () => {

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -18,6 +18,7 @@ describe('TransactionListComponent', () => {
   let component: TransactionListComponent;
   let fixture: ComponentFixture<TransactionListComponent>;
   let router: Router;
+  let testItemService: TransactionService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -61,6 +62,7 @@ describe('TransactionListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TransactionListComponent);
     router = TestBed.inject(Router);
+    testItemService = TestBed.inject(TransactionService);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -109,20 +111,18 @@ describe('TransactionListComponent', () => {
   });
 
   it('test forceItemize', () => {
-    const componentUpdateItemSpy = spyOn(component, 'updateItem');
+    spyOn(testItemService, 'getTableData').and.returnValue(of());
     const testTransaction: Transaction =
       { force_itemized: null } as unknown as Transaction;
     component.forceItemize(testTransaction);
-    expect(componentUpdateItemSpy).toHaveBeenCalledOnceWith(testTransaction);
     expect(testTransaction.force_itemized).toBe(true);
   });
 
   it('test forceItemize', () => {
-    const componentUpdateItemSpy = spyOn(component, 'updateItem');
+    spyOn(testItemService, 'getTableData').and.returnValue(of());
     const testTransaction: Transaction =
       { force_itemized: null } as unknown as Transaction;
     component.forceUnitemize(testTransaction);
-    expect(componentUpdateItemSpy).toHaveBeenCalledOnceWith(testTransaction);
     expect(testTransaction.force_itemized).toBe(false);
   });
 

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -1,17 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import { testMockStore } from 'app/shared/utils/unit-test.utils';
 import { F3xSummary } from 'app/shared/models/f3x-summary.model';
 import { SchATransaction } from 'app/shared/models/scha-transaction.model';
 import { TransactionService } from 'app/shared/services/transaction.service';
+import { testMockStore } from 'app/shared/utils/unit-test.utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { of } from 'rxjs';
-import { ToolbarModule } from 'primeng/toolbar';
 import { TableModule } from 'primeng/table';
-import { RouterTestingModule } from '@angular/router/testing';
+import { ToolbarModule } from 'primeng/toolbar';
+import { of } from 'rxjs';
 
-import { TransactionListComponent, MemoCodePipe } from './transaction-list.component';
+import { Transaction } from 'app/shared/models/transaction.model';
+import { MemoCodePipe, TransactionListComponent } from './transaction-list.component';
 
 describe('TransactionListComponent', () => {
   let component: TransactionListComponent;
@@ -37,6 +38,7 @@ describe('TransactionListComponent', () => {
                 })
               ),
             getTableData: () => of([]),
+            update: () => of([]),
           },
         },
         {
@@ -105,4 +107,23 @@ describe('TransactionListComponent', () => {
     expect(component.tableActions[2].isEnabled({})).toEqual(false);
     expect(component.tableActions[3].isEnabled({})).toEqual(false);
   });
+
+  it('test forceItemize', () => {
+    const componentUpdateItemSpy = spyOn(component, 'updateItem');
+    const testTransaction: Transaction =
+      { force_itemized: null } as unknown as Transaction;
+    component.forceItemize(testTransaction);
+    expect(componentUpdateItemSpy).toHaveBeenCalledOnceWith(testTransaction);
+    expect(testTransaction.force_itemized).toBe(true);
+  });
+
+  it('test forceItemize', () => {
+    const componentUpdateItemSpy = spyOn(component, 'updateItem');
+    const testTransaction: Transaction =
+      { force_itemized: null } as unknown as Transaction;
+    component.forceUnitemize(testTransaction);
+    expect(componentUpdateItemSpy).toHaveBeenCalledOnceWith(testTransaction);
+    expect(testTransaction.force_itemized).toBe(false);
+  });
+
 });

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -135,4 +135,18 @@ describe('TransactionListComponent', () => {
     expect(testTransaction.force_itemized).toBe(false);
   });
 
+  it('test editItem', () => {
+    const navigateSpy = spyOn(router, 'navigate');
+    const testTransaction: Transaction =
+      { id: 'testId' } as unknown as Transaction;
+    component.editItem(testTransaction);
+    expect(navigateSpy).toHaveBeenCalled();
+  });
+
+  it('should navigate to create other transactions', () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    component.onTableActionClick(component.tableActions[3], { id: '999' } as F3xSummary);
+    expect(navigateSpy).toHaveBeenCalledWith(`/transactions/report/999/select/other-transactions`);
+  });
+
 });

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
@@ -97,6 +97,10 @@ export class TransactionListComponent extends TableListBaseComponent<Transaction
     this.router.navigateByUrl(`/transactions/report/${report?.id}/select/${transactionCategory}`);
   }
 
+  public override editItem(item: Transaction): void {
+    this.router.navigate([`edit/${item.id}`], { relativeTo: this.activatedRoute });
+  }
+
   public onTableActionClick(action: TableAction, report?: F3xSummary) {
     action.action(report);
   }

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
@@ -10,7 +10,7 @@ import { TransactionService } from 'app/shared/services/transaction.service';
 import { LabelList } from 'app/shared/utils/label.utils';
 import { selectActiveReport } from 'app/store/active-report.selectors';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject, take, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-transaction-list',
@@ -125,7 +125,10 @@ export class TransactionListComponent extends TableListBaseComponent<Transaction
   }
 
   public updateItem(item: Transaction) {
-    this.itemService.update(item).subscribe(() => {
+    this.itemService.update(item).pipe(
+      take(1),
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
       this.loadTableItems({});
     });
   }

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
@@ -51,17 +51,20 @@ export class TransactionListComponent extends TableListBaseComponent<Transaction
     new TableAction(
       'Edit',
       this.editItem.bind(this),
+      () => true,
       () => true
     ),
     new TableAction(
       'Itemize',
       this.forceItemize.bind(this),
-      (transaction: Transaction) => transaction.itemized === false
+      (transaction: Transaction) => transaction.itemized === false,
+      () => true
     ),
     new TableAction(
       'Unitemize',
       this.forceUnitemize.bind(this),
-      (transaction: Transaction) => transaction.itemized === true
+      (transaction: Transaction) => transaction.itemized === true,
+      () => true
     ),
   ];
   constructor(

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.ts
@@ -1,16 +1,16 @@
 import { Component, ElementRef, OnDestroy, OnInit, Pipe, PipeTransform } from '@angular/core';
-import { Subject, takeUntil } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { selectActiveReport } from 'app/store/active-report.selectors';
-import { F3xSummary } from 'app/shared/models/f3x-summary.model';
 import { TableAction, TableListBaseComponent } from 'app/shared/components/table-list-base/table-list-base.component';
-import { Transaction } from 'app/shared/models/transaction.model';
-import { ConfirmationService, MessageService } from 'primeng/api';
-import { TransactionService } from 'app/shared/services/transaction.service';
+import { F3xSummary } from 'app/shared/models/f3x-summary.model';
 import { ScheduleATransactionTypeLabels } from 'app/shared/models/scha-transaction.model';
 import { ScheduleBTransactionTypeLabels } from 'app/shared/models/schb-transaction.model';
+import { Transaction } from 'app/shared/models/transaction.model';
+import { TransactionService } from 'app/shared/services/transaction.service';
 import { LabelList } from 'app/shared/utils/label.utils';
+import { selectActiveReport } from 'app/store/active-report.selectors';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-transaction-list',
@@ -45,6 +45,23 @@ export class TransactionListComponent extends TableListBaseComponent<Transaction
       this.createTransactions.bind(this, 'other-transactions'),
       (report: F3xSummary) => report.report_status === 'In-Progress',
       () => false
+    ),
+  ];
+  public rowActions: TableAction[] = [
+    new TableAction(
+      'Edit',
+      this.editItem.bind(this),
+      () => true
+    ),
+    new TableAction(
+      'Itemize',
+      this.forceItemize.bind(this),
+      (transaction: Transaction) => transaction.itemized === false
+    ),
+    new TableAction(
+      'Unitemize',
+      this.forceUnitemize.bind(this),
+      (transaction: Transaction) => transaction.itemized === true
     ),
   ];
   constructor(
@@ -89,6 +106,27 @@ export class TransactionListComponent extends TableListBaseComponent<Transaction
     const reportId = this.activatedRoute.snapshot.params['reportId'];
     return { report_id: reportId };
   }
+
+  public onRowActionClick(action: TableAction, transaction: Transaction) {
+    action.action(transaction);
+  }
+
+  public forceItemize(transaction: Transaction): void {
+    transaction.force_itemized = true;
+    this.updateItem(transaction);
+  }
+
+  public forceUnitemize(transaction: Transaction): void {
+    transaction.force_itemized = false;
+    this.updateItem(transaction);
+  }
+
+  public updateItem(item: Transaction) {
+    this.itemService.update(item).subscribe(() => {
+      this.loadTableItems({});
+    });
+  }
+
 }
 
 @Pipe({ name: 'memoCode' })

--- a/front-end/src/app/transactions/transactions.module.ts
+++ b/front-end/src/app/transactions/transactions.module.ts
@@ -9,7 +9,6 @@ import { CalendarModule } from 'primeng/calendar';
 import { CheckboxModule } from 'primeng/checkbox';
 import { DividerModule } from 'primeng/divider';
 import { DropdownModule } from 'primeng/dropdown';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { InputNumberModule } from 'primeng/inputnumber';
 import { InputTextModule } from 'primeng/inputtext';
 import { InputTextareaModule } from 'primeng/inputtextarea';
@@ -21,17 +20,17 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SharedModule } from '../shared/shared.module';
 import { TransactionContainerComponent } from './transaction-container/transaction-container.component';
 import { TransactionGroupAComponent } from './transaction-group-a/transaction-group-a.component';
+import { TransactionGroupAgComponent } from './transaction-group-ag/transaction-group-ag.component';
 import { TransactionGroupBComponent } from './transaction-group-b/transaction-group-b.component';
 import { TransactionGroupCComponent } from './transaction-group-c/transaction-group-c.component';
 import { TransactionGroupDComponent } from './transaction-group-d/transaction-group-d.component';
 import { TransactionGroupEComponent } from './transaction-group-e/transaction-group-e.component';
-import { TransactionGroupIComponent } from './transaction-group-i/transaction-group-i.component';
-import { TransactionGroupAgComponent } from './transaction-group-ag/transaction-group-ag.component';
 import { TransactionGroupFgComponent } from './transaction-group-fg/transaction-group-fg.component';
+import { TransactionGroupIComponent } from './transaction-group-i/transaction-group-i.component';
+import { TransactionGroupMComponent } from './transaction-group-m/transaction-group-m.component';
 import { MemoCodePipe, TransactionListComponent } from './transaction-list/transaction-list.component';
 import { TransactionTypePickerComponent } from './transaction-type-picker/transaction-type-picker.component';
 import { TransactionsRoutingModule } from './transactions-routing.module';
-import { TransactionGroupMComponent } from './transaction-group-m/transaction-group-m.component';
 
 @NgModule({
   declarations: [
@@ -58,7 +57,6 @@ import { TransactionGroupMComponent } from './transaction-group-m/transaction-gr
     ButtonModule,
     DividerModule,
     DropdownModule,
-    OverlayPanelModule,
     CheckboxModule,
     InputTextModule,
     InputTextareaModule,
@@ -71,4 +69,4 @@ import { TransactionGroupMComponent } from './transaction-group-m/transaction-gr
     ConfirmDialogModule,
   ],
 })
-export class TransactionsModule {}
+export class TransactionsModule { }


### PR DESCRIPTION
updated the "itemized" flag logic to use the new "force_itemized" flag so that we can avoid checking two flags everywhere (front-end, .fec construction, etc) and I thought it made more sense this way. Open to other options though.