### PR TITLE
Patch/1522 Remove css class that is hiding the summary page data

### DIFF
--- a/front-end/src/app/reports/f3x/report-detailed-summary/report-detailed-summary.component.html
+++ b/front-end/src/app/reports/f3x/report-detailed-summary/report-detailed-summary.component.html
@@ -15,7 +15,7 @@
     />
   </div>
   <div *ngIf="calculationFinished$ | async">
-    <table class="collapse">
+    <table>
       <caption>
         Receipts
       </caption>
@@ -191,7 +191,7 @@
 
     <div class="table-spacer"></div>
 
-    <table class="collapse">
+    <table>
       <caption>
         Disbursements
       </caption>
@@ -411,7 +411,7 @@
 
     <div class="table-spacer"></div>
 
-    <table class="collapse">
+    <table>
       <caption>
         Net contributions/operating expenditures
       </caption>

--- a/front-end/src/app/reports/f3x/report-summary/report-summary.component.html
+++ b/front-end/src/app/reports/f3x/report-summary/report-summary.component.html
@@ -16,7 +16,7 @@
     />
   </div>
   <div *ngIf="calculationFinished$ | async">
-    <table class="collapse">
+    <table>
       <caption>
         Report Summary
       </caption>


### PR DESCRIPTION
A recent style sheet change caused a "collapse" class to hide the detail summary page table and the summary page table. This patch removes the unneeded class so the tables show again.