### PR TITLE
feature/1106 just checking box showing when typing date

### DIFF
--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -74,8 +74,8 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit, 
   }
 
   updateMemoItemWithDate(date: Date) {
-    if (date && this.report?.coverage_from_date && this.report?.coverage_through_date) {
-      if (date < this.report.coverage_from_date || date > this.report.coverage_through_date) {
+    if (this.report?.coverage_from_date && this.report?.coverage_through_date) {
+      if (date && (date < this.report.coverage_from_date || date > this.report.coverage_through_date)) {
         this.memoControl.addValidators(Validators.requiredTrue);
         this.memoControl.markAsTouched();
         this.memoControl.updateValueAndValidity();

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.ts
@@ -74,7 +74,7 @@ export class AmountInputComponent extends BaseInputComponent implements OnInit, 
   }
 
   updateMemoItemWithDate(date: Date) {
-    if (this.report?.coverage_from_date && this.report?.coverage_through_date) {
+    if (date && this.report?.coverage_from_date && this.report?.coverage_through_date) {
       if (date < this.report.coverage_from_date || date > this.report.coverage_through_date) {
         this.memoControl.addValidators(Validators.requiredTrue);
         this.memoControl.markAsTouched();


### PR DESCRIPTION
date is null until full string is types (ie '05/22/2023') but still is sent to the Observable.  Need to add null check on date to updateMemoItemWithDate so that this method doesn't trigger the dialog before they have finished typing.