### PR TITLE
Feature/1454 2 - Fixed issue with memo text of pull forward changing the memo text of the original.

### DIFF
--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
@@ -5,6 +5,7 @@ import { getTestIndividualReceipt, testScheduleATransaction, testScheduleBTransa
 import { RedesignatedUtils } from './redesignated.utils';
 import _ from 'lodash';
 import { SchBTransaction } from '../../models/schb-transaction.model';
+import { MemoText } from '../../models/memo-text.model';
 
 describe('ReattRedesUtils', () => {
   describe('isReattRedes', () => {
@@ -171,6 +172,15 @@ describe('ReattRedesUtils', () => {
     it('should clone ', () => {
       const cloneSpy = spyOn(_, 'cloneDeep').and.callThrough();
       if (!payload.reatt_redes) throw new Error('Bad test setup');
+      payload.reatt_redes.memo_text_id = 'TEST';
+      const memo = new MemoText();
+      memo.report_id = 'ORIGINAL';
+      memo.text_prefix = 'PREFIX';
+      memo.text4000 = 'MEMO TEXT';
+      memo.rec_type = 'TEXT';
+      memo.transaction_id_number = payload.reatt_redes.id;
+      memo.transaction_uuid = 'UUID';
+      payload.reatt_redes.memo_text = memo;
       payload.reatt_redes = RedesignatedUtils.overlayTransactionProperties(payload.reatt_redes as SchBTransaction);
       const cloned = ReattRedesUtils.getPayloads(payload, true);
       expect(cloneSpy).toHaveBeenCalled();
@@ -179,6 +189,16 @@ describe('ReattRedesUtils', () => {
       expect(cloned[0].id).toBeFalsy();
       expect(cloned[0].reattribution_redesignation_tag).toBe(ReattRedesTypes.REDESIGNATED);
       expect(cloned[0].force_unaggregated).toBeTrue();
+
+      // Test memo text
+      expect(cloned[0].memo_text_id).toBeFalsy();
+      expect(cloned[0].memo_text).toBeTruthy();
+      if (cloned[0].memo_text) {
+        expect(cloned[0].memo_text.id).toBeFalsy();
+        expect(cloned[0].memo_text?.transaction_uuid).toBeFalsy();
+        expect(cloned[0].memo_text?.transaction_id_number).toBeFalsy();
+        expect(cloned[0].memo_text?.report_id).toBe(payload.report_id);
+      }
     });
   });
 });

--- a/front-end/src/app/shared/utils/reatt-redes/reattributed.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reattributed.utils.spec.ts
@@ -1,7 +1,6 @@
 import { SchATransaction } from '../../models/scha-transaction.model';
 import { testScheduleATransaction } from '../unit-test.utils';
 import { ReattributedUtils } from './reattributed.utils';
-import _ from 'lodash';
 import { ReattRedesTypes } from './reatt-redes.utils';
 
 describe('Reattributed Utils', () => {
@@ -14,30 +13,6 @@ describe('Reattributed Utils', () => {
 
     payload.reatt_redes = SchATransaction.fromJSON({
       ...testScheduleATransaction,
-    });
-  });
-  describe('getPayload', () => {
-    it('should throw error when originating missing transaction type', () => {
-      if (!payload.reatt_redes) throw new Error('Bad test setup');
-      payload.reatt_redes.transaction_type_identifier = undefined;
-      expect(function () {
-        ReattributedUtils.getPayload(payload);
-      }).toThrow(Error('Fecfile online: originating reattribution transaction type not found.'));
-    });
-
-    it('should clone to make reattributed', () => {
-      const cloneSpy = spyOn(_, 'cloneDeep').and.callThrough();
-      if (!payload.reatt_redes) throw new Error('Bad test setup');
-      payload.reatt_redes = ReattributedUtils.overlayTransactionProperties(payload.reatt_redes as SchATransaction);
-      if (!payload.reatt_redes || !(payload.reatt_redes instanceof SchATransaction)) throw new Error('Bad test setup');
-      expect(payload.reatt_redes.reattribution_redesignation_tag).toBe(ReattRedesTypes.REATTRIBUTED);
-      const reattributed = ReattributedUtils.getPayload(payload);
-      expect(cloneSpy).toHaveBeenCalledWith(payload.reatt_redes);
-      expect(reattributed.report_id).toEqual(payload.report_id);
-      expect(reattributed.report).toBeFalsy();
-      expect(reattributed.id).toBeFalsy();
-      expect(reattributed.reattribution_redesignation_tag).toBe(ReattRedesTypes.REATTRIBUTED);
-      expect(reattributed.force_unaggregated).toBeTrue();
     });
   });
 

--- a/front-end/src/app/shared/utils/reatt-redes/reattributed.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reattributed.utils.ts
@@ -1,30 +1,14 @@
-import { ReattRedesTypes } from './reatt-redes.utils';
+import { ReattRedesTypes, ReattRedesUtils } from './reatt-redes.utils';
 import { SchATransaction } from '../../models/scha-transaction.model';
-import { cloneDeep } from 'lodash';
-import { MemoText } from '../../models/memo-text.model';
 import { getReportCodeLabel } from '../report-code.utils';
 import { Form3X } from '../../models/form-3x.model';
 
 export class ReattributedUtils {
   public static overlayTransactionProperties(transaction: SchATransaction, activeReportId?: string): SchATransaction {
-    if (!transaction.report) throw new Error('Transaction missing report');
-
     if (!transaction.reattribution_redesignation_tag) {
       if (transaction.contribution_purpose_descrip) {
         const prefix = `[Original purpose description: ${transaction.contribution_purpose_descrip}] `;
-        if (transaction.memo_text) {
-          if (!transaction.memo_text.text_prefix) {
-            transaction.memo_text.text_prefix = prefix;
-            transaction.memo_text.text4000 = prefix + transaction?.memo_text?.text4000;
-          }
-        } else {
-          transaction.memo_text = MemoText.fromJSON({
-            rec_type: 'TEXT',
-            report_id: transaction?.report_id,
-            text_prefix: prefix,
-            text4000: prefix,
-          });
-        }
+        ReattRedesUtils.updateMemo(transaction, prefix);
       }
       if (transaction.report_id === activeReportId) {
         transaction.contribution_purpose_descrip = 'See reattribution below.';
@@ -44,22 +28,5 @@ export class ReattributedUtils {
     );
 
     return transaction;
-  }
-
-  static getPayload(payload: SchATransaction): SchATransaction {
-    if (!payload.reatt_redes?.transaction_type_identifier) {
-      throw Error('Fecfile online: originating reattribution transaction type not found.');
-    }
-    const reattributed = cloneDeep(payload.reatt_redes) as SchATransaction;
-    reattributed.reatt_redes = payload.reatt_redes;
-    reattributed.reatt_redes_id = payload.reatt_redes.id;
-    reattributed.report_id = payload.report_id;
-    reattributed.id = undefined;
-    reattributed.report = undefined;
-    reattributed.memo_code = true;
-    reattributed.force_unaggregated = true;
-    reattributed.children = []; // Children of original transaction do not copy over.
-
-    return reattributed;
   }
 }

--- a/front-end/src/app/shared/utils/reatt-redes/redesignated.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/redesignated.utils.spec.ts
@@ -1,7 +1,6 @@
 import { SchBTransaction } from '../../models/schb-transaction.model';
 import { RedesignatedUtils } from './redesignated.utils';
 import { ReattRedesTypes } from './reatt-redes.utils';
-import _ from 'lodash';
 import { testScheduleBTransaction } from '../unit-test.utils';
 import { F3xReportCodes } from '../report-code.utils';
 
@@ -72,29 +71,6 @@ describe('Redesignated Utils', () => {
       payload = RedesignatedUtils.overlayTransactionProperties(payload, '1');
       expect(payload.expenditure_purpose_descrip).toEqual('See redesignation below.');
       expect(payload.reattribution_redesignation_tag).toEqual(ReattRedesTypes.REDESIGNATED);
-    });
-  });
-
-  describe('getPayload', () => {
-    it('should throw error when originating missing transaction type', () => {
-      if (!payload.reatt_redes) throw new Error('Bad test setup');
-      payload.reatt_redes.transaction_type_identifier = undefined;
-      expect(function () {
-        RedesignatedUtils.getPayload(payload);
-      }).toThrow(Error('Fecfile online: originating redesignation transaction type not found.'));
-    });
-
-    it('should clone to make reattributed', () => {
-      const cloneSpy = spyOn(_, 'cloneDeep').and.callThrough();
-      if (!payload.reatt_redes) throw new Error('Bad test setup');
-      payload.reatt_redes = RedesignatedUtils.overlayTransactionProperties(payload.reatt_redes as SchBTransaction);
-      const redesignated = RedesignatedUtils.getPayload(payload);
-      expect(cloneSpy).toHaveBeenCalledWith(payload.reatt_redes);
-      expect(redesignated.report_id).toEqual(payload.report_id);
-      expect(redesignated.report).toBeFalsy();
-      expect(redesignated.id).toBeFalsy();
-      expect(redesignated.reattribution_redesignation_tag).toBe(ReattRedesTypes.REDESIGNATED);
-      expect(redesignated.force_unaggregated).toBeTrue();
     });
   });
 });

--- a/front-end/src/app/shared/utils/reatt-redes/redesignated.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/redesignated.utils.spec.ts
@@ -1,6 +1,6 @@
 import { SchBTransaction } from '../../models/schb-transaction.model';
 import { RedesignatedUtils } from './redesignated.utils';
-import { ReattRedesTypes } from './reatt-redes.utils';
+import { ReattRedesTypes, ReattRedesUtils } from './reatt-redes.utils';
 import { testScheduleBTransaction } from '../unit-test.utils';
 import { F3xReportCodes } from '../report-code.utils';
 
@@ -71,6 +71,24 @@ describe('Redesignated Utils', () => {
       payload = RedesignatedUtils.overlayTransactionProperties(payload, '1');
       expect(payload.expenditure_purpose_descrip).toEqual('See redesignation below.');
       expect(payload.reattribution_redesignation_tag).toEqual(ReattRedesTypes.REDESIGNATED);
+    });
+
+    it('should update the memo', () => {
+      const updateMemoSpy = spyOn(ReattRedesUtils, 'updateMemo').and.callThrough();
+      data = {
+        id: '999',
+        form_type: 'SA11Ai',
+        payee_organization_name: 'foo',
+        expenditure_date: undefined,
+        fields_to_validate: ['abc', 'expenditure_purpose_descrip'],
+        report_id: '1',
+        expenditure_purpose_descrip: 'PURPOSE',
+        text4000: 'MEMO',
+      };
+      payload = SchBTransaction.fromJSON(data);
+      payload = RedesignatedUtils.overlayTransactionProperties(payload, '1');
+      expect(payload.memo_text).toBeTruthy();
+      expect(updateMemoSpy).toHaveBeenCalled();
     });
   });
 });

--- a/front-end/src/app/shared/utils/reatt-redes/redesignated.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/redesignated.utils.ts
@@ -1,29 +1,13 @@
-import { ReattRedesTypes } from './reatt-redes.utils';
+import { ReattRedesTypes, ReattRedesUtils } from './reatt-redes.utils';
 import { SchBTransaction } from '../../models/schb-transaction.model';
-import { cloneDeep } from 'lodash';
-import { MemoText } from '../../models/memo-text.model';
 import { getReportCodeLabel } from '../report-code.utils';
 
 export class RedesignatedUtils {
   public static overlayTransactionProperties(transaction: SchBTransaction, activeReportId?: string): SchBTransaction {
-    // if (!transaction.report) throw new Error('Transaction missing report');
-
     if (!transaction.reattribution_redesignation_tag) {
       if (transaction.expenditure_purpose_descrip) {
         const prefix = `[Original purpose description: ${transaction.expenditure_purpose_descrip}] `;
-        if (transaction.memo_text) {
-          if (!transaction.memo_text.text_prefix) {
-            transaction.memo_text.text_prefix = prefix;
-            transaction.memo_text.text4000 = prefix + transaction?.memo_text?.text4000;
-          }
-        } else {
-          transaction.memo_text = MemoText.fromJSON({
-            rec_type: 'TEXT',
-            report_id: transaction?.report_id,
-            text_prefix: prefix,
-            text4000: prefix,
-          });
-        }
+        ReattRedesUtils.updateMemo(transaction, prefix);
       }
       if (transaction.report_id === activeReportId) {
         transaction.expenditure_purpose_descrip = 'See redesignation below.';
@@ -43,22 +27,5 @@ export class RedesignatedUtils {
     );
 
     return transaction;
-  }
-
-  static getPayload(payload: SchBTransaction): SchBTransaction {
-    if (!payload.reatt_redes?.transaction_type_identifier) {
-      throw Error('Fecfile online: originating redesignation transaction type not found.');
-    }
-    const redesignated = cloneDeep(payload.reatt_redes) as SchBTransaction;
-    redesignated.report_id = payload.report_id;
-    redesignated.reatt_redes = payload.reatt_redes;
-    redesignated.reatt_redes_id = payload.reatt_redes.id;
-    redesignated.id = undefined;
-    redesignated.report = undefined;
-    redesignated.memo_code = true;
-    redesignated.force_unaggregated = true;
-    redesignated.children = []; // Children of original transaction do not copy over.
-
-    return redesignated;
   }
 }


### PR DESCRIPTION
The issue was that memo_text was it's own table, and I had not cleared the relationship, so it was using the same memo code id for both transactions.