### PR TITLE
Feature/1366 Remove itemize/unitemize options from Sch C & D

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -45,7 +45,8 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
         transaction.itemized === false &&
         this.reportIsEditable &&
         !transaction.parent_transaction &&
-        !transaction.parent_transaction_id,
+        !transaction.parent_transaction_id &&
+        !['C', 'D'].includes(transaction.transactionType.scheduleId),
       () => true
     ),
     new TableAction(
@@ -55,7 +56,8 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
         transaction.itemized === true &&
         this.reportIsEditable &&
         !transaction.parent_transaction &&
-        !transaction.parent_transaction_id,
+        !transaction.parent_transaction_id &&
+        !['C', 'D'].includes(transaction.transactionType.scheduleId),
       () => true
     ),
     new TableAction(

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -14,6 +14,7 @@ import { ScheduleBTransactionTypes } from 'app/shared/models/schb-transaction.mo
 import { ScheduleCTransactionTypes } from 'app/shared/models/schc-transaction.model';
 import { ScheduleDTransactionTypes } from 'app/shared/models/schd-transaction.model';
 import { ScheduleC1TransactionTypes } from 'app/shared/models/schc1-transaction.model';
+import { ScheduleIds } from 'app/shared/models/transaction.model';
 
 @Component({
   template: '',
@@ -46,7 +47,7 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
         this.reportIsEditable &&
         !transaction.parent_transaction &&
         !transaction.parent_transaction_id &&
-        !['C', 'D'].includes(transaction.transactionType.scheduleId),
+        ![ScheduleIds.C, ScheduleIds.D].includes(transaction.transactionType.scheduleId),
       () => true
     ),
     new TableAction(
@@ -57,7 +58,7 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
         this.reportIsEditable &&
         !transaction.parent_transaction &&
         !transaction.parent_transaction_id &&
-        !['C', 'D'].includes(transaction.transactionType.scheduleId),
+        ![ScheduleIds.C, ScheduleIds.D].includes(transaction.transactionType.scheduleId),
       () => true
     ),
     new TableAction(

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { take, takeUntil } from 'rxjs';
 import { F3xSummary } from 'app/shared/models/f3x-summary.model';
 import { TableAction, TableListBaseComponent } from 'app/shared/components/table-list-base/table-list-base.component';
-import { Transaction } from 'app/shared/models/transaction.model';
+import { ScheduleIds, Transaction } from 'app/shared/models/transaction.model';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { LabelList, LineIdentifierLabels } from 'app/shared/utils/label.utils';
 import { Store } from '@ngrx/store';
@@ -14,7 +14,6 @@ import { ScheduleBTransactionTypes } from 'app/shared/models/schb-transaction.mo
 import { ScheduleCTransactionTypes } from 'app/shared/models/schc-transaction.model';
 import { ScheduleDTransactionTypes } from 'app/shared/models/schd-transaction.model';
 import { ScheduleC1TransactionTypes } from 'app/shared/models/schc1-transaction.model';
-import { ScheduleIds } from 'app/shared/models/transaction.model';
 
 @Component({
   template: '',

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
@@ -12,12 +12,11 @@ import { SharedModule } from 'app/shared/shared.module';
 import { TransactionLoansAndDebtsComponent } from './transaction-loans-and-debts.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TransactionSchCService } from 'app/shared/services/transaction-schC.service';
-import { Transaction } from 'app/shared/models/transaction.model';
+import { Transaction, ScheduleIds } from 'app/shared/models/transaction.model';
 import { SchC1Transaction } from 'app/shared/models/schc1-transaction.model';
 import { ScheduleCTransactionTypes } from 'app/shared/models/schc-transaction.model';
 import { DropdownModule } from 'primeng/dropdown';
 import { ScheduleDTransactionTypes } from 'app/shared/models/schd-transaction.model';
-import { ScheduleIds } from 'app/shared/models/transaction.model';
 
 describe('TransactionReceiptsComponent', () => {
   let fixture: ComponentFixture<TransactionLoansAndDebtsComponent>;

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
@@ -17,6 +17,7 @@ import { SchC1Transaction } from 'app/shared/models/schc1-transaction.model';
 import { ScheduleCTransactionTypes } from 'app/shared/models/schc-transaction.model';
 import { DropdownModule } from 'primeng/dropdown';
 import { ScheduleDTransactionTypes } from 'app/shared/models/schd-transaction.model';
+import { ScheduleIds } from 'app/shared/models/transaction.model';
 
 describe('TransactionReceiptsComponent', () => {
   let fixture: ComponentFixture<TransactionLoansAndDebtsComponent>;
@@ -52,7 +53,7 @@ describe('TransactionReceiptsComponent', () => {
                 SchC1Transaction.fromJSON({
                   id: transactionId,
                   transaction_type_identifier: 'OFFSET_TO_OPERATING_EXPENDITURES',
-                  transactionType: { scheduleId: 'A ' },
+                  transactionType: { scheduleId: ScheduleIds.A },
                 })
               ),
             getTableData: () => of([]),

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
@@ -52,6 +52,7 @@ describe('TransactionReceiptsComponent', () => {
                 SchC1Transaction.fromJSON({
                   id: transactionId,
                   transaction_type_identifier: 'OFFSET_TO_OPERATING_EXPENDITURES',
+                  transactionType: { scheduleId: 'A ' },
                 })
               ),
             getTableData: () => of([]),
@@ -76,13 +77,21 @@ describe('TransactionReceiptsComponent', () => {
   it('should show the correct row actions', () => {
     expect(component.rowActions[0].isAvailable()).toEqual(true);
     expect(component.rowActions[1].isAvailable()).toEqual(false);
-    expect(component.rowActions[2].isAvailable({ itemized: false })).toEqual(false);
-    expect(component.rowActions[3].isAvailable({ itemized: true })).toEqual(false);
+    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'C' } })).toEqual(
+      false
+    );
+    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'C' } })).toEqual(
+      false
+    );
     component.reportIsEditable = true;
     expect(component.rowActions[0].isAvailable()).toEqual(false);
     expect(component.rowActions[1].isAvailable()).toEqual(true);
-    expect(component.rowActions[2].isAvailable({ itemized: false })).toEqual(true);
-    expect(component.rowActions[3].isAvailable({ itemized: true })).toEqual(true);
+    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'C' } })).toEqual(
+      false
+    );
+    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'C' } })).toEqual(
+      false
+    );
     expect(component.rowActions[0].isEnabled({})).toEqual(true);
     expect(component.rowActions[1].isEnabled({})).toEqual(true);
     expect(component.rowActions[2].isEnabled({})).toEqual(true);

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.spec.ts
@@ -74,30 +74,6 @@ describe('TransactionReceiptsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should show the correct row actions', () => {
-    expect(component.rowActions[0].isAvailable()).toEqual(true);
-    expect(component.rowActions[1].isAvailable()).toEqual(false);
-    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'C' } })).toEqual(
-      false
-    );
-    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'C' } })).toEqual(
-      false
-    );
-    component.reportIsEditable = true;
-    expect(component.rowActions[0].isAvailable()).toEqual(false);
-    expect(component.rowActions[1].isAvailable()).toEqual(true);
-    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'C' } })).toEqual(
-      false
-    );
-    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'C' } })).toEqual(
-      false
-    );
-    expect(component.rowActions[0].isEnabled({})).toEqual(true);
-    expect(component.rowActions[1].isEnabled({})).toEqual(true);
-    expect(component.rowActions[2].isEnabled({})).toEqual(true);
-    expect(component.rowActions[3].isEnabled({})).toEqual(true);
-  });
-
   it('test editItem', () => {
     const navigateSpy = spyOn(router, 'navigate');
     const testTransaction: Transaction = { id: 'testId' } as unknown as Transaction;

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
@@ -80,13 +80,19 @@ describe('TransactionReceiptsComponent', () => {
   it('should show the correct row actions', () => {
     expect(component.rowActions[0].isAvailable()).toEqual(true);
     expect(component.rowActions[1].isAvailable()).toEqual(false);
-    expect(component.rowActions[2].isAvailable({ itemized: false })).toEqual(false);
-    expect(component.rowActions[3].isAvailable({ itemized: true })).toEqual(false);
+    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'A' } })).toEqual(
+      false
+    );
+    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'A' } })).toEqual(
+      false
+    );
     component.reportIsEditable = true;
     expect(component.rowActions[0].isAvailable()).toEqual(false);
     expect(component.rowActions[1].isAvailable()).toEqual(true);
