### PR TITLE
Patch/Scroll Bug Fix

### DIFF
--- a/front-end/src/app/app-routing.module.ts
+++ b/front-end/src/app/app-routing.module.ts
@@ -43,7 +43,12 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { onSameUrlNavigation: 'reload' })],
+  imports: [
+    RouterModule.forRoot(routes, {
+      onSameUrlNavigation: 'reload',
+      scrollPositionRestoration: 'top',
+    }),
+  ],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/front-end/src/app/app-routing.module.ts
+++ b/front-end/src/app/app-routing.module.ts
@@ -46,6 +46,8 @@ const routes: Routes = [
   imports: [
     RouterModule.forRoot(routes, {
       onSameUrlNavigation: 'reload',
+      // Fixes bug that had window scroll position being preserved between routes.
+      // https://stackoverflow.com/questions/39601026/angular-2-scroll-to-top-on-route-change
       scrollPositionRestoration: 'top',
     }),
   ],


### PR DESCRIPTION
Fixes issue with the router not resetting the window's scroll to the top of the page when the route changes.

The fix was found in a [Stackoverflow post](https://stackoverflow.com/questions/39601026/angular-2-scroll-to-top-on-route-change)