### PR TITLE
Bug/1299 Contact lookup dropdown not updating properly

### DIFF
--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouteReuseStrategy } from '@angular/router';
 
 // NGRX
 import { EffectsModule } from '@ngrx/effects';
@@ -46,6 +47,7 @@ import { LoginComponent } from './login/login/login.component';
 import { HttpErrorInterceptor } from './shared/interceptors/http-error.interceptor';
 import { FecDatePipe } from './shared/pipes/fec-date.pipe';
 import { SharedModule } from './shared/shared.module';
+import { CustomRouteReuseStrategy } from './custom-route-reuse-strategy';
 
 // Save ngrx store to localStorage dynamically
 function localStorageSyncReducer(reducer: ActionReducer<AppState>): ActionReducer<AppState> {
@@ -103,7 +105,8 @@ const metaReducers: Array<MetaReducer<AppState, Action>> = [localStorageSyncRedu
     MessageService,
     { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true },
     FecDatePipe,
+    { provide: RouteReuseStrategy, useClass: CustomRouteReuseStrategy },
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/front-end/src/app/custom-route-reuse-strategy.ts
+++ b/front-end/src/app/custom-route-reuse-strategy.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { BaseRouteReuseStrategy } from '@angular/router';
+
+/**
+ * Code adapted from: https://blog.nativescript.org/how-to-extend-custom-router-reuse-strategy/
+ */
+
+@Injectable()
+export class CustomRouteReuseStrategy extends BaseRouteReuseStrategy {
+  override shouldReuseRoute(future: ActivatedRouteSnapshot, current: ActivatedRouteSnapshot): boolean {
+    // First use the global Reuse Strategy evaluation function,
+    // which will return true, when we are navigating from the same component to itself
+    let shouldReuse = super.shouldReuseRoute(future, current);
+
+    if (shouldReuse && current.data['noComponentReuse']) {
+      shouldReuse = false;
+    }
+
+    return shouldReuse;
+  }
+}

--- a/front-end/src/app/custom-route-reuse-strategy.ts
+++ b/front-end/src/app/custom-route-reuse-strategy.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot } from '@angular/router';
-import { BaseRouteReuseStrategy } from '@angular/router';
+import { ActivatedRouteSnapshot, BaseRouteReuseStrategy } from '@angular/router';
 
 /**
  * Code adapted from: https://blog.nativescript.org/how-to-extend-custom-router-reuse-strategy/

--- a/front-end/src/app/reports/transactions/double-transaction-detail/double-transaction-detail.component.html
+++ b/front-end/src/app/reports/transactions/double-transaction-detail/double-transaction-detail.component.html
@@ -199,7 +199,7 @@
         </div>
         <ng-container *ngIf="childTransaction?.contact_1">
           <ng-container
-            *ngIf="[ContactTypes.ORGANIZATION, ContactTypes.COMMITTEE].includes(form.get('entity_type')?.value)"
+            *ngIf="[ContactTypes.ORGANIZATION, ContactTypes.COMMITTEE].includes(childForm.get('entity_type')?.value)"
           >
             <app-committee-input
               [form]="childForm"

--- a/front-end/src/app/reports/transactions/transactions-routing.module.ts
+++ b/front-end/src/app/reports/transactions/transactions-routing.module.ts
@@ -66,17 +66,11 @@ const routes: Routes = [
       sidebar: SidebarStateResolver,
     },
     canActivate: [ReportIsEditableGuard],
-  },
-  // The following route goes to the same component as above but provides the siblingId so that
-  // the page is recreated and all components call ngOnInit().
-  {
-    path: 'report/:reportId/list/:parentTransactionId/create-sub-transaction/:transactionType/:siblingId',
-    component: TransactionContainerComponent,
-    resolve: {
-      transaction: TransactionResolver,
-      sidebar: SidebarStateResolver,
-    },
-    canActivate: [ReportIsEditableGuard],
+    // There is a scenario where a memo is saved and then navigates to create
+    // a sibling transaction of a different transaction type, the below setting ensures
+    // the transaction form components are destroyed and recreated so initialization
+    // happens correcty.
+    data: { noComponentReuse: true }, // Handled in src/app/custom-route-reuse-strategy.ts
   },
   { path: '**', redirectTo: '' },
 ];

--- a/front-end/src/app/reports/transactions/transactions-routing.module.ts
+++ b/front-end/src/app/reports/transactions/transactions-routing.module.ts
@@ -67,6 +67,17 @@ const routes: Routes = [
     },
     canActivate: [ReportIsEditableGuard],
   },
+  // The following route goes to the same component as above but provides the siblingId so that
+  // the page is recreated and all components call ngOnInit().
+  {
+    path: 'report/:reportId/list/:parentTransactionId/create-sub-transaction/:transactionType/:siblingId',
+    component: TransactionContainerComponent,
+    resolve: {
+      transaction: TransactionResolver,
+      sidebar: SidebarStateResolver,
+    },
+    canActivate: [ReportIsEditableGuard],
+  },
   { path: '**', redirectTo: '' },
 ];
 

--- a/front-end/src/app/reports/transactions/transactions-routing.module.ts
+++ b/front-end/src/app/reports/transactions/transactions-routing.module.ts
@@ -69,7 +69,7 @@ const routes: Routes = [
     // There is a scenario where a memo is saved and then navigates to create
     // a sibling transaction of a different transaction type, the below setting ensures
     // the transaction form components are destroyed and recreated so initialization
-    // happens correcty.
+    // of the new transaction form happens correctly.
     data: { noComponentReuse: true }, // Handled in src/app/custom-route-reuse-strategy.ts
   },
   { path: '**', redirectTo: '' },

--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.ts
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.ts
@@ -35,15 +35,12 @@ export class ContactLookupComponent implements OnInit {
   searchTerm = '';
   requiredErrorMessage = '';
 
-  constructor(
-    private contactService: ContactService
-  ) { }
+  constructor(private contactService: ContactService) {}
   ngOnInit(): void {
     this.contactTypeFormControl.valueChanges.subscribe((contactType) => {
-      this.requiredErrorMessage = LabelUtils.get(
-        ContactTypeLabels, contactType) + ' information is required';
+      this.requiredErrorMessage = LabelUtils.get(ContactTypeLabels, contactType) + ' information is required';
     });
-    if (this.contactTypeOptions && this.contactTypeOptions.length > 0) {
+    if (!this.contactTypeFormControl.value && this.contactTypeOptions && this.contactTypeOptions.length > 0) {
       this.contactTypeFormControl.setValue(this.contactTypeOptions[0].value);
     }
   }

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -268,13 +268,15 @@ export abstract class TransactionTypeBaseComponent implements OnInit, OnDestroy 
         life: 3000,
       });
       if (event.transaction?.parent_transaction_id) {
+        // Append the sibling ID to the end of the URL so that the components are not cached from the existing page
+        // and used in the new transaction input page. The transaction form needs to be initialized from scratch when displayed
+        // which required a new URL from the current one when navigateByUrl is called. The URL is the same when
+        // "Save & add memo" is clicked to create a new sibiling transaction.
         this.router.navigateByUrl(
-          `${reportPath}/list/${event.transaction?.parent_transaction_id}/create-sub-transaction/${event.destinationTransactionType}`
+          `${reportPath}/list/${event.transaction?.parent_transaction_id}/create-sub-transaction/${event.destinationTransactionType}/${event.transaction.id}`
         );
-        this.resetForm();
       } else {
         this.router.navigateByUrl(`${reportPath}/create/${event.destinationTransactionType}`);
-        this.resetForm();
       }
     } else if (event.destination === NavigationDestination.CHILD) {
       this.messageService.add({

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -268,12 +268,8 @@ export abstract class TransactionTypeBaseComponent implements OnInit, OnDestroy 
         life: 3000,
       });
       if (event.transaction?.parent_transaction_id) {
-        // Append the sibling ID to the end of the URL so that the components are not cached from the existing page
-        // and used in the new transaction input page. The transaction form needs to be initialized from scratch when displayed
-        // which required a new URL from the current one when navigateByUrl is called. The URL is the same when
-        // "Save & add memo" is clicked to create a new sibiling transaction.
         this.router.navigateByUrl(
-          `${reportPath}/list/${event.transaction?.parent_transaction_id}/create-sub-transaction/${event.destinationTransactionType}/${event.transaction.id}`
+          `${reportPath}/list/${event.transaction?.parent_transaction_id}/create-sub-transaction/${event.destinationTransactionType}`
         );
       } else {
         this.router.navigateByUrl(`${reportPath}/create/${event.destinationTransactionType}`);


### PR DESCRIPTION
This patch fixes 2 issues:

1) When an existing contact is edited, the contact lookup drop down was not checking the existing entity_type value when setting the value of that field. It was simply using the first value of the contactTypeOptions array.

2) When a new memo transaction is saved with the "Save & create another" memo, the URL contains the parent ID which does not change across sibling transaction types so the URL was not changing for the new sibling transaction form and the initialization was based on the previously saved transaction. The fix was to add a new feature in the angular RouteReuseStrategy to force destroy and recreate the route component based on a custom route flag.