-    expect(component.rowActions[2].isAvailable({ itemized: false })).toEqual(true);
-    expect(component.rowActions[3].isAvailable({ itemized: true })).toEqual(true);
+    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'A' } })).toEqual(
+      true
+    );
+    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'A' } })).toEqual(true);
     expect(component.rowActions[0].isEnabled({})).toEqual(true);
     expect(component.rowActions[1].isEnabled({})).toEqual(true);
     expect(component.rowActions[2].isEnabled({})).toEqual(true);

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
@@ -13,7 +13,7 @@ import { SharedModule } from 'app/shared/shared.module';
 import { TransactionReceiptsComponent } from './transaction-receipts.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TransactionSchAService } from 'app/shared/services/transaction-schA.service';
-import { Transaction } from 'app/shared/models/transaction.model';
+import { ScheduleIds, Transaction } from 'app/shared/models/transaction.model';
 import { SchATransaction } from 'app/shared/models/scha-transaction.model';
 
 describe('TransactionReceiptsComponent', () => {
@@ -80,19 +80,21 @@ describe('TransactionReceiptsComponent', () => {
   it('should show the correct row actions', () => {
     expect(component.rowActions[0].isAvailable()).toEqual(true);
     expect(component.rowActions[1].isAvailable()).toEqual(false);
-    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'A' } })).toEqual(
-      false
-    );
-    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'A' } })).toEqual(
-      false
-    );
+    expect(
+      component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: ScheduleIds.A } })
+    ).toEqual(false);
+    expect(
+      component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: ScheduleIds.A } })
+    ).toEqual(false);
     component.reportIsEditable = true;
     expect(component.rowActions[0].isAvailable()).toEqual(false);
     expect(component.rowActions[1].isAvailable()).toEqual(true);
