### PR TITLE
Patch/1118 Fix display of election office label for contact lookups

### DIFF
--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.html
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.html
@@ -1,4 +1,4 @@
-<div class="grid" *ngIf="candidateOffice">
+<div class="grid" *ngIf="candidateOffice && contactType === contactTypes.CANDIDATE">
   <em>{{ candidateOfficeLabel }} candidates only</em>
 </div>
 <div class="grid contact-lookup-container">

--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.ts
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.ts
@@ -39,6 +39,7 @@ export class ContactLookupComponent extends DestroyerComponent implements OnInit
   @Output() createNewContactSelect = new EventEmitter<void>();
 
   contactType = ContactTypes.INDIVIDUAL;
+  contactTypes = ContactTypes;
   contactTypeReadOnly = false;
   contactLookupList: SelectItemGroup[] = [];
   contactTypeLabels: LabelList = ContactTypeLabels;


### PR DESCRIPTION
The "Presidential candidates only" sub label was showing up on contact lookups for orgs and individuals. This patch fixes that.