### PR TITLE
Bug/1395 Fixed bug in contact options for contact_2 lookup

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-input/transaction-input.component.html
+++ b/front-end/src/app/reports/transactions/transaction-input/transaction-input.component.html
@@ -178,6 +178,10 @@
       ></app-committee-input>
     </ng-container>
     <ng-container *ngIf="transaction?.transactionType?.hasCandidateInformation()">
+      <label for="contact_2"
+        >LOOKUP
+        <ng-container *ngIf="!transaction?.transactionType?.contact2IsRequired(form)">(OPTIONAL)</ng-container></label
+      >
       <app-transaction-contact-lookup
         contactProperty="contact_2"
         [transaction]="transaction"

--- a/front-end/src/app/shared/components/transaction-contact-lookup/transaction-contact-lookup.component.ts
+++ b/front-end/src/app/shared/components/transaction-contact-lookup/transaction-contact-lookup.component.ts
@@ -10,14 +10,14 @@ import { schema as contactIndividualSchema } from 'fecfile-validate/fecfile_vali
 import { schema as contactOrganizationSchema } from 'fecfile-validate/fecfile_validate_js/dist/Contact_Organization';
 import { SelectItem } from 'primeng/api';
 import { ContactDialogComponent } from '../contact-dialog/contact-dialog.component';
-import { Transaction, ScheduleTransaction } from 'app/shared/models/transaction.model';
+import { Transaction } from 'app/shared/models/transaction.model';
 
 @Component({
   selector: 'app-transaction-contact-lookup',
   templateUrl: './transaction-contact-lookup.component.html',
 })
 export class TransactionContactLookupComponent implements OnInit {
-  @Input() contactProperty?: string;
+  @Input() contactProperty = 'contact_1';
   @Input() transaction?: Transaction;
   @Input() form: FormGroup = new FormGroup({});
   @Input() formSubmitted = false;
@@ -55,7 +55,7 @@ export class TransactionContactLookupComponent implements OnInit {
     // Limit contact type options in contact lookup to one when editing a transaction
     if (this.transaction?.id) {
       this.contactTypeOptions = LabelUtils.getPrimeOptions(ContactTypeLabels, [
-        (this.transaction as ScheduleTransaction).entity_type as ContactTypes,
+        (this.transaction[this.contactProperty as keyof Transaction] as Contact).type as ContactTypes,
       ]);
     }
 

--- a/front-end/src/app/shared/utils/transaction-type-properties.ts
+++ b/front-end/src/app/shared/utils/transaction-type-properties.ts
@@ -56,9 +56,6 @@ export const CANDIDATE_FIELDS: string[] = [
   'candidate_middle_name',
   'candidate_prefix',
   'candidate_suffix',
-  'candidate_office',
-  'candidate_state',
-  'candidate_district',
 ];
 export const CANDIDATE_OFFICE_FIELDS: string[] = ['candidate_office', 'candidate_state', 'candidate_district'];
 


### PR DESCRIPTION
#1395 

Fixes bugs:

1. Label for contact_2 must be LOOKUP with (OPTIONAL) depending on the transaction
2. The contact type lookup select box for contact_2 was defaulting to wrong contact type when editing a transaction
3. The candidate office form inputs should not be displayed for 100% Federal Election Activity Payment and Void of 100% Federal Election Activity Payment transaction types