### PR TITLE
remove duplicate snyk install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,11 +246,11 @@ workflows:
     jobs:
       - lint
       - test
-      # - dependency-check
+      - dependency-check
       - deploy:
           requires:
             - test
-            # - dependency-check
+            - dependency-check
 
   nightly-run:
     when: << pipeline.parameters.is-nightly-run >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ parameters:
     default: false
 
 workflows:
-  test:
+  main:
     when:
       not: << pipeline.parameters.is-nightly-run >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,50 +164,6 @@ jobs:
             export PATH=$HOME/bin:$PATH
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
 
-      - restore_cache:
-          keys:
-            - v2-snyk-files
-
-      - run:
-          name: Verify Snyk auth token is present
-          command: |
-            if [ -z ${SNYK_AUTH_TOKEN} ]; then
-              echo "";
-              echo "You must set the SNYK_AUTH_TOKEN environment variable.";
-              echo "Go to https://app.snyk.io/account ";
-              echo "";
-              exit 15
-            fi
-
-      - run:
-          name: Download Snyk CLI
-          command: |
-            ls -l snyk-linux || echo cached snyk binary not found
-            ls -l snyk.version || echo cached snyk version not found
-            LATEST_SNYK_CLI_VERSION=$(curl https://static.snyk.io/cli/latest/version)
-            touch snyk.version
-            CACHE_SNYK_CLI_VERSION=$(cat snyk.version)
-            echo "Cached version is ${CACHE_SNYK_CLI_VERSION} "
-            if [[ ! "${CACHE_SNYK_CLI_VERSION}" == "${LATEST_SNYK_CLI_VERSION}"  ]]; then
-              echo "Downloading Snyk CLI version ${LATEST_SNYK_CLI_VERSION}"
-              curl -sO https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-linux
-              curl -sO https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-linux.sha256
-              sha256sum -c snyk-linux.sha256
-              echo $LATEST_SNYK_CLI_VERSION > snyk.version
-            else
-              echo "Using cached snyk version ${CACHE_SNYK_CLI_VERSION}"
-            fi
-            sudo cp snyk-linux /usr/local/bin/snyk
-            sudo chmod +x /usr/local/bin/snyk
-            snyk config set disableSuggestions=true
-            snyk auth $SNYK_AUTH_TOKEN
-
-      - save_cache:
-          key: v3-snyk-files
-          paths:
-            - snyk-linux
-            - snyk.version
-
       - run:
           name: run deploy script
           no_output_timeout: 15m


### PR DESCRIPTION
This was just downloading Snyk on deploy and not even running "snyk test", which is run during dependency-check.

Also, it seems the deploy ran successfully on 6-30 even using cflinuxfs3, so perhaps the deploy failures were only temporary in nature.  

I propose we monitor it moving forward before changing this image.