### PR TITLE
Fix bug in IsAtAmountLimit function

### DIFF
--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
@@ -21,14 +21,9 @@ describe('ReattRedesUtils', () => {
 
     txn.reatt_redes_total = 100;
     txn.contribution_amount = 100;
+    txn.reattribution_redesignation_tag = ReattRedesTypes.REATTRIBUTED;
     result = ReattRedesUtils.isAtAmountLimit(txn);
     expect(result).toBeTrue();
-
-    txn.reatt_redes_total = 200;
-    txn.contribution_amount = 100;
-    expect(() => ReattRedesUtils.isAtAmountLimit(txn)).toThrow(
-      new Error('Fecfile: Transaction (AC9877E1) has more reattributions or redesignations that its amount allows.')
-    );
   });
 
   it('should overlay forms correctly', () => {

--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
@@ -23,21 +23,15 @@ export class ReattRedesUtils {
 
   public static isAtAmountLimit(transaction: Transaction | undefined): boolean {
     const txn = transaction as SchATransaction | SchBTransaction;
-    if (txn.reatt_redes_total !== undefined) {
+    if (
+      ReattRedesUtils.isReattRedes(txn, [ReattRedesTypes.REATTRIBUTED, ReattRedesTypes.REDESIGNATED]) &&
+      txn.reatt_redes_total !== undefined
+    ) {
       if (
-        +txn.reatt_redes_total ===
+        +txn.reatt_redes_total >=
         +(txn[txn.transactionType.templateMap.amount as keyof (SchATransaction | SchBTransaction)] ?? 0)
       ) {
         return true;
-      }
-      if (
-        txn.reatt_redes_total &&
-        +txn.reatt_redes_total >
-          +(txn[txn.transactionType.templateMap.amount as keyof (SchATransaction | SchBTransaction)] ?? 0)
-      ) {
-        throw new Error(
-          `Fecfile: Transaction (${txn.transaction_id}) has more reattributions or redesignations that its amount allows.`
-        );
       }
     }
     return false;


### PR DESCRIPTION
There was a bug in the isAtAmountLimit function for reattributions where the limit sum was being tested for transactions that were not reattributions.