### PR TITLE
Update transactions tests to account for new inherited itemization rules

### DIFF
--- a/front-end/cypress/e2e/reports-f3x-transactions.cy.ts
+++ b/front-end/cypress/e2e/reports-f3x-transactions.cy.ts
@@ -188,7 +188,7 @@ describe('Transactions', () => {
       .find('td')
       .eq(TransactionTableColumns.transaction_type)
       .should('contain', 'Partnership Attribution');
-    cy.get('@row-1').find('td').eq(TransactionTableColumns.transaction_type).should('not.contain', 'Unitemized');
+    cy.get('@row-1').find('td').eq(TransactionTableColumns.transaction_type).should('contain', 'Unitemized');
     cy.get('@row-1').find('td').eq(TransactionTableColumns.memo_code).should('contain', 'Y');
     cy.get('@row-1').find('td').eq(TransactionTableColumns.aggregate).should('contain', '$201.10');
 
@@ -593,7 +593,7 @@ describe('Transactions', () => {
       .find('td')
       .eq(TransactionTableColumns.transaction_type)
       .should('contain', 'Partnership Receipt Joint Fundraising Transfer Memo');
-    cy.get('@row-2').find('td').eq(TransactionTableColumns.transaction_type).should('contain', 'Unitemized');
+    cy.get('@row-2').find('td').eq(TransactionTableColumns.transaction_type).should('not.contain', 'Unitemized');
     cy.get('@row-2').find('td').eq(TransactionTableColumns.memo_code).should('contain', 'Y');
     cy.get('@row-2').find('td').eq(TransactionTableColumns.aggregate).should('contain', '$100.55');
 


### PR DESCRIPTION
The e2e tests were failing on 2 assert that were asserting memo/attribution transaction children a different itemization state than their parent transaction. This was the case prior to the implementation of the new inherited itemization rules but the e2e tests needed to be updated to account for the new rules in the 2 asserts.