### PR TITLE
Convert empty strings being save for empty candidate fields to nulls

### DIFF
--- a/front-end/src/app/shared/components/inputs/candidate-office-input/candidate-office-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/candidate-office-input/candidate-office-input.component.spec.ts
@@ -49,40 +49,37 @@ describe('CandidateOfficeInputComponent', () => {
 
   it('test PRESIDENTIAL office', () => {
     component.form.patchValue({
-      [testCandidateOfficeFormControlName]:
-        CandidateOfficeTypes.PRESIDENTIAL
+      [testCandidateOfficeFormControlName]: CandidateOfficeTypes.PRESIDENTIAL,
     });
     const stateFormControl = component.form.get(component.candidateStateFormControlName);
     const districtFormControl = component.form.get(component.candidateDistrictFormControlName);
 
-    expect(stateFormControl?.value).toBe('');
+    expect(stateFormControl?.value).toBeNull();
     expect(stateFormControl?.disabled).toBe(true);
 
-    expect(districtFormControl?.value).toBe('');
+    expect(districtFormControl?.value).toBeNull();
     expect(districtFormControl?.disabled).toBe(true);
   });
 
   it('test SENATE office', () => {
     component.form.patchValue({
-      [testCandidateOfficeFormControlName]:
-        CandidateOfficeTypes.SENATE
+      [testCandidateOfficeFormControlName]: CandidateOfficeTypes.SENATE,
     });
     const stateFormControl = component.form.get(component.candidateStateFormControlName);
     const districtFormControl = component.form.get(component.candidateDistrictFormControlName);
 
     expect(stateFormControl?.disabled).toBe(false);
 
-    expect(districtFormControl?.value).toBe('');
+    expect(districtFormControl?.value).toBeNull();
     expect(districtFormControl?.disabled).toBe(true);
   });
 
   it('test HOUSE office', () => {
     component.form.patchValue({
-      [testCandidateOfficeFormControlName]:
-        CandidateOfficeTypes.HOUSE
+      [testCandidateOfficeFormControlName]: CandidateOfficeTypes.HOUSE,
     });
     component.form.patchValue({
-      [testCandidateStateFormControlName]: 'FL'
+      [testCandidateStateFormControlName]: 'FL',
     });
     const stateFormControl = component.form.get(component.candidateStateFormControlName);
     const districtFormControl = component.form.get(component.candidateDistrictFormControlName);
@@ -90,8 +87,8 @@ describe('CandidateOfficeInputComponent', () => {
     expect(stateFormControl?.disabled).toBe(false);
     expect(districtFormControl?.disabled).toBe(false);
 
-    expect(component.candidateDistrictOptions).toEqual(LabelUtils.getPrimeOptions(
-      LabelUtils.getCongressionalDistrictLabels('FL')));
+    expect(component.candidateDistrictOptions).toEqual(
+      LabelUtils.getPrimeOptions(LabelUtils.getCongressionalDistrictLabels('FL'))
+    );
   });
-
 });

--- a/front-end/src/app/shared/components/inputs/candidate-office-input/candidate-office-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/candidate-office-input/candidate-office-input.component.ts
@@ -30,14 +30,14 @@ export class CandidateOfficeInputComponent extends DestroyerComponent implements
       .subscribe((value: string) => {
         if (!value || value === CandidateOfficeTypes.PRESIDENTIAL) {
           this.form.patchValue({
-            [this.candidateStateFormControlName]: '',
-            [this.candidateDistrictFormControlName]: '',
+            [this.candidateStateFormControlName]: null,
+            [this.candidateDistrictFormControlName]: null,
           });
           this.form.get(this.candidateStateFormControlName)?.disable();
           this.form.get(this.candidateDistrictFormControlName)?.disable();
         } else if (value === CandidateOfficeTypes.SENATE) {
           this.form.patchValue({
-            [this.candidateDistrictFormControlName]: '',
+            [this.candidateDistrictFormControlName]: null,
           });
           this.form.get(this.candidateStateFormControlName)?.enable();
           this.form.get(this.candidateDistrictFormControlName)?.disable();


### PR DESCRIPTION
The validation schema is failing the empty save for candidate_state and candidate_district because the default reset value for those form controls is '' rather than null. This patch changes the '' to null and validation is passing as it should.