### PR TITLE
Fix race condition in Sch D e2e test

### DIFF
--- a/front-end/cypress/e2e/reports-f3x-transactions.cy.ts
+++ b/front-end/cypress/e2e/reports-f3x-transactions.cy.ts
@@ -175,7 +175,7 @@ describe('Transactions', () => {
     cy.contains('Transactions in this report').should('exist');
     PageUtils.clickLink('Partnership Receipt');
     PageUtils.dropdownSetValue('[data-test="navigation-control-dropdown"]', 'Partnership Attribution');
-    cy.contains('Partnership Attribution').wait(500);
+    cy.get('h1').contains('Partnership Attribution').should('exist');
     cy.get('[role="searchbox"]').type(defaultContactFormData['last_name'].slice(0, 1));
     cy.contains(defaultContactFormData['last_name']).should('exist');
     cy.contains(defaultContactFormData['last_name']).click();


### PR DESCRIPTION
We were getting periodic fails from the nightly e2e tests for the SchD test. It was being caused by an element selector that was finding the wrong element on the page being viewed prior to the one being tested. The selector was improved to be more specific.