### PR TITLE
1059 fix enter key cancelling transaction form

### DIFF
--- a/front-end/src/app/transactions/transaction-detail/transaction-detail.component.html
+++ b/front-end/src/app/transactions/transaction-detail/transaction-detail.component.html
@@ -87,14 +87,15 @@
         </ng-template>
       </div>
     </ng-container>
-    <p-divider></p-divider>
-    <app-navigation-control-bar
-      [navigationControls]="getNavigationControls()"
-      [transaction]="transaction"
-      (navigate)="handleNavigate($event)"
-      [class]="isEditable ? '' : 'flex-center'"
-    ></app-navigation-control-bar>
   </form>
 </div>
+
+<p-divider></p-divider>
+<app-navigation-control-bar
+  [navigationControls]="getNavigationControls()"
+  [transaction]="transaction"
+  (navigate)="handleNavigate($event)"
+  [class]="isEditable ? '' : 'flex-center'"
+></app-navigation-control-bar>
 
 <p-confirmDialog key="dialog" [style]="{ width: '450px' }"></p-confirmDialog>


### PR DESCRIPTION
The problem is the click() event in `app-navigation-control` was being fired when hitting enter anywhere in the form (which is default browser behavior).  Moving `app-navigation-control-bar` outside the form now matches double-transaction-detail and other forms where this isn't an issue. 