-    expect(component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: 'A' } })).toEqual(
-      true
-    );
-    expect(component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: 'A' } })).toEqual(true);
+    expect(
+      component.rowActions[2].isAvailable({ itemized: false, transactionType: { scheduleId: ScheduleIds.A } })
+    ).toEqual(true);
+    expect(
+      component.rowActions[3].isAvailable({ itemized: true, transactionType: { scheduleId: ScheduleIds.A } })
+    ).toEqual(true);
     expect(component.rowActions[0].isEnabled({})).toEqual(true);
     expect(component.rowActions[1].isEnabled({})).toEqual(true);
     expect(component.rowActions[2].isEnabled({})).toEqual(true);

--- a/front-end/src/app/shared/models/scha-transaction-type.model.ts
+++ b/front-end/src/app/shared/models/scha-transaction-type.model.ts
@@ -1,7 +1,8 @@
 import { TransactionType, TransactionTemplateMapType } from './transaction-type.model';
+import { ScheduleIds } from './transaction.model';
 
 export abstract class SchATransactionType extends TransactionType {
-  scheduleId = 'A';
+  scheduleId = ScheduleIds.A;
   apiEndpoint = '/transactions/schedule-a';
 
   //Labels

--- a/front-end/src/app/shared/models/schb-transaction-type.model.ts
+++ b/front-end/src/app/shared/models/schb-transaction-type.model.ts
@@ -1,7 +1,8 @@
 import { TransactionType, TransactionTemplateMapType } from './transaction-type.model';
+import { ScheduleIds } from './transaction.model';
 
 export abstract class SchBTransactionType extends TransactionType {
-  scheduleId = 'B';
+  scheduleId = ScheduleIds.B;
   apiEndpoint = '/transactions/schedule-b';
 
   // Labels

--- a/front-end/src/app/shared/models/schc-transaction-type.model.ts
+++ b/front-end/src/app/shared/models/schc-transaction-type.model.ts
@@ -1,9 +1,9 @@
 import { TransactionType, TransactionTemplateMapType } from './transaction-type.model';
-import { Transaction, isPulledForwardLoan } from './transaction.model';
+import { ScheduleIds, Transaction, isPulledForwardLoan } from './transaction.model';
 import { TransactionNavigationControls, SAVE_LIST_CONTROL } from './transaction-navigation-controls.model';
 
 export abstract class SchCTransactionType extends TransactionType {
-  scheduleId = 'C';
+  scheduleId = ScheduleIds.C;
   apiEndpoint = '/transactions/schedule-c';
 
   // Labels

--- a/front-end/src/app/shared/models/schc1-transaction-type.model.ts
+++ b/front-end/src/app/shared/models/schc1-transaction-type.model.ts
@@ -1,7 +1,8 @@
 import { TransactionType, TransactionTemplateMapType } from './transaction-type.model';
+import { ScheduleIds } from './transaction.model';
 
 export abstract class SchC1TransactionType extends TransactionType {
-  scheduleId = 'C1';
+  scheduleId = ScheduleIds.C1;
   apiEndpoint = '/transactions/schedule-c1';
 
   // Labels

--- a/front-end/src/app/shared/models/schc2-transaction-type.model.ts
+++ b/front-end/src/app/shared/models/schc2-transaction-type.model.ts
@@ -1,7 +1,8 @@
 import { TransactionType, TransactionTemplateMapType } from './transaction-type.model';
+import { ScheduleIds } from './transaction.model';
 
 export abstract class SchC2TransactionType extends TransactionType {
-  scheduleId = 'C2';
+  scheduleId = ScheduleIds.C2;
   apiEndpoint = '/transactions/schedule-c2';
   override amountInputHeader = 'Guaranteed financial information';
 

--- a/front-end/src/app/shared/models/schd-transaction-type.model.ts
+++ b/front-end/src/app/shared/models/schd-transaction-type.model.ts
@@ -1,7 +1,8 @@
 import { TransactionType, TransactionTemplateMapType } from './transaction-type.model';
+import { ScheduleIds } from './transaction.model';
 
 export abstract class SchDTransactionType extends TransactionType {
-  scheduleId = 'D';
+  scheduleId = ScheduleIds.D;
   apiEndpoint = '/transactions/schedule-d';
 
   // Labels

--- a/front-end/src/app/shared/models/transaction-type.model.ts
+++ b/front-end/src/app/shared/models/transaction-type.model.ts
@@ -12,14 +12,14 @@ import {
 } from '../utils/transaction-type-properties';
 import { ContactType, STANDARD_SINGLE_CONTACT } from './contact.model';
 import { TransactionNavigationControls } from './transaction-navigation-controls.model';
-import { Transaction, TransactionTypes } from './transaction.model';
+import { ScheduleIds, Transaction, TransactionTypes } from './transaction.model';
 
 /**
  * Class that defines the meta data associated with a transaction type.
  * Populated and used by the transaction resovler for use in the transaction components.
  */
 export abstract class TransactionType {
-  abstract scheduleId: string;
+  abstract scheduleId: ScheduleIds;
   abstract apiEndpoint: string; // Root URL to API endpoint for CRUDing transaction
   abstract formFields: string[];
   abstract contactTypeOptions?: ContactType[];

--- a/front-end/src/app/shared/models/transaction.model.ts
+++ b/front-end/src/app/shared/models/transaction.model.ts
@@ -177,7 +177,7 @@ export function isExistingTransaction(transaction?: Transaction): boolean {
   return !!transaction?.id;
 }
 export function isPulledForwardLoan(transaction?: Transaction): boolean {
-  return !!transaction?.loan_id && transaction.transactionType.scheduleId === 'C';
+  return !!transaction?.loan_id && transaction.transactionType.scheduleId === ScheduleIds.C;
 }
 
 export type ScheduleTransaction =
@@ -217,4 +217,14 @@ export enum AggregationGroups {
   OTHER_RECEIPTS = 'OTHER_RECEIPTS',
   RECOUNT_ACCOUNT = 'RECOUNT_ACCOUNT',
   GENERAL_DISBURSEMENT = 'GENERAL_DISBURSEMENT',
+}
+
+export enum ScheduleIds {
+  A = 'A',
+  B = 'B',
+  C = 'C',
+  C1 = 'C1',
+  C2 = 'C2',
+  D = 'D',
+  E = 'E',
 }

--- a/front-end/src/app/shared/utils/transaction-type.utils.ts
+++ b/front-end/src/app/shared/utils/transaction-type.utils.ts
@@ -4,7 +4,7 @@ import { SchCTransaction } from '../models/schc-transaction.model';
 import { SchC1Transaction } from '../models/schc1-transaction.model';
 import { SchC2Transaction } from '../models/schc2-transaction.model';
 import { SchDTransaction } from '../models/schd-transaction.model';
-import { ScheduleTransaction } from '../models/transaction.model';
+import { ScheduleIds, ScheduleTransaction } from '../models/transaction.model';
 
 // Schedule A /////////////////////////////////////////////////////
 import { TransactionType } from '../models/transaction-type.model';
@@ -405,12 +405,12 @@ export function getTransactionTypeClass(transactionTypeIdentifier: string): any 
 export function getFromJSON(json: any, depth = 2): ScheduleTransaction { // eslint-disable-line @typescript-eslint/no-explicit-any
   if (json.transaction_type_identifier) {
     const transactionType = TransactionTypeUtils.factory(json.transaction_type_identifier);
-    if (transactionType.scheduleId === 'A') return SchATransaction.fromJSON(json, depth);
-    if (transactionType.scheduleId === 'B') return SchBTransaction.fromJSON(json, depth);
-    if (transactionType.scheduleId === 'C') return SchCTransaction.fromJSON(json, depth);
-    if (transactionType.scheduleId === 'C1') return SchC1Transaction.fromJSON(json, depth);
-    if (transactionType.scheduleId === 'C2') return SchC2Transaction.fromJSON(json, depth);
-    if (transactionType.scheduleId === 'D') return SchDTransaction.fromJSON(json, depth);
+    if (transactionType.scheduleId === ScheduleIds.A) return SchATransaction.fromJSON(json, depth);
+    if (transactionType.scheduleId === ScheduleIds.B) return SchBTransaction.fromJSON(json, depth);
+    if (transactionType.scheduleId === ScheduleIds.C) return SchCTransaction.fromJSON(json, depth);
+    if (transactionType.scheduleId === ScheduleIds.C1) return SchC1Transaction.fromJSON(json, depth);
+    if (transactionType.scheduleId === ScheduleIds.C2) return SchC2Transaction.fromJSON(json, depth);
+    if (transactionType.scheduleId === ScheduleIds.D) return SchDTransaction.fromJSON(json, depth);
   }
   return SchATransaction.fromJSON(json, depth); // Until 404 resolved
   // throw new Error('Fecfile: Missing transaction type identifier when creating a transaction object from a JSON record');


### PR DESCRIPTION
#1366 
Remove the "itemize" and "unitemize" options from the action select on the Loans & Debts transaction table.