### PR TITLE
Patch/1332 Remove red border around contact searchbox in contact dialog

### DIFF
--- a/front-end/src/app/shared/components/transaction-contact-lookup/transaction-contact-lookup.component.html
+++ b/front-end/src/app/shared/components/transaction-contact-lookup/transaction-contact-lookup.component.html
@@ -1,11 +1,13 @@
-<div class="p-fluid" [ngClass]="{ 'transaction-contact-invalid': errorMessageFormControl?.status === 'INVALID' }">
-  <app-contact-lookup
-    [contactTypeOptions]="contactTypeOptions"
-    (contactTypeSelect)="contactTypeSelected($event)"
-    (contactLookupSelect)="contactLookupSelected($event)"
-    (createNewContactSelect)="createNewContactSelected()"
-  >
-  </app-contact-lookup>
+<div class="p-fluid">
+  <div [ngClass]="{ 'transaction-contact-invalid': errorMessageFormControl?.status === 'INVALID' }">
+    <app-contact-lookup
+      [contactTypeOptions]="contactTypeOptions"
+      (contactTypeSelect)="contactTypeSelected($event)"
+      (contactLookupSelect)="contactLookupSelected($event)"
+      (createNewContactSelect)="createNewContactSelected()"
+    >
+    </app-contact-lookup>
+  </div>
   <app-contact-dialog
     headerTitle="Create a new contact"
     [contactTypeOptions]="dialogContactTypeOptions"


### PR DESCRIPTION
#1332 

When opening the contact dialog from a transaction and clicking save with out entering any data, the contact lookup searchbox is no longer getting a red border.