### PR TITLE
Feature/977 cleanup unit test errors

### DIFF
--- a/front-end/src/app/contacts/contact-list/contact-list.component.spec.ts
+++ b/front-end/src/app/contacts/contact-list/contact-list.component.spec.ts
@@ -13,6 +13,7 @@ import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
 import { Contact, ContactTypes } from '../../shared/models/contact.model';
 import { ContactDetailComponent } from '../contact-detail/contact-detail.component';
+import { DeletedContactDialogComponent } from '../deleted-contact-dialog/deleted-contact-dialog.component';
 import { ContactListComponent } from './contact-list.component';
 import { of } from 'rxjs';
 
@@ -37,7 +38,7 @@ describe('ContactListComponent', () => {
         ConfirmDialogModule,
         SharedModule,
       ],
-      declarations: [ContactListComponent, ContactDetailComponent],
+      declarations: [ContactListComponent, ContactDetailComponent, DeletedContactDialogComponent],
       providers: [ConfirmationService, MessageService, FormBuilder, provideMockStore(testMockStore)],
     }).compileComponents();
   });

--- a/front-end/src/app/login/login/login.component.spec.ts
+++ b/front-end/src/app/login/login/login.component.spec.ts
@@ -10,6 +10,7 @@ import { environment } from 'environments/environment';
 import { of, throwError } from 'rxjs';
 import { LoginService } from '../../shared/services/login.service';
 import { LoginComponent } from './login.component';
+import { BannerComponent } from 'app/layout/banner/banner.component';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -21,13 +22,16 @@ describe('LoginComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
-        RouterTestingModule.withRoutes([{
-          path: 'dashboard', component: DashboardComponent
-        }]),
-        ReactiveFormsModule
+        RouterTestingModule.withRoutes([
+          {
+            path: 'dashboard',
+            component: DashboardComponent,
+          },
+        ]),
+        ReactiveFormsModule,
       ],
       providers: [{ provide: Window, useValue: window }, provideMockStore(testMockStore)],
-      declarations: [LoginComponent],
+      declarations: [LoginComponent, BannerComponent],
     }).compileComponents();
   });
 

--- a/front-end/src/app/login/login/login.component.ts
+++ b/front-end/src/app/login/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, NgZone, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
@@ -30,7 +30,8 @@ export class LoginComponent implements OnInit {
     private fb: FormBuilder,
     private loginService: LoginService,
     private router: Router,
-    private store: Store
+    private store: Store,
+    private ngZone: NgZone
   ) {
     this.form = this.fb.group({
       committeeId: ['', Validators.required],
@@ -94,7 +95,9 @@ export class LoginComponent implements OnInit {
       next: (res: UserLoginData) => {
         if (res.is_allowed) {
           this.store.dispatch(userLoggedInAction({ payload: res }));
-          this.router.navigate(['dashboard']);
+          this.ngZone.run(() => {
+            this.router.navigate(['dashboard']);
+          });
         }
       },
       error: () => {

--- a/front-end/src/app/reports/f3x/report-web-print/report-web-print.component.spec.ts
+++ b/front-end/src/app/reports/f3x/report-web-print/report-web-print.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { testMockStore } from 'app/shared/utils/unit-test.utils';
@@ -35,10 +35,16 @@ describe('ReportWebPrintComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('Sets the status messages as expected', () => {
+  it('Sets the status messages as expected', fakeAsync(() => {
+    const refresh = spyOn(component, 'refreshReportStatus');
     component.pollPrintStatus();
-    expect(component.pollingStatusMessage).toBe('This may take a while...');
-  });
+    tick(5001);
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(refresh).toHaveBeenCalled();
+      expect(component.pollingStatusMessage).toBe('This may take a while...');
+    });
+  }));
 
   it('refreshes the active report', () => {
     const refresh = spyOn(webPrintService, 'getStatus');
@@ -82,9 +88,15 @@ describe('ReportWebPrintComponent', () => {
     );
   });
 
-  it('#submitPrintJob() calls the service', () => {
+  it('#submitPrintJob() calls the service', fakeAsync(() => {
     const submit = spyOn(webPrintService, 'submitPrintJob');
+    const refresh = spyOn(component, 'refreshReportStatus');
     component.submitPrintJob();
     expect(submit).toHaveBeenCalled();
-  });
+    tick(5001);
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(refresh).toHaveBeenCalled();
+    });
+  }));
 });

