### PR TITLE
Feature/1524 - Add Caption to table for screen readers

### DIFF
--- a/front-end/src/app/reports/report-list/report-list.component.ts
+++ b/front-end/src/app/reports/report-list/report-list.component.ts
@@ -50,6 +50,7 @@ export class ReportListComponent extends TableListBaseComponent<Report> implemen
     public router: Router
   ) {
     super(messageService, confirmationService, elementRef);
+    this.caption = "Data table of all reports created by the committee broken down by form type, report type, coverage date, status, version, Date filled, and actions.";
   }
 
   override ngOnInit() {

--- a/front-end/src/app/shared/components/table-list-base/table-list-base.component.ts
+++ b/front-end/src/app/shared/components/table-list-base/table-list-base.component.ts
@@ -22,6 +22,8 @@ export abstract class TableListBaseComponent<T> extends DestroyerComponent imple
   isNewItem = true;
   protected itemService!: TableListService<T>;
 
+  protected caption?: string;
+
   constructor(
     protected messageService: MessageService,
     protected confirmationService: ConfirmationService,
@@ -45,6 +47,16 @@ export abstract class TableListBaseComponent<T> extends DestroyerComponent imple
     paginatorNextButton?.setAttribute('title', 'paginator go to next table page');
     const paginatorLastButton = (<HTMLElement>this.elementRef.nativeElement).querySelector('.p-paginator-last');
     paginatorLastButton?.setAttribute('title', 'paginator go to last table page');
+
+    if (this.caption) {
+      const table = (<HTMLElement>this.elementRef.nativeElement).querySelector('table');
+      if (table) {
+        const captionElem = table.createCaption();
+        captionElem.innerHTML = this.caption;
+        (<HTMLElement>captionElem).className = 'sr-only';
+
+      }
+    }
   }
 
   /**

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -399,3 +399,15 @@ label.disabled {
   border-color: #e8e8e8;
   color: #212121;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
So, this is where PrimeNG caused a bit of an issue. I love the PrimeNG table, it is incredibly powerful. However, it has a major problem for 508 compliance in that it does not allow you to put a caption for screen readers. Confusingly, they have a caption template but it doesn't actually use the caption html tag, which is what is required for 508 compliance.

I rebuilt this table using pure html with as few changes as possible. Visually it should appear exactly the same. I did have to add some logic for handling changing the page and sorting, but thankfully those were just hitting a back end call, so I didn't have to completely design a full front end sorting algorithm, though I did notice the sorting isn't actually working for most of the fields. 