### PR TITLE
fix tier3 creation form keeping tier2 form values bug

### DIFF
--- a/front-end/src/app/transactions/transaction-detail/transaction-detail.component.spec.ts
+++ b/front-end/src/app/transactions/transaction-detail/transaction-detail.component.spec.ts
@@ -62,7 +62,7 @@ describe('TransactionDetailComponent', () => {
     component = fixture.componentInstance;
     component.transaction = transaction;
     component.templateMap = testTemplateMap;
-    fixture.detectChanges();
+    component.ngOnChanges({});
   });
 
   it('should create', () => {

--- a/front-end/src/app/transactions/transaction-detail/transaction-detail.component.ts
+++ b/front-end/src/app/transactions/transaction-detail/transaction-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnChanges, SimpleChanges } from '@angular/core';
 import { TransactionTypeBaseComponent } from 'app/shared/components/transaction-type-base/transaction-type-base.component';
 import { ContactTypes } from 'app/shared/models/contact.model';
 import { TransactionGroup } from 'app/shared/models/transaction-groups/transaction-group.model';
@@ -9,13 +9,14 @@ import { takeUntil } from 'rxjs';
   templateUrl: './transaction-detail.component.html',
   styleUrls: ['../transaction.scss'],
 })
-export class TransactionDetailComponent extends TransactionTypeBaseComponent implements OnInit {
+export class TransactionDetailComponent extends TransactionTypeBaseComponent implements OnChanges {
   override formProperties: string[] = [];
   hasEmployerInput = false;
   hasCommitteeFecIdInput = false;
   hasElectionInformationInput = false;
 
-  override ngOnInit(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ngOnChanges(changes: SimpleChanges): void {
     if (this.transaction?.transactionType?.templateMap) {
       const transactionType = this.transaction.transactionType;
       const transactionGroup = transactionType.transactionGroup as TransactionGroup;


### PR DESCRIPTION
This seems to only show up when creating a tier3 transaction.  Since we are no longer creating separate "transaction detail" templates for each group, we need to detect transaction @input changes to the template.