### PR TITLE
Solves stale committee data

### DIFF
--- a/front-end/src/app/login/login/login.component.ts
+++ b/front-end/src/app/login/login/login.component.ts
@@ -3,6 +3,8 @@ import { environment } from '../../../environments/environment';
 import { LoginService } from '../../shared/services/login.service';
 import { Store } from '@ngrx/store';
 import { userLoggedOutAction } from 'app/store/login.actions';
+import { setCommitteeAccountDetailsAction } from 'app/store/committee-account.actions';
+import { CommitteeAccount } from 'app/shared/models/committee-account.model';
 
 @Component({
   selector: 'app-login',
@@ -13,11 +15,15 @@ export class LoginComponent implements OnInit {
   public loginDotGovAuthUrl: string | undefined;
   public localLoginAvailable = false;
 
-  constructor(private loginService: LoginService, private store: Store) {}
+  constructor(
+    private loginService: LoginService,
+    private store: Store,
+  ) {}
 
   ngOnInit() {
     localStorage.clear();
     this.loginService.clearUserLoggedInCookies();
+    this.store.dispatch(setCommitteeAccountDetailsAction({ payload: new CommitteeAccount() }));
     this.store.dispatch(userLoggedOutAction());
     this.loginDotGovAuthUrl = environment.loginDotGovAuthUrl;
     this.checkLocalLoginAvailability();


### PR DESCRIPTION
Tested this by:
 logging in before change -> selecting committee -> delete session cookie -> navigate to reports and get redirected to login -> login -> not asked to select committee (because account data is stale) -> got to reports page -> get 500 because session has no active commmittee

Tests fix by:
logging in after change -> select committee -> delete session cookeie -> navigate to reports and get redirected to login -> login -> asked to select committee -> got to reports page -> get reports