### PR TITLE
1339 - Move report submit alert text into models

### DIFF
--- a/front-end/src/app/reports/submission-workflow/submit-report-step2.component.ts
+++ b/front-end/src/app/reports/submission-workflow/submit-report-step2.component.ts
@@ -101,8 +101,7 @@ export class SubmitReportStep2Component extends DestroyerComponent implements On
     }
 
     this.confirmationService.confirm({
-      message:
-        'Are you sure you want to submit this form electronically? Please note that you cannot undo this action. Any changes needed will need to be filed as an amended report.',
+      message: this.report?.submitAlertText,
       header: 'Are you sure?',
       icon: 'pi pi-exclamation-triangle',
       accept: () => {

--- a/front-end/src/app/shared/models/form-99.model.ts
+++ b/front-end/src/app/shared/models/form-99.model.ts
@@ -17,6 +17,8 @@ export class Form99 extends Report {
   override schema = f99Schema;
   override report_type = ReportTypes.F99;
   override form_type = F99FormTypes.F99;
+  override submitAlertText =
+    'Are you sure you want to submit this form electronically? Please note that you cannot undo this action.';
 
   get formLabel() {
     return 'FORM 99';

--- a/front-end/src/app/shared/models/report.model.ts
+++ b/front-end/src/app/shared/models/report.model.ts
@@ -14,6 +14,9 @@ export abstract class Report extends BaseModel {
   abstract get formSubLabel(): string;
   abstract get versionLabel(): string;
   hasChangeOfAddress = false;
+  submitAlertText =
+    'Are you sure you want to submit this form electronically? Please note that you cannot undo this action. Any changes needed will need to be filed as an amended report.';
+
   get reportCode(): F3xReportCodes | undefined {
     return;
   }


### PR DESCRIPTION
This is a patch to update the text showing in the pop-up when a user submits a F99 report. The text is different from the other report types.