--- a/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.spec.ts
+++ b/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.spec.ts
@@ -4,6 +4,7 @@ import { FormTypes } from 'app/shared/utils/form-type.utils';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { FormTypeDialogComponent } from './form-type-dialog.component';
+import { Dialog, DialogModule } from 'primeng/dialog';
 
 describe('FormTypeDialogComponent', () => {
   let component: FormTypeDialogComponent;
@@ -12,8 +13,8 @@ describe('FormTypeDialogComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([])],
-      declarations: [FormTypeDialogComponent],
+      imports: [RouterTestingModule.withRoutes([]), DialogModule],
+      declarations: [Dialog, FormTypeDialogComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FormTypeDialogComponent);

--- a/front-end/src/app/reports/report-list/report-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/report-list.component.spec.ts
@@ -13,6 +13,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { UploadSubmission } from 'app/shared/models/upload-submission.model';
 import { TableAction } from 'app/shared/components/table-list-base/table-list-base.component';
+import { FormTypeDialogComponent } from '../form-type-dialog/form-type-dialog.component';
+import { Dialog, DialogModule } from 'primeng/dialog';
 
 describe('ReportListComponent', () => {
   let component: ReportListComponent;
@@ -21,8 +23,8 @@ describe('ReportListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, TableModule, ToolbarModule, RouterTestingModule.withRoutes([])],
-      declarations: [ReportListComponent],
+      imports: [HttpClientTestingModule, TableModule, ToolbarModule, RouterTestingModule.withRoutes([]), DialogModule],
+      declarations: [ReportListComponent, FormTypeDialogComponent, Dialog],
       providers: [ConfirmationService, MessageService, ApiService, provideMockStore(testMockStore)],
     }).compileComponents();
   });

--- a/front-end/src/app/shared/components/contact-form/contact-form.component.spec.ts
+++ b/front-end/src/app/shared/components/contact-form/contact-form.component.spec.ts
@@ -4,7 +4,13 @@ import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angul
 import { provideMockStore } from '@ngrx/store/testing';
 import { Candidate } from 'app/shared/models/candidate.model';
 import { CommitteeAccount } from 'app/shared/models/committee-account.model';
-import { CandidateOfficeTypes, Contact, ContactTypes, FecApiCandidateLookupData, FecApiCommitteeLookupData } from 'app/shared/models/contact.model';
+import {
+  CandidateOfficeTypes,
+  Contact,
+  ContactTypes,
+  FecApiCandidateLookupData,
+  FecApiCommitteeLookupData,
+} from 'app/shared/models/contact.model';
 import { FecApiService } from 'app/shared/services/fec-api.service';
 import { testMockStore } from 'app/shared/utils/unit-test.utils';
 import { DropdownModule } from 'primeng/dropdown';
@@ -12,6 +18,7 @@ import { of } from 'rxjs';
 import { ErrorMessagesComponent } from '../error-messages/error-messages.component';
 import { FecInternationalPhoneInputComponent } from '../fec-international-phone-input/fec-international-phone-input.component';
 import { ContactFormComponent } from './contact-form.component';
+import { ContactLookupComponent } from '../contact-lookup/contact-lookup.component';
 
 describe('ContactFormComponent', () => {
   let component: ContactFormComponent;
@@ -20,14 +27,13 @@ describe('ContactFormComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-        FormsModule,
-        ReactiveFormsModule,
-        DropdownModule,
+      imports: [HttpClientTestingModule, FormsModule, ReactiveFormsModule, DropdownModule],
+      declarations: [
+        ContactFormComponent,
+        ErrorMessagesComponent,
+        FecInternationalPhoneInputComponent,
+        ContactLookupComponent,
       ],
-      declarations: [ContactFormComponent, ErrorMessagesComponent,
-        FecInternationalPhoneInputComponent],
       providers: [FormBuilder, provideMockStore(testMockStore)],
     }).compileComponents();
     testFecApiService = TestBed.inject(FecApiService);
@@ -72,7 +78,6 @@ describe('ContactFormComponent', () => {
     component.form.get('type')?.setValue(ContactTypes.COMMITTEE);
   });
 
-
   it('changing country from USA should change state', () => {
     component.form.patchValue({
       country: 'USA',
@@ -90,8 +95,8 @@ describe('ContactFormComponent', () => {
 
   it('#onContactLookupSelect CANDIDATE Contact happy path', () => {
     const testContact = new Contact();
-    const testLastName = "testLastName";
-    const testZip = "12345";
+    const testLastName = 'testLastName';
+    const testZip = '12345';
     testContact.type = ContactTypes.CANDIDATE;
     testContact.last_name = testLastName;
     testContact.zip = testZip;
@@ -107,8 +112,8 @@ describe('ContactFormComponent', () => {
 
   it('#onContactLookupSelect COMMITTEE Contact happy path', () => {
     const testContact = new Contact();
-    const testCommitteeId = "C1234568";
-    const testZip = "12345";
+    const testCommitteeId = 'C1234568';
+    const testZip = '12345';
     testContact.type = ContactTypes.COMMITTEE;
     testContact.committee_id = testCommitteeId;
     testContact.zip = testZip;
@@ -123,14 +128,14 @@ describe('ContactFormComponent', () => {
   });
 
   it('#onContactLookupSelect FecApiCandidateLookupData happy path', () => {
-    const testId = 'P12345678'
+    const testId = 'P12345678';
     const testOfficeSought = 'P';
     const testName = 'testName';
     const testAddressCity = 'testAddressCity';
     const testFecApiCandidateLookupData = new FecApiCandidateLookupData({
       id: testId,
       office_sought: testOfficeSought,
-      name: testName
+      name: testName,
     } as FecApiCandidateLookupData);
     const testResponse = new Candidate();
     testResponse.candidate_id = testId;
@@ -149,14 +154,14 @@ describe('ContactFormComponent', () => {
   });
 
   it('#onContactLookupSelect FecApiCommitteeLookupData happy path', () => {
-    const testId = 'C12345678'
+    const testId = 'C12345678';
     const testIsActive = true;
     const testName = 'testName';
     const testPhone = '1234567890';
     const testFecApiCommitteeLookupData = new FecApiCommitteeLookupData({
       id: testId,
       is_active: testIsActive,
-      name: testName
+      name: testName,
     } as FecApiCommitteeLookupData);
     const testResponse = new CommitteeAccount();
     testResponse.committee_id = testId;
@@ -173,5 +178,4 @@ describe('ContactFormComponent', () => {
     component.form = new FormGroup({});
     component.onContactLookupSelect({ value: testFecApiCommitteeLookupData });
   });
-
 });

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.spec.ts
@@ -10,6 +10,8 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { ConfirmationService } from 'primeng/api';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
 import { F3xSummary } from 'app/shared/models/f3x-summary.model';
+import { Dialog } from 'primeng/dialog';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 describe('AmountInputComponent', () => {
   let component: AmountInputComponent;
@@ -17,8 +19,8 @@ describe('AmountInputComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AmountInputComponent, ErrorMessagesComponent, FecDatePipe],
-      imports: [CheckboxModule, InputNumberModule, CalendarModule, ReactiveFormsModule],
+      declarations: [AmountInputComponent, ErrorMessagesComponent, FecDatePipe, Dialog, Tooltip],
+      imports: [CheckboxModule, InputNumberModule, CalendarModule, ReactiveFormsModule, TooltipModule],
       providers: [provideMockStore(testMockStore), ConfirmationService],
     }).compileComponents();
 

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
@@ -11,6 +11,7 @@ import { ButtonModule } from 'primeng/button';
 import { NavigationControlComponent } from './navigation-control.component';
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
 import { FormBuilder } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 
 describe('NavigationControlComponent', () => {
   let component: NavigationControlComponent;
@@ -18,7 +19,7 @@ describe('NavigationControlComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ButtonModule, DropdownModule],
+      imports: [ButtonModule, DropdownModule, ReactiveFormsModule],
       declarations: [NavigationControlComponent, Dropdown],
       providers: [FormBuilder],
     }).compileComponents();

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
@@ -9,6 +9,8 @@ import { JOINT_FUNDRAISING_TRANSFER } from 'app/shared/models/transaction-types/
 import { TransactionTypeUtils } from 'app/shared/utils/transaction-type.utils';
 import { ButtonModule } from 'primeng/button';
 import { NavigationControlComponent } from './navigation-control.component';
+import { Dropdown, DropdownModule } from 'primeng/dropdown';
+import { FormBuilder } from '@angular/forms';
 
 describe('NavigationControlComponent', () => {
   let component: NavigationControlComponent;
@@ -16,8 +18,9 @@ describe('NavigationControlComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ButtonModule],
-      declarations: [NavigationControlComponent],
+      imports: [ButtonModule, DropdownModule],
+      declarations: [NavigationControlComponent, Dropdown],
+      providers: [FormBuilder],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavigationControlComponent);

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
@@ -10,8 +10,7 @@ import { TransactionTypeUtils } from 'app/shared/utils/transaction-type.utils';
 import { ButtonModule } from 'primeng/button';
 import { NavigationControlComponent } from './navigation-control.component';
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
-import { FormBuilder } from '@angular/forms';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 
 describe('NavigationControlComponent', () => {
   let component: NavigationControlComponent;

--- a/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.spec.ts
+++ b/front-end/src/app/shared/components/table-actions-button/table-actions-button.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { TableActionsButtonComponent } from './table-actions-button.component';
+import { Button, ButtonModule } from 'primeng/button';
 
 describe('TableActionsButtonComponent', () => {
   let component: TableActionsButtonComponent;
@@ -8,10 +9,8 @@ describe('TableActionsButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        OverlayPanelModule,
-      ],
-      declarations: [TableActionsButtonComponent],
+      imports: [OverlayPanelModule, ButtonModule],
+      declarations: [TableActionsButtonComponent, Button],
       providers: [],
     }).compileComponents();
   });
@@ -24,5 +23,4 @@ describe('TableActionsButtonComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
 });

--- a/front-end/src/app/shared/components/transaction-contact-lookup/transaction-contact-lookup.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-contact-lookup/transaction-contact-lookup.component.spec.ts
@@ -3,12 +3,7 @@ import { EventEmitter } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { provideMockStore } from '@ngrx/store/testing';
-import {
-  Contact,
-  ContactTypes,
-  FecApiCommitteeLookupData,
-  FecApiLookupData
-} from 'app/shared/models/contact.model';
+import { Contact, ContactTypes, FecApiCommitteeLookupData, FecApiLookupData } from 'app/shared/models/contact.model';
 import { testMockStore } from 'app/shared/utils/unit-test.utils';
 import { DropdownModule } from 'primeng/dropdown';
 import { of } from 'rxjs';
@@ -19,6 +14,7 @@ import { SelectItem } from 'primeng/api';
 import { AutoCompleteModule } from 'primeng/autocomplete';
 import { DialogModule } from 'primeng/dialog';
 import { TransactionContactLookupComponent } from './transaction-contact-lookup.component';
+import { ContactLookupComponent } from '../contact-lookup/contact-lookup.component';
 
 describe('TransactionContactLookupComponent', () => {
   let component: TransactionContactLookupComponent;
@@ -28,7 +24,7 @@ describe('TransactionContactLookupComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TransactionContactLookupComponent],
+      declarations: [TransactionContactLookupComponent, ContactLookupComponent],
       imports: [
         FormsModule,
         ReactiveFormsModule,
@@ -131,5 +127,4 @@ describe('TransactionContactLookupComponent', () => {
     component.onCreateContactDialogClose();
     expect(component.createContactFormSubmitted).toBeFalse();
   });
-  
 });

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
@@ -493,6 +493,31 @@ describe('TransactionTypeBaseComponent', () => {
 
     component.form.addControl('entity_type', { value: testEntityType });
     component.onContactLookupSelect(testContactSelectItem);
+    const lastNameFormControlValue = component.form.get('contributor_last_name')?.value;
+    const firstNameFormControlValue = component.form.get('contributor_first_name')?.value;
+    const middleNameFormControlValue = component.form.get('contributor_middle_name')?.value;
+    const prefixFormControlValue = component.form.get('contributor_prefix')?.value;
+    const suffixFormControlValue = component.form.get('contributor_suffix')?.value;
+    const employerFormControlValue = component.form.get('contributor_employer')?.value;
+    const occupationFormControlValue = component.form.get('contributor_occupation')?.value;
+    const street1FormControlValue = component.form.get('contributor_street_1')?.value;
+    const street2FormControlValue = component.form.get('contributor_street_2')?.value;
+    const cityFormControlValue = component.form.get('contributor_city')?.value;
+    const stateFormControlValue = component.form.get('contributor_state')?.value;
+    const zipFormControlValue = component.form.get('contributor_zip')?.value;
+
+    expect(lastNameFormControlValue === testContact.last_name).toBeTrue();
+    expect(firstNameFormControlValue === testContact.first_name).toBeTrue();
+    expect(middleNameFormControlValue === testContact.middle_name).toBeTrue();
+    expect(prefixFormControlValue === testContact.prefix).toBeTrue();
+    expect(suffixFormControlValue === testContact.suffix).toBeTrue();
+    expect(employerFormControlValue === testContact.employer).toBeTrue();
+    expect(occupationFormControlValue === testContact.occupation).toBeTrue();
+    expect(street1FormControlValue === testContact.street_1).toBeTrue();
+    expect(street2FormControlValue === testContact.street_2).toBeTrue();
+    expect(cityFormControlValue === testContact.city).toBeTrue();
+    expect(stateFormControlValue === testContact.state).toBeTrue();
+    expect(zipFormControlValue === testContact.zip).toBeTrue();
   });
 
   it('#onContactLookupSelect INDIVIDUAL should calculate aggregate', () => {

--- a/front-end/src/app/shared/resolvers/report.resolver.spec.ts
+++ b/front-end/src/app/shared/resolvers/report.resolver.spec.ts
@@ -42,7 +42,7 @@ describe('ReportResolver', () => {
     httpTestingController.verify();
   });
 
-  xit('should return undefined', () => {
+  it('should return undefined', () => {
     const route = {
       paramMap: convertToParamMap({ reportId: undefined }),
     };

--- a/front-end/src/app/shared/resolvers/report.resolver.spec.ts
+++ b/front-end/src/app/shared/resolvers/report.resolver.spec.ts
@@ -42,7 +42,7 @@ describe('ReportResolver', () => {
     httpTestingController.verify();
   });
 
-  it('should return undefined', () => {
+  xit('should return undefined', () => {
     const route = {
       paramMap: convertToParamMap({ reportId: undefined }),
     };

--- a/front-end/src/app/shared/resolvers/transaction.resolver.spec.ts
+++ b/front-end/src/app/shared/resolvers/transaction.resolver.spec.ts
@@ -106,7 +106,7 @@ describe('TransactionResolver', () => {
     });
   });
 
-  it('should attach child for transaction with dependent child transaction type', () => {
+  xit('should attach child for transaction with dependent child transaction type', () => {
     resolver.resolve_new_child_transaction('1', ScheduleATransactionTypes.EARMARK_RECEIPT).subscribe((transaction) => {
       if (transaction?.children) {
         expect(transaction.children[0].transactionType?.title).toBe('Earmark Memo');

--- a/front-end/src/app/shared/resolvers/transaction.resolver.spec.ts
+++ b/front-end/src/app/shared/resolvers/transaction.resolver.spec.ts
@@ -106,7 +106,7 @@ describe('TransactionResolver', () => {
     });
   });
 
-  xit('should attach child for transaction with dependent child transaction type', () => {
+  it('should attach child for transaction with dependent child transaction type', () => {
     resolver.resolve_new_child_transaction('1', ScheduleATransactionTypes.EARMARK_RECEIPT).subscribe((transaction) => {
       if (transaction?.children) {
         expect(transaction.children[0].transactionType?.title).toBe('Earmark Memo');

--- a/front-end/src/app/transactions/transaction-container/transaction-container.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-container/transaction-container.component.spec.ts
@@ -21,6 +21,7 @@ import { of } from 'rxjs';
 import { SharedModule } from '../../shared/shared.module';
 import { TransactionGroupBComponent } from '../transaction-group-b/transaction-group-b.component';
 import { TransactionContainerComponent } from './transaction-container.component';
+import { ConfirmDialog, ConfirmDialogModule } from 'primeng/confirmdialog';
 
 describe('TransactionContainerComponent', () => {
   let component: TransactionContainerComponent;
@@ -43,8 +44,9 @@ describe('TransactionContainerComponent', () => {
         InputTextModule,
         InputNumberModule,
         InputTextareaModule,
+        ConfirmDialogModule,
       ],
-      declarations: [TransactionContainerComponent, TransactionGroupBComponent],
+      declarations: [TransactionContainerComponent, TransactionGroupBComponent, ConfirmDialog],
       providers: [
         FormBuilder,
         MessageService,

--- a/front-end/src/app/transactions/transaction-group-b/transaction-group-b.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-group-b/transaction-group-b.component.spec.ts
@@ -18,7 +18,7 @@ import { Confirmation, ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { CalendarModule } from 'primeng/calendar';
 import { CheckboxModule } from 'primeng/checkbox';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
+import { ConfirmDialogModule, ConfirmDialog } from 'primeng/confirmdialog';
 import { DividerModule } from 'primeng/divider';
 import { DropdownModule } from 'primeng/dropdown';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -74,7 +74,7 @@ describe('TransactionGroupBComponent', () => {
         InputTextareaModule,
         ConfirmDialogModule,
       ],
-      declarations: [TransactionGroupBComponent],
+      declarations: [TransactionGroupBComponent, ConfirmDialog],
       providers: [MessageService, ConfirmationService, FormBuilder, provideMockStore(testMockStore), FecDatePipe],
     }).compileComponents();
     testContactService = TestBed.inject(ContactService);

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -16,6 +16,7 @@ import { MemoCodePipe, TransactionListComponent } from './transaction-list.compo
 import { ConfirmDialog } from 'primeng/confirmdialog';
 import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 import { Button, ButtonModule } from 'primeng/button';
+import { TableActionsButtonComponent } from 'app/shared/components/table-actions-button/table-actions-button.component';
 
 describe('TransactionListComponent', () => {
   let component: TransactionListComponent;
@@ -33,7 +34,7 @@ describe('TransactionListComponent', () => {
         OverlayPanelModule,
         ButtonModule,
       ],
-      declarations: [TransactionListComponent, ConfirmDialog, OverlayPanel, Button],
+      declarations: [TransactionListComponent, ConfirmDialog, OverlayPanel, Button, TableActionsButtonComponent],
       providers: [
         MessageService,
         ConfirmationService,

--- a/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-list/transaction-list.component.spec.ts
@@ -13,6 +13,9 @@ import { of } from 'rxjs';
 
 import { Transaction } from 'app/shared/models/transaction.model';
 import { MemoCodePipe, TransactionListComponent } from './transaction-list.component';
+import { ConfirmDialog } from 'primeng/confirmdialog';
+import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
+import { Button, ButtonModule } from 'primeng/button';
 
 describe('TransactionListComponent', () => {
   let component: TransactionListComponent;
@@ -22,8 +25,15 @@ describe('TransactionListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ToolbarModule, TableModule, RouterTestingModule, RouterTestingModule.withRoutes([])],
-      declarations: [TransactionListComponent],
+      imports: [
+        ToolbarModule,
+        TableModule,
+        RouterTestingModule,
+        RouterTestingModule.withRoutes([]),
+        OverlayPanelModule,
+        ButtonModule,
+      ],
+      declarations: [TransactionListComponent, ConfirmDialog, OverlayPanel, Button],
       providers: [
         MessageService,
         ConfirmationService,
@@ -121,18 +131,15 @@ describe('TransactionListComponent', () => {
 
   it('test forceItemize', () => {
     spyOn(testItemService, 'getTableData').and.returnValue(of());
-    const testTransaction: Transaction =
-      { force_itemized: null } as unknown as Transaction;
+    const testTransaction: Transaction = { force_itemized: null } as unknown as Transaction;
     component.forceItemize(testTransaction);
     expect(testTransaction.force_itemized).toBe(true);
   });
 
   it('test forceItemize', () => {
     spyOn(testItemService, 'getTableData').and.returnValue(of());
-    const testTransaction: Transaction =
-      { force_itemized: null } as unknown as Transaction;
+    const testTransaction: Transaction = { force_itemized: null } as unknown as Transaction;
     component.forceUnitemize(testTransaction);
     expect(testTransaction.force_itemized).toBe(false);
   });
-
 });


### PR DESCRIPTION
Cleaned up 147 errors and 3 warnings, comprising about 75% of the length of warnings/errors (see size of scrollbar) in the browser dev console when unit tests are run.

Of the remaining issues
 - 1 type of errors remain
    - 2 (NG04002) invalid route errors (these are likely the same error)
 - 1 type of warnings remain
    - 118 [disabled]="X" style warnings (the cure might be worse than the disease)



![image.png](https://images.zenhubusercontent.com/626ab5e81394ace64f8ed65d/3bb895e8-d6f2-4eb9-87ad-3c40e9ee933a)

![image.png](https://images.zenhubusercontent.com/626ab5e81394ace64f8ed65d/9da7018c-5af9-42c4-9f8e-00a230fa7d25)