### PR TITLE
Increase e2e contact search to 3 letters

### DIFF
--- a/front-end/cypress/e2e/pages/pageUtils.ts
+++ b/front-end/cypress/e2e/pages/pageUtils.ts
@@ -149,7 +149,7 @@ export class PageUtils {
   }
 
   static searchBoxInput(input: string) {
-    cy.get('[role="searchbox"]').type(input.slice(0, 1));
+    cy.get('[role="searchbox"]').type(input.slice(0, 3));
     cy.contains(input).should('exist');
     cy.contains(input).click({ force: true });
   }


### PR DESCRIPTION
The e2e tests on CircleCI are not able to find an existing contact in the search box. This increases the number of characters in the search box to 3 so that it triggers the lookup.