### PR TITLE
Bug/1302 Fix inherited field list for LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT

### DIFF
--- a/front-end/src/app/shared/models/transaction-types/LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT.model.ts
+++ b/front-end/src/app/shared/models/transaction-types/LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT.model.ts
@@ -8,7 +8,6 @@ import {
   INDIVIDUAL_ORGANIZATION_COMMITTEE,
   INDIVIDUAL_FIELDS,
   ORG_FIELDS,
-  CORE_FIELDS,
 } from 'app/shared/utils/transaction-type-properties';
 
 export class LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT extends SchATransactionType {
@@ -19,7 +18,18 @@ export class LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT extends SchATransactionType {
   title = 'Receipt';
   schema = schema;
   override useParentContact = true;
-  override inheritedFields = [...CORE_FIELDS, ...INDIVIDUAL_FIELDS, ...ORG_FIELDS] as TemplateMapKeyType[];
+  override inheritedFields = [
+    ...INDIVIDUAL_FIELDS,
+    ...ORG_FIELDS,
+    'street_1',
+    'street_2',
+    'city',
+    'state',
+    'zip',
+    'date',
+    'amount',
+    'memo_code'
+  ] as TemplateMapKeyType[];
 
   override description =
     'Only the Purpose of Receipt and Note/Memo Text are editable. To update any errors found, return to the previous step to update loan information.';
@@ -29,6 +39,7 @@ export class LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT extends SchATransactionType {
   override footer = undefined;
   override contactTitle = 'Contact';
   override contactLookupLabel = 'CONTACT LOOKUP';
+  override dateLabel = 'DATE';
 
   getNewTransaction() {
     return SchATransaction.fromJSON({


### PR DESCRIPTION
#1302 

1) Corrected the inheritedFields list for the LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT transaction type. It was erroneously including purpose_description and memo_text
2) Updated date label for the same transaction type. Changed from DATE RECEIVED to DATE