### PR TITLE
Patch/1147-partnership-memo-transaction-name-changes

### DIFF
--- a/front-end/src/app/shared/models/transaction-types/PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO.model.ts
+++ b/front-end/src/app/shared/models/transaction-types/PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO.model.ts
@@ -14,7 +14,7 @@ export class PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO 
   );
   override updateParentOnSave = true;
   schema = schema;
-  override shortName = 'Partnership Individual';
+  override shortName = 'Partnership Attribution';
   override navigationControls: TransactionNavigationControls = getChildNavigationControls();
 
   override generatePurposeDescription(transaction: SchATransaction): string {

--- a/front-end/src/app/shared/models/transaction-types/PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO.model.ts
+++ b/front-end/src/app/shared/models/transaction-types/PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO.model.ts
@@ -14,7 +14,7 @@ export class PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO ext
   );
   override updateParentOnSave = true;
   schema = schema;
-  override shortName = 'Partnership Individual';
+  override shortName = 'Partnership Attribution';
   override navigationControls: TransactionNavigationControls = getChildNavigationControls();
 
   override generatePurposeDescription(transaction: SchATransaction): string {


### PR DESCRIPTION
#1147 

A couple memos didn't have their shortnames changed, leading to the old names showing up in the Save & Add a Memo dropdowns for their parents.