### PR TITLE
Remove reference to archived image generator repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ finance information. The project code is distributed across these repositories:
 - [fecfile-web-app](https://github.com/fecgov/fecfile-web-app): this is the browser-based front-end developed in Angualar
 - [fecfile-web-api](https://github.com/fecgov/fecfile-web-api): RESTful endpoint supporting the front-end
 - [fecfile-validate](https://github.com/fecgov/fecfile-validate): data validation rules and engine
-- [fecfile-image-generator](https://github.com/fecgov/fecfile-image-generator): provides competed FEC forms in PDF format
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Senate, Presidency and the Vice Presidency.
 This project will provide a web application for filling out FEC campaign
 finance information. The project code is distributed across these repositories:
 
-- [fecfile-web-app](https://github.com/fecgov/fecfile-web-app): this is the browser-based front-end developed in Angualar
+- [fecfile-web-app](https://github.com/fecgov/fecfile-web-app): this is the browser-based front-end developed in Angular
 - [fecfile-web-api](https://github.com/fecgov/fecfile-web-api): RESTful endpoint supporting the front-end
 - [fecfile-validate](https://github.com/fecgov/fecfile-validate): data validation rules and engine
 


### PR DESCRIPTION
Archived repository: https://github.com/fecgov/fecfile-image-generator

FECfile will use [Web Print](https://efoservices.fec.gov/static/webprint_help.html)