### PR TITLE
feature/1581 fix login.gov logout

### DIFF
--- a/front-end/src/app/shared/services/login.service.ts
+++ b/front-end/src/app/shared/services/login.service.ts
@@ -57,6 +57,7 @@ export class LoginService {
         window.location.href = environment.loginDotGovLogoutUrl;
       }
     }
+    return false;
   }
 
   public clearUserLoggedInCookies() {


### PR DESCRIPTION
According to [this answer](https://stackoverflow.com/questions/18300674/window-location-href-not-working#answer-18300733) we need to return false after setting window.location.href if using a form.  I can't figure out exactly what caused it to stop working but this does fix the issue.