### PR TITLE
1636 - Update e2e tests to better handle dropdowns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ workflows:
           requires:
             - test
             - dependency-check
-            # - e2e-test -- temporarily turn off until dropdown issue fixed
+            - e2e-test
           filters:
             branches:
               only: /develop|release\/sprint-\d+|main/

--- a/front-end/cypress/e2e/F3X/f3x-setup.ts
+++ b/front-end/cypress/e2e/F3X/f3x-setup.ts
@@ -1,11 +1,11 @@
 import {
   defaultFormData as reportFormData,
   defaultFormData as defaultReportFormData,
-  F3xCreateReportFormData
-} from "../models/ReportFormModel";
-import { ContactListPage } from "../pages/contactListPage";
-import { ReportListPage } from "../pages/reportListPage";
-import { currentYear } from "../pages/pageUtils";
+  F3xCreateReportFormData,
+} from '../models/ReportFormModel';
+import { ContactListPage } from '../pages/contactListPage';
+import { ReportListPage } from '../pages/reportListPage';
+import { currentYear } from '../pages/pageUtils';
 
 export interface Setup {
   organization?: boolean;
@@ -22,7 +22,6 @@ export function F3XSetup(setup: Setup = {}) {
   if (setup.committee) ContactListPage.createCommittee();
   ReportListPage.createF3X(setup.report ?? defaultReportFormData);
 }
-
 
 export const reportFormDataApril: F3xCreateReportFormData = {
   ...reportFormData,

--- a/front-end/cypress/e2e/F3X/reattributions.cy.ts
+++ b/front-end/cypress/e2e/F3X/reattributions.cy.ts
@@ -88,7 +88,8 @@ describe('Reattributions', () => {
     Reattribute();
   });
 
-  it('should test reattributing a Schedule A in a submitted report', () => {
+  // Test disabled until a mock is set up for submitting a report.
+  xit('should test reattributing a Schedule A in a submitted report', () => {
     // Create an individual contact to be used with contact lookup
     ContactListPage.createIndividual(assignee);
     CreateReceipt();

--- a/front-end/cypress/e2e/F3X/reattributions.cy.ts
+++ b/front-end/cypress/e2e/F3X/reattributions.cy.ts
@@ -1,5 +1,5 @@
 import { ContactListPage } from '../pages/contactListPage';
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
 import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
@@ -46,7 +46,7 @@ function CreateReceipt() {
   F3XSetup({ individual: true, candidate: true, report: reportFormDataApril });
   StartTransaction.Receipts().Individual().IndividualReceipt();
 
-  cy.get('[role="searchbox"]').type(individualContactFormData.last_name.slice(0, 1));
+  cy.get('[id="searchBox"]').type(individualContactFormData.last_name.slice(0, 1));
   cy.contains(individualContactFormData.last_name).should('exist');
   cy.contains(individualContactFormData.last_name).click();
   TransactionDetailPage.enterScheduleFormData(new ScheduleFormData(receiptData));
@@ -66,7 +66,7 @@ function Reattribute(old = false) {
   }
   cy.wait(500);
 
-  cy.get('[role="searchbox"]').type(assignee.last_name.slice(0, 1));
+  cy.get('[id="searchBox"]').type(assignee.last_name.slice(0, 1));
   cy.contains(assignee.last_name).should('exist');
   cy.contains(assignee.last_name).click();
   TransactionDetailPage.enterScheduleFormData(new ScheduleFormData(reattributeData));
@@ -78,9 +78,7 @@ function Reattribute(old = false) {
 
 describe('Reattributions', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
+    Initialize();
   });
 
   it('should test reattributing a Schedule A in the current report', () => {

--- a/front-end/cypress/e2e/F3X/redesignations.cy.ts
+++ b/front-end/cypress/e2e/F3X/redesignations.cy.ts
@@ -1,5 +1,4 @@
-import { ContactListPage } from '../pages/contactListPage';
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { PageUtils } from '../pages/pageUtils';
 import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
@@ -35,7 +34,7 @@ function CreateContribution() {
 
   StartTransaction.Disbursements().Contributions().ToCandidate();
 
-  cy.get('[role="searchbox"]').type(committeeFormData.name.slice(0, 1));
+  cy.get('[id="searchBox"]').type(committeeFormData.name.slice(0, 1));
   cy.contains(committeeFormData.name).should('exist');
   cy.contains(committeeFormData.name).click();
 
@@ -65,9 +64,7 @@ function Redesignate(old = false) {
 
 describe('Redesignations', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
+    Initialize();
   });
 
   it('should test redesignating a Schedule E contribution in the current report', () => {

--- a/front-end/cypress/e2e/F3X/redesignations.cy.ts
+++ b/front-end/cypress/e2e/F3X/redesignations.cy.ts
@@ -73,7 +73,8 @@ describe('Redesignations', () => {
     Redesignate();
   });
 
-  it('should test redesignating a Schedule E contribution from a submitted report', () => {
+  // Test disabled until a mock is set up for submitting a report.
+  xit('should test redesignating a Schedule E contribution from a submitted report', () => {
     // Create an individual contact to be used with contact lookup
     CreateContribution();
     ReportListPage.createF3X(reportFormDataJuly);

--- a/front-end/cypress/e2e/F3X/reports-f3x-amendments.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x-amendments.cy.ts
@@ -2,16 +2,13 @@ import { defaultFormData as contactFormData } from '../models/ContactFormModel';
 import { defaultFormData as reportFormData } from '../models/ReportFormModel';
 import { ContactListPage } from '../pages/contactListPage';
 import { F3xCreateReportPage } from '../pages/f3xCreateReportPage';
-import { LoginPage } from '../pages/loginPage';
 import { PageUtils } from '../pages/pageUtils';
 import { ReportListPage } from '../pages/reportListPage';
+import { Initialize } from '../pages/loginPage';
 
 describe('Amendments', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
-    ReportListPage.goToPage();
+    Initialize();
   });
 
   xit('should test Create an amendment', () => {

--- a/front-end/cypress/e2e/F3X/reports-f3x-debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x-debts.cy.ts
@@ -1,31 +1,23 @@
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { PageUtils } from '../pages/pageUtils';
-import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
-import { ContactListPage } from '../pages/contactListPage';
 import { defaultDebtFormData as debtFormData } from '../models/TransactionFormModel';
 import { committeeFormData } from '../models/ContactFormModel';
-import { F3XSetup } from "./f3x-setup";
-import { StartTransaction } from "./start-transaction/start-transaction";
-
+import { F3XSetup } from './f3x-setup';
+import { StartTransaction } from './start-transaction/start-transaction';
 
 describe('Debts', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
-    ContactListPage.goToPage();
-    ReportListPage.goToPage();
+    Initialize();
   });
 
   it('should test Debt Owed By Committee loan', () => {
-    F3XSetup({committee: true});
+    F3XSetup({ committee: true });
     StartTransaction.Debts().ByCommittee();
 
     PageUtils.urlCheck('DEBT_OWED_BY_COMMITTEE');
     PageUtils.containedOnPage('Debt Owed By Committee');
-    cy.get('#entity_type_dropdown').type(committeeFormData.contact_type);
-
+    PageUtils.dropdownSetValue('#entity_type_dropdown', committeeFormData.contact_type, '');
     PageUtils.searchBoxInput(committeeFormData.committee_id);
     TransactionDetailPage.enterLoanFormData(debtFormData);
     PageUtils.clickButton('Save');
@@ -34,12 +26,11 @@ describe('Debts', () => {
   });
 
   it('should test Owed To Committee loan', () => {
-    F3XSetup({committee: true});
+    F3XSetup({ committee: true });
     StartTransaction.Debts().ToCommittee();
 
     PageUtils.urlCheck('DEBT_OWED_TO_COMMITTEE');
     PageUtils.containedOnPage('Debt Owed To Committee');
-    cy.get('#entity_type_dropdown').type(committeeFormData['contact_type']);
 
     PageUtils.searchBoxInput(committeeFormData['committee_id']);
     TransactionDetailPage.enterLoanFormData(debtFormData);

--- a/front-end/cypress/e2e/F3X/reports-f3x-disbursements.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x-disbursements.cy.ts
@@ -1,20 +1,17 @@
-import { ContactListPage } from '../pages/contactListPage';
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
-import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import {
   candidateFormData,
   defaultFormData as individualContactFormData,
-  organizationFormData
+  organizationFormData,
 } from '../models/ContactFormModel';
 import {
   defaultScheduleFormData as defaultTransactionFormData,
   DisbursementFormData,
 } from '../models/TransactionFormModel';
-import { F3XSetup } from "./f3x-setup";
-import { StartTransaction } from "./start-transaction/start-transaction";
-
+import { F3XSetup } from './f3x-setup';
+import { StartTransaction } from './start-transaction/start-transaction';
 
 const independentExpVoidData: DisbursementFormData = {
   ...defaultTransactionFormData,
@@ -29,20 +26,16 @@ const independentExpVoidData: DisbursementFormData = {
 
 describe('Disbursements', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
-    ContactListPage.goToPage();
-    ReportListPage.goToPage();
+    Initialize();
   });
 
   it('should test F3xFederalElectionActivityExpendituresPage disbursement', () => {
-    F3XSetup({individual: true});
+    F3XSetup({ individual: true });
     StartTransaction.Disbursements().Federal().HundredPercentFederalElectionActivityPayment();
 
-    cy.get('#entity_type_dropdown').type(individualContactFormData.contact_type);
+    PageUtils.dropdownSetValue('#entity_type_dropdown', individualContactFormData.contact_type, '');
     cy.contains('LOOKUP').should('exist');
-    cy.get('[role="searchbox"]').type(individualContactFormData.last_name.slice(0, 1));
+    cy.get('[id="searchBox"]').type(individualContactFormData.last_name.slice(0, 1));
     cy.contains(individualContactFormData.last_name).should('exist');
     cy.contains(individualContactFormData.last_name).click();
 
@@ -55,12 +48,12 @@ describe('Disbursements', () => {
   });
 
   it('should test Independent Expenditure - Void Schedule E disbursement', () => {
-    F3XSetup({organization: true, candidate: true});
+    F3XSetup({ organization: true, candidate: true });
     StartTransaction.Disbursements().Independent().IndependentExpenditureVoid();
 
-    cy.get('#entity_type_dropdown').type(organizationFormData.contact_type);
+    PageUtils.dropdownSetValue('#entity_type_dropdown', organizationFormData.contact_type, '');
     cy.contains('LOOKUP').should('exist');
-    cy.get('[role="searchbox"]').type(organizationFormData.name.slice(0, 1));
+    cy.get('[id="searchBox"]').type(organizationFormData.name.slice(0, 1));
     cy.contains(organizationFormData.name).should('exist');
     cy.contains(organizationFormData.name).click();
 

--- a/front-end/cypress/e2e/F3X/reports-f3x-loans-bank.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x-loans-bank.cy.ts
@@ -1,13 +1,11 @@
 import { defaultFormData as individualContactFormData, organizationFormData } from '../models/ContactFormModel';
 import { defaultLoanFormData } from '../models/TransactionFormModel';
-import { ContactListPage } from '../pages/contactListPage';
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
 import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
-import { StartTransaction } from "./start-transaction/start-transaction";
-import { F3XSetup, reportFormDataApril, reportFormDataJuly, Setup } from "./f3x-setup";
-
+import { StartTransaction } from './start-transaction/start-transaction';
+import { F3XSetup, reportFormDataApril, reportFormDataJuly, Setup } from './f3x-setup';
 
 const formData = {
   ...defaultLoanFormData,
@@ -36,14 +34,11 @@ function setupLoanFromBank(setup: Setup) {
 
 describe('Loans', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
-    ReportListPage.goToPage();
+    Initialize();
   });
 
   it('should test new C1 - Loan Agreement for existing Schedule C Loan', () => {
-    setupLoanFromBank({individual: true, organization: true, report: reportFormDataApril});
+    setupLoanFromBank({ individual: true, organization: true, report: reportFormDataApril });
 
     PageUtils.clickButton('Save transactions');
     PageUtils.urlCheck('/list');
@@ -104,7 +99,7 @@ describe('Loans', () => {
   });
 
   it('should test: Loan Received from Bank', () => {
-    setupLoanFromBank({individual: true, organization: true});
+    setupLoanFromBank({ individual: true, organization: true });
 
     PageUtils.clickButton('Save transactions');
     PageUtils.urlCheck('/list');
@@ -112,14 +107,14 @@ describe('Loans', () => {
   });
 
   it('should test: Loan Received from Bank - Make loan repayment', () => {
-    setupLoanFromBank({organization: true});
+    setupLoanFromBank({ organization: true });
 
     PageUtils.clickButton('Save transactions');
 
     PageUtils.urlCheck('/list');
     cy.contains('Loan Received from Bank').last().should('exist');
     PageUtils.clickElement('loans-and-debts-button');
-    cy.contains('Make loan repayment').click({force: true});
+    cy.contains('Make loan repayment').click({ force: true });
     PageUtils.urlCheck('LOAN_REPAYMENT_MADE');
 
     formData.date_received = new Date(currentYear, 4 - 1, 27);
@@ -131,7 +126,7 @@ describe('Loans', () => {
   });
 
   it('should test: Loan Received from Bank - Review loan agreement', () => {
-    setupLoanFromBank({organization: true});
+    setupLoanFromBank({ organization: true });
 
     PageUtils.clickButton('Save transactions');
 
@@ -143,7 +138,7 @@ describe('Loans', () => {
       .children()
       .last()
       .click();
-    cy.contains('Review loan agreement').click();
+    cy.contains('Review loan agreement').click({ force: true });
     PageUtils.urlCheck('/list/');
     PageUtils.clickButton('Save transactions');
     PageUtils.urlCheck('/list');
@@ -151,7 +146,7 @@ describe('Loans', () => {
   });
 
   it('should test: Loan Received from Bank - add Guarantor', () => {
-    setupLoanFromBank({individual: true, organization: true});
+    setupLoanFromBank({ individual: true, organization: true });
 
     PageUtils.clickButton('Save & add loan guarantor');
 
@@ -162,6 +157,6 @@ describe('Loans', () => {
     cy.contains('Loan Received from Bank').click();
     PageUtils.urlCheck('/list/');
     cy.contains('ORGANIZATION NAME').should('exist');
-    cy.get('#organization_name').should('have.value', individualContactFormData.name);
+    cy.get('#organization_name').should('have.value', organizationFormData.name);
   });
 });

--- a/front-end/cypress/e2e/F3X/reports-f3x-loans-committee.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x-loans-committee.cy.ts
@@ -1,17 +1,10 @@
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
-import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
-import { ContactListPage } from '../pages/contactListPage';
 import { defaultLoanFormData } from '../models/TransactionFormModel';
-import { ContactFormData, defaultFormData as individualContactFormData } from '../models/ContactFormModel';
-import { F3XSetup } from "./f3x-setup";
-import { StartTransaction } from "./start-transaction/start-transaction";
-
-const committeeFormData: ContactFormData = {
-  ...individualContactFormData,
-  ...{contact_type: 'Committee'},
-};
+import { committeeFormData, defaultFormData as individualContactFormData } from '../models/ContactFormModel';
+import { F3XSetup } from './f3x-setup';
+import { StartTransaction } from './start-transaction/start-transaction';
 
 const formData = {
   ...defaultLoanFormData,
@@ -21,9 +14,9 @@ const formData = {
 };
 
 function setupLoanByCommittee() {
-  F3XSetup({committee: true, individual: true})
+  F3XSetup({ committee: true, individual: true });
   StartTransaction.Loans().ByCommittee();
-  // Search for created committee and enter load data, then add load gaurantor
+  // Search for created committee and enter load data, then add load guarantor
   PageUtils.urlCheck('LOAN_BY_COMMITTEE');
   PageUtils.searchBoxInput(committeeFormData.committee_id);
   formData.date_received = undefined;
@@ -32,12 +25,7 @@ function setupLoanByCommittee() {
 
 describe('Loans', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ContactListPage.deleteAllContacts();
-    ContactListPage.goToPage();
-    ReportListPage.goToPage();
-
+    Initialize();
   });
 
   it('should test: Loan By Committee', () => {
@@ -49,14 +37,14 @@ describe('Loans', () => {
   });
 
   it('should test: Loan By Committee - Receive loan repayment', () => {
-    // Search for created committee and enter load data, then add load gaurantor
+    // Search for created committee and enter load data, then add load guarantor
     setupLoanByCommittee();
     PageUtils.clickButton('Save both transactions');
     PageUtils.urlCheck('/list');
     cy.contains('Loan By Committee').should('exist');
     cy.contains('Loan Made').should('exist');
     PageUtils.clickElement('loans-and-debts-button');
-    cy.contains('Receive loan repayment').click({force: true});
+    cy.contains('Receive loan repayment').click({ force: true });
 
     PageUtils.urlCheck('LOAN_REPAYMENT_RECEIVED');
     PageUtils.searchBoxInput(committeeFormData.committee_id);

--- a/front-end/cypress/e2e/F3X/reports-f3x-transactions.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x-transactions.cy.ts
@@ -1,12 +1,9 @@
 import { ContactListPage } from '../pages/contactListPage';
-import { F3xCreateReportPage } from '../pages/f3xCreateReportPage';
 import { TransactionTableColumns } from '../pages/f3xTransactionListPage';
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
-import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
-import { defaultFormData as defaultContactFormData } from '../models/ContactFormModel';
-import { defaultFormData as defaultReportFormData } from '../models/ReportFormModel';
+import { defaultFormData as defaultContactFormData, organizationFormData } from '../models/ContactFormModel';
 import { defaultScheduleFormData, formTransactionDataForSchedule } from '../models/TransactionFormModel';
 import { F3XSetup } from './f3x-setup';
 import { StartTransaction } from './start-transaction/start-transaction';
@@ -22,10 +19,7 @@ const scheduleData = {
 
 describe('Transactions', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ContactListPage.deleteAllContacts();
-    ReportListPage.deleteAllReports();
-    ReportListPage.goToPage();
+    Initialize();
   });
 
   it('Create an Individual Receipt transaction using the contact lookup', () => {
@@ -35,9 +29,9 @@ describe('Transactions', () => {
     StartTransaction.Receipts().Individual().IndividualReceipt();
 
     // Select the contact from the contact lookup
-    cy.get('[role="searchbox"]').type(defaultContactFormData['last_name'].slice(0, 1));
+    cy.get('[id="searchBox"]').type(defaultContactFormData['last_name'].slice(0, 1));
     cy.contains(defaultContactFormData['last_name']).should('exist');
-    cy.contains(defaultContactFormData['last_name']).click();
+    cy.contains(defaultContactFormData['last_name']).click({ force: true });
 
     TransactionDetailPage.enterScheduleFormData(scheduleData);
     PageUtils.clickButton('Save');
@@ -130,7 +124,7 @@ describe('Transactions', () => {
     TransactionDetailPage.assertFormData(negativeAmountFormData);
   });
 
-  xit('Create a Partnership Receipt transaction and memos with correct aggregate values', () => {
+  it('Create a Partnership Receipt transaction and memos with correct aggregate values', () => {
     function checkTable(index: number, type: string, containMemo: boolean, value: string) {
       cy.get('tbody tr').eq(index).as('row');
       cy.get('@row').find('td').eq(TransactionTableColumns.transaction_type).should('contain', type);
@@ -157,7 +151,9 @@ describe('Transactions', () => {
       ...{ purpose_description: '', category_code: '' },
     };
     TransactionDetailPage.enterScheduleFormData(formTransactionData);
-    PageUtils.dropdownSetValue('[data-test="navigation-control-dropdown"]', 'Partnership Attribution');
+    const alias = PageUtils.getAlias('');
+    cy.get(alias).find('[data-test="navigation-control-dropdown"]').first().click();
+    cy.get(alias).find('[data-test="navigation-control-dropdown-option"]').first().click();
     cy.contains('Confirm').should('exist');
     PageUtils.clickButton('Continue');
 
@@ -172,20 +168,22 @@ describe('Transactions', () => {
     };
 
     TransactionDetailPage.enterScheduleFormData(memoFormTransactionData);
-    PageUtils.clickButton('Save');
+    cy.get('[data-test="navigation-control-button"]').contains('button', 'Save').click();
     cy.contains('Confirm').should('exist');
     PageUtils.clickButton('Continue');
 
     // Create a second memo transaction so we can check the aggregate value
     cy.contains('Transactions in this report').should('exist');
     PageUtils.clickLink('Partnership Receipt');
-    PageUtils.dropdownSetValue('[data-test="navigation-control-dropdown"]', 'Partnership Attribution');
+    cy.get(alias).find('[data-test="navigation-control-dropdown"]').first().click();
+    cy.get(alias).find('[data-test="navigation-control-dropdown-option"]').first().click();
     PageUtils.urlCheck('PARTNERSHIP_ATTRIBUTION');
-    cy.get('[role="searchbox"]').type(defaultContactFormData['last_name'].slice(0, 1));
+    cy.get('[id="searchBox"]').type(defaultContactFormData['last_name'].slice(0, 1));
     cy.contains(defaultContactFormData['last_name']).should('exist');
     cy.contains(defaultContactFormData['last_name']).click();
     TransactionDetailPage.enterScheduleFormData(memoFormTransactionData);
-    PageUtils.clickButton('Save');
+
+    cy.get('[data-test="navigation-control-button"]').contains('button', 'Save').click();
 
     // Assert transaction list table is correct
     checkTable(0, 'Partnership Receipt', false, '$200.01');
@@ -295,6 +293,10 @@ describe('Transactions', () => {
     F3XSetup({ organization: true });
     StartTransaction.Disbursements().Federal().CreditCardPayment();
 
+    cy.get('[id="searchBox"]').type(organizationFormData.name.slice(0, 1));
+    cy.contains(organizationFormData.name).should('exist');
+    cy.contains(organizationFormData.name).click();
+
     const transactionFormData = {
       ...formTransactionDataForSchedule,
       ...{
@@ -306,13 +308,11 @@ describe('Transactions', () => {
         date_received: new Date(currentYear, 4 - 1, 27),
       },
     };
-    TransactionDetailPage.enterScheduleFormData(transactionFormData);
-    PageUtils.clickButton('Save');
-    cy.contains('Confirm').should('exist');
-    PageUtils.clickButton('Continue');
+    TransactionDetailPage.enterScheduleFormData(transactionFormData, false, '', false);
+    cy.get('[data-test="navigation-control-button"]').contains('button', 'Save').click();
 
     cy.get('tr').should('contain', 'Credit Card Payment for 100% Federal Election Activity');
-    cy.get('tr').should('contain', defaultContactFormData['name']);
+    cy.get('tr').should('contain', organizationFormData['name']);
     cy.get('tr').should('contain', PageUtils.dateToString(transactionFormData.date_received));
     cy.get('tr').should('contain', '$' + transactionFormData.amount);
 
@@ -320,7 +320,7 @@ describe('Transactions', () => {
     PageUtils.clickLink('Credit Card Payment for 100% Federal Election Activity');
     cy.get('#entity_type_dropdown > div.readonly').should('exist');
     cy.get('#entity_type_dropdown').should('contain', 'Organization');
-    ContactListPage.assertFormData(defaultContactFormData, true);
+    ContactListPage.assertFormData(organizationFormData, true);
     TransactionDetailPage.assertFormData(transactionFormData);
   });
 
@@ -402,13 +402,8 @@ describe('Transactions', () => {
   });
 
   it('Create a dual-entry PAC Earmark Receipt transaction', () => {
-    ReportListPage.clickCreateButton();
-    F3xCreateReportPage.enterFormData(defaultReportFormData);
-    PageUtils.clickButton('Save and continue');
-
-    PageUtils.clickSidebarItem('Add a receipt');
-    PageUtils.clickLink('CONTRIBUTIONS FROM REGISTERED FILERS');
-    PageUtils.clickLink('PAC Earmark Receipt');
+    F3XSetup();
+    StartTransaction.Receipts().RegisteredFilers().PAC();
 
     // Enter STEP ONE transaction
     cy.get('p-accordiontab').first().as('stepOneAccordion');
@@ -488,15 +483,11 @@ describe('Transactions', () => {
     );
   });
 
-  xit('Create a Joint Fundraising Transfer transactin with Tier 3 child transactions', () => {
-    ReportListPage.clickCreateButton();
-    F3xCreateReportPage.enterFormData(defaultReportFormData);
-    PageUtils.clickButton('Save and continue');
+  it('Create a Joint Fundraising Transfer transaction with Tier 3 child transactions', () => {
+    F3XSetup();
 
     // Create a Joint Fundraising Transfer
-    PageUtils.clickSidebarItem('Add a receipt');
-    PageUtils.clickLink('TRANSFERS');
-    PageUtils.clickLink('Joint Fundraising Transfer');
+    StartTransaction.Receipts().Transfers().JointFundraising();
 
     PageUtils.clickLink('Create a new contact');
     const committeeFormContactData = {
@@ -515,7 +506,9 @@ describe('Transactions', () => {
       },
     };
     TransactionDetailPage.enterScheduleFormData(tier1TransactionData);
-    PageUtils.dropdownSetValue('[data-test="navigation-control-dropdown"]', 'Partnership Receipt');
+    const alias = PageUtils.getAlias('');
+    cy.get(alias).find('[data-test="navigation-control-dropdown"]').first().click();
+    cy.get(alias).find('[data-test="navigation-control-dropdown-option"]').contains('Partnership Receipt').click();
     cy.contains('Confirm').should('exist');
     PageUtils.clickButton('Continue');
 
@@ -537,7 +530,8 @@ describe('Transactions', () => {
       },
     };
     TransactionDetailPage.enterScheduleFormData(tier2TransactionData);
-    PageUtils.dropdownSetValue('[data-test="navigation-control-dropdown"]', 'Individual');
+    cy.get(alias).find('[data-test="navigation-control-dropdown"]').first().click();
+    cy.get(alias).find('[data-test="navigation-control-dropdown-option"]').contains('Individual').click();
     cy.contains('Confirm').should('exist');
     PageUtils.clickButton('Continue');
 
@@ -559,7 +553,7 @@ describe('Transactions', () => {
       },
     };
     TransactionDetailPage.enterScheduleFormData(tier3TransactionData);
-    PageUtils.clickButton('Save');
+    cy.get('[data-test="navigation-control-button"]').contains('button', 'Save').click();
     cy.contains('Confirm').should('exist');
     PageUtils.clickButton('Continue');
 

--- a/front-end/cypress/e2e/F3X/reports-f3x.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x.cy.ts
@@ -1,6 +1,5 @@
-import { LoginPage } from '../pages/loginPage';
+import { Initialize } from '../pages/loginPage';
 import { ReportListPage } from '../pages/reportListPage';
-import { F3xCreateReportPage } from '../pages/f3xCreateReportPage';
 import { defaultFormData as cohFormData, F3xCashOnHandPage } from '../pages/f3xCashOnHandPage';
 import { F3xReportLevelMemoPage } from '../pages/f3xReportLevelMemoPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
@@ -8,21 +7,15 @@ import { defaultFormData } from '../models/ReportFormModel';
 
 describe('Manage reports', () => {
   beforeEach(() => {
-    LoginPage.login();
-    ReportListPage.deleteAllReports();
-    ReportListPage.goToPage();
+    Initialize();
   });
 
   it('Create a Quarterly Election Year report', () => {
     cy.runLighthouse('reports', 'list');
 
-    ReportListPage.clickCreateButton();
-
+    ReportListPage.createF3X();
+    ReportListPage.goToPage();
     cy.runLighthouse('reports', 'create-report');
-
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save');
 
     cy.get('tr').should('contain', 'FORM 3X');
     cy.get('tr').should('contain', 'GENERAL (12G)');
@@ -30,7 +23,6 @@ describe('Manage reports', () => {
   });
 
   it('Create a Monthly Election Year report', () => {
-    ReportListPage.clickCreateButton();
     const formData = {
       ...defaultFormData,
       ...{
@@ -38,15 +30,13 @@ describe('Manage reports', () => {
         report_code: 'M10',
       },
     };
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save');
-
+    ReportListPage.createF3X(formData);
+    ReportListPage.goToPage();
     cy.get('tr').should('contain', 'FORM 3X');
     cy.get('tr').should('contain', 'OCTOBER 20 (M10)');
   });
 
   it('Create a Quarterly Non-Election Year report', () => {
-    ReportListPage.clickCreateButton();
     const formData = {
       ...defaultFormData,
       ...{
@@ -54,15 +44,13 @@ describe('Manage reports', () => {
         report_code: '30R',
       },
     };
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save');
-
+    ReportListPage.createF3X(formData);
+    ReportListPage.goToPage();
     cy.get('tr').should('contain', 'FORM 3X');
     cy.get('tr').should('contain', 'RUNOFF (30R)');
   });
 
   it('Create a Monthly Non-Election Year report', () => {
-    ReportListPage.clickCreateButton();
     const formData = {
       ...defaultFormData,
       ...{
@@ -71,9 +59,8 @@ describe('Manage reports', () => {
         report_code: 'YE',
       },
     };
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save');
-
+    ReportListPage.createF3X(formData);
+    ReportListPage.goToPage();
     cy.get('tr').should('contain', 'FORM 3X');
     cy.get('tr').should('contain', 'JANUARY 31 (YE)');
     cy.get('tr').should('contain', `04/01/${currentYear} - 04/30/${currentYear}`);
@@ -81,23 +68,19 @@ describe('Manage reports', () => {
 
   it('Create a report error for overlapping coverage dates', () => {
     // Create report #1
-    ReportListPage.clickCreateButton();
-    const formData1 = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData1);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
     F3xCashOnHandPage.enterFormData(cohFormData);
     PageUtils.clickButton('Save & continue');
     ReportListPage.goToPage();
 
     // Create report #2
-    ReportListPage.clickCreateButton();
-    const formData2 = {
+    const formData = {
       ...defaultFormData,
       ...{
         report_code: '30G',
       },
     };
-    F3xCreateReportPage.enterFormData(formData2);
+    ReportListPage.createF3X(formData);
 
     // Check for error messages caused by the overlapping dates
     const errorMessage = `You have entered coverage dates that overlap the coverage dates of the following report: 12-DAY PRE-GENERAL (12G)  04/01/${currentYear} - 04/30/${currentYear}`;
@@ -107,21 +90,15 @@ describe('Manage reports', () => {
 
   xit('Create report with previous existing report types disabled', () => {
     // Create report #1
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save');
-
+    ReportListPage.createF3X();
+    ReportListPage.goToPage();
     // Start second report and check to see if report code disabled
     ReportListPage.clickCreateButton();
     cy.get('label[for="12G"]').should('have.class', 'p-disabled');
   });
 
   it('Create report and save cash on hand', () => {
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
 
     F3xCashOnHandPage.enterFormData(cohFormData);
     PageUtils.clickButton('Save & continue');
@@ -131,24 +108,15 @@ describe('Manage reports', () => {
   });
 
   xit('Check values on the Summary Page', () => {
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
   });
 
   xit('Check values on the Detail Summary Page', () => {
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
   });
 
   it('Create a report level memo', () => {
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
 
     // Enter the memo text
     PageUtils.clickSidebarSection('REVIEW A REPORT');
@@ -166,16 +134,10 @@ describe('Manage reports', () => {
   });
 
   xit('Confirm report information', () => {
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
   });
 
   xit('Submit a report', () => {
-    ReportListPage.clickCreateButton();
-    const formData = {...defaultFormData};
-    F3xCreateReportPage.enterFormData(formData);
-    PageUtils.clickButton('Save and continue');
+    ReportListPage.createF3X();
   });
 });

--- a/front-end/cypress/e2e/F3X/start-transaction/receipts.ts
+++ b/front-end/cypress/e2e/F3X/start-transaction/receipts.ts
@@ -15,6 +15,11 @@ export class Receipts {
     PageUtils.clickLink('REFUNDS');
     return Refunds;
   }
+
+  static Transfers() {
+    PageUtils.clickLink('TRANSFERS');
+    return Transfers;
+  }
 }
 
 export class Individual {
@@ -41,10 +46,20 @@ export class RegisteredFilers {
   static Party() {
     PageUtils.clickLink('Party Receipt');
   }
+
+  static PAC() {
+    PageUtils.clickLink('PAC Earmark Receipt');
+  }
 }
 
 export class Refunds {
   static ContributionToOtherPoliticalCommittee() {
     PageUtils.clickLink('Refund of Contribution to Other Political Committee');
+  }
+}
+
+export class Transfers {
+  static JointFundraising() {
+    PageUtils.clickLink('Joint Fundraising Transfer');
   }
 }

--- a/front-end/cypress/e2e/pages/contactListPage.ts
+++ b/front-end/cypress/e2e/pages/contactListPage.ts
@@ -17,9 +17,7 @@ export class ContactListPage {
     alias = PageUtils.getAlias(alias);
 
     if (!excludeContactType) {
-      alias = PageUtils.getAlias(alias);
-      const selector = cy.get(alias).find('#entity_type_dropdown').first();
-      selector.select(formData['contact_type']);
+      PageUtils.dropdownSetValue('#entity_type_dropdown', formData['contact_type'], alias);
     }
 
     if (formData['contact_type'] == 'Individual' || formData['contact_type'] == 'Candidate') {
@@ -137,14 +135,6 @@ export class ContactListPage {
     });
   }
 
-  private static create(fd: ContactFormData) {
-    ContactListPage.goToPage();
-    PageUtils.clickButton('New');
-    cy.wait(150);
-    ContactListPage.enterFormData(fd);
-    PageUtils.clickButton('Save');
-  }
-
   static createIndividual(fd = individualContactFormData) {
     fd.contact_type = 'Individual';
     ContactListPage.create(fd);
@@ -160,5 +150,13 @@ export class ContactListPage {
 
   static createCommittee(fd = committeeFormData) {
     ContactListPage.create(fd);
+  }
+
+  private static create(fd: ContactFormData) {
+    ContactListPage.goToPage();
+    PageUtils.clickButton('New');
+    cy.wait(150);
+    ContactListPage.enterFormData(fd);
+    PageUtils.clickButton('Save');
   }
 }

--- a/front-end/cypress/e2e/pages/loginPage.ts
+++ b/front-end/cypress/e2e/pages/loginPage.ts
@@ -1,3 +1,6 @@
+import { ContactListPage } from './contactListPage';
+import { ReportListPage } from './reportListPage';
+
 export class LoginPage {
   static login() {
     const sessionDuration = 10; //Login session duration in minutes
@@ -83,4 +86,10 @@ function retrieveAuthToken() {
   const storedData = localStorage.getItem('fecfile_online_userLoginData');
   const loginData = JSON.parse(storedData ?? '');
   return 'JWT ' + loginData.token;
+}
+
+export function Initialize() {
+  LoginPage.login();
+  ReportListPage.deleteAllReports();
+  ContactListPage.deleteAllContacts();
 }

--- a/front-end/cypress/e2e/pages/pageUtils.ts
+++ b/front-end/cypress/e2e/pages/pageUtils.ts
@@ -15,8 +15,9 @@ export class PageUtils {
 
     if (value) {
       cy.get(alias).find(querySelector).first().click();
-      cy.contains('p-dropdownitem', value).should('be.visible');
-      cy.contains('p-dropdownitem', value).click();
+      cy.contains('p-dropdownitem', value)
+        .scrollIntoView({ offset: { top: 0, left: 0 } })
+        .click();
     }
   }
 
@@ -26,7 +27,7 @@ export class PageUtils {
     //
     cy.get(alias).find(calendar).first().as('calendarElement').click();
 
-    cy.get('@calendarElement').find('.p-datepicker-year').first().click();
+    cy.get('@calendarElement').find('.p-datepicker-year').first().scrollIntoView().click();
     //    Choose the year
     const year: number = dateObj.getFullYear();
     const currentYear: number = currentDate.getFullYear();
@@ -34,24 +35,36 @@ export class PageUtils {
     const decadeEnd: number = decadeStart + 9;
     if (year < decadeStart) {
       for (let i = 0; i < decadeStart - year; i += 10) {
-        cy.get('@calendarElement').find('.p-datepicker-prev').click();
+        cy.get('@calendarElement').find('.p-datepicker-prev').scrollIntoView().click();
       }
     }
     if (year > decadeEnd) {
       for (let i = 0; i < year - decadeEnd; i += 10) {
-        cy.get('@calendarElement').find('.p-datepicker-next').click();
+        cy.get('@calendarElement').find('.p-datepicker-next').scrollIntoView().click();
       }
     }
-    cy.get('@calendarElement').find('.p-yearpicker-year').contains(year.toString()).click();
+    cy.get('@calendarElement')
+      .find('.p-yearpicker-year')
+      .contains(year.toString())
+      .scrollIntoView()
+      .click({ force: true });
 
     //    Choose the month
     const Months: Array<string> = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     const Month: string = Months[dateObj.getMonth()];
-    cy.get('@calendarElement').find('.p-monthpicker-month').contains(Month).click();
+    cy.get('@calendarElement').find('.p-monthpicker-month').contains(Month).scrollIntoView().click({ force: true });
 
     //    Choose the day
     const Day: string = dateObj.getDate().toString();
-    cy.get('@calendarElement').find('td').find('span').not('.p-disabled').parent().contains(Day).click();
+    cy.get('@calendarElement')
+      .find('td')
+      .find('span')
+      .not('.p-disabled')
+      .parent()
+      .contains(Day)
+      .scrollIntoView()
+      .click();
+    cy.wait(100);
   }
 
   static randomString(
@@ -60,10 +73,10 @@ export class PageUtils {
     includeCurlyBraces = true,
   ): string {
     // prettier-ignore
-    let symbols: Array<string> = [' ', '!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', '|', '~', '`'];
+    let symbols: Array<string> = [' ', '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', '|', '~', '`'];
     if (includeCurlyBraces) symbols = symbols.concat('{', '}');
     // prettier-ignore
-    const alphabet: Array<string> = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',];
+    const alphabet: Array<string> = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'];
     // prettier-ignore
     const numeric: Array<string> = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
@@ -141,7 +154,11 @@ export class PageUtils {
   }
 
   static searchBoxInput(input: string) {
-    cy.get('[role="searchbox"]').type(input.slice(0, 3));
+    cy.get('[id="searchBox"]').type(input.slice(0, 3));
+    cy.intercept({
+      method: 'Get',
+    }).as('search');
+    cy.wait('@search');
     cy.contains(input).should('exist');
     cy.contains(input).click({ force: true });
   }

--- a/front-end/cypress/e2e/pages/profileAccountPage.ts
+++ b/front-end/cypress/e2e/pages/profileAccountPage.ts
@@ -3,7 +3,7 @@ export class ProfileAccountPage {
     cy.intercept('/profile').as('account');
     cy.visit('/dashboard');
     cy.get('#navbarProfileDropdownMenuLink').click();
-    cy.get('[href="/profile/account"]').contains('Account').click();
-    cy.location('pathname').should('include', '/account');
+    cy.get('[href="/committee"]').contains('Account').click();
+    cy.location('pathname').should('include', '/committee');
   }
 }

--- a/front-end/cypress/e2e/pages/profileUserListPage.ts
+++ b/front-end/cypress/e2e/pages/profileUserListPage.ts
@@ -2,7 +2,7 @@ export class ProfileUserListPage {
   static goToPage() {
     cy.visit('/dashboard');
     cy.get('#navbarProfileDropdownMenuLink').click();
-    cy.get('[href="/committee/users"]').contains('Users').click();
-    cy.location('pathname').should('include', '/users');
+    cy.get('[href="/committee/members"]').contains('Users').click();
+    cy.location('pathname').should('include', '/members');
   }
 }

--- a/front-end/cypress/e2e/pages/reportListPage.ts
+++ b/front-end/cypress/e2e/pages/reportListPage.ts
@@ -30,7 +30,7 @@ export class ReportListPage {
           'x-csrftoken': cookie?.value,
         },
       }).then((resp) => {
-        const reports = resp.body.results;
+        const reports = resp.body;
         for (const report of reports) {
           ReportListPage.deleteReport(report.id);
         }
@@ -72,7 +72,7 @@ export class ReportListPage {
     PageUtils.clickSidebarItem('SUBMIT YOUR REPORT');
     PageUtils.clickSidebarItem('Submit report');
     const alias = PageUtils.getAlias('');
-    cy.get(alias).find('#filingPassword').type('Test123!');
+    cy.get(alias).find('#filingPassword').type(''); // Insert password from env variable
     cy.get(alias).find('.p-checkbox').click();
     PageUtils.clickButton('Submit');
     PageUtils.clickButton('Yes');

--- a/front-end/cypress/e2e/pages/transactionDetailPage.ts
+++ b/front-end/cypress/e2e/pages/transactionDetailPage.ts
@@ -13,45 +13,6 @@ export class TransactionDetailPage {
     PageUtils.calendarSetValue(dateFieldName, dateFieldValue, alias);
   }
 
-  private static enterMemo(formData: ScheduleFormData, alias: string) {
-    if (formData.memo_code) {
-      cy.get(alias).find('p-checkbox[inputid="memo_code"]').click();
-    }
-    if (formData.memo_text !== '') {
-      cy.get(alias).find('#text4000').first().type(formData.memo_text);
-    }
-  }
-
-  private static enterCategoryCode(formData: ScheduleFormData, alias: string) {
-    if (formData.category_code) {
-      PageUtils.dropdownSetValue('[inputid="category_code"]', formData.category_code, alias);
-    }
-  }
-
-  private static enterElection(formData: ScheduleFormData, alias: string) {
-    if (formData.electionType) {
-      PageUtils.dropdownSetValue('[inputid="electionType"]', formData.electionType, alias);
-    }
-    if (formData.electionYear) {
-      cy.get(alias).find('#electionYear').safeType(formData.electionYear);
-    }
-    if (formData.election_other_description) {
-      cy.get(alias).find('#election_other_description').safeType(formData.election_other_description);
-    }
-  }
-
-  private static enterPurpose(formData: ScheduleFormData, alias: string) {
-    if (formData.purpose_description) {
-      cy.get(alias).find('textarea#purpose_description').first().safeType(formData.purpose_description);
-    }
-  }
-
-  private static enterCommon(formData: ScheduleFormData, alias: string) {
-    this.enterMemo(formData, alias);
-    this.enterPurpose(formData, alias);
-    this.enterCategoryCode(formData, alias);
-  }
-
   static enterScheduleFormDataForContribution(formData: ContributionFormData, readOnlyAmount = false, alias = '') {
     alias = PageUtils.getAlias(alias);
 
@@ -60,7 +21,7 @@ export class TransactionDetailPage {
     }
 
     if (formData.candidate) {
-      cy.get('.contact-lookup-container').last().get('[role="searchbox"]').last().type(formData.candidate);
+      cy.get('.contact-lookup-container').last().get('[id="searchBox"]').last().type(formData.candidate);
       cy.contains(formData.candidate).should('exist');
       cy.contains(formData.candidate).click();
     }
@@ -90,7 +51,7 @@ export class TransactionDetailPage {
     if (formData.supportOpposeCode) {
       cy.get("p-radiobutton[FormControlName='support_oppose_code']").contains(formData.supportOpposeCode).click();
       cy.get('#entity_type_dropdown').last().type(contactData.contact_type);
-      cy.get('[role="searchbox"]').last().type(contactData.last_name.slice(0, 1));
+      cy.get('[id="searchBox"]').last().type(contactData.last_name.slice(0, 1));
       cy.contains(contactData.last_name).should('exist');
       cy.contains(contactData.last_name).click();
     }
@@ -131,23 +92,19 @@ export class TransactionDetailPage {
     this.enterLoanFormDataStepTwo(formData);
   }
 
-  static enterScheduleFormData(formData: ScheduleFormData, readOnlyAmount = false, alias = '') {
+  static enterScheduleFormData(formData: ScheduleFormData, readOnlyAmount = false, alias = '', includeMemo = true) {
     alias = PageUtils.getAlias(alias);
 
     if (formData.date_received) {
       this.enterDate('p-calendar[inputid="date"]', formData.date_received, alias);
     }
 
-    this.enterCommon(formData, alias);
+    this.enterCommon(formData, alias, includeMemo);
     if (!readOnlyAmount) {
       cy.get(alias).find('#amount').safeType(formData['amount']);
     }
     this.enterElection(formData, alias);
   }
-
-  /*
-  
-  */
 
   static enterLoanFormData(formData: LoanFormData, readOnlyAmount = false, alias = '') {
     alias = PageUtils.getAlias(alias);
@@ -275,5 +232,48 @@ export class TransactionDetailPage {
     if (formData.category_code != '') {
       cy.get(alias).find('[inputid="category_code"]').should('contain', formData.category_code);
     }
+  }
+
+  private static enterMemo(formData: ScheduleFormData, alias: string) {
+    if (formData.memo_code) {
+      cy.get(alias).find('p-checkbox[inputid="memo_code"]').click();
+    }
+    if (formData.memo_text !== '') {
+      cy.get(alias).find('#text4000').first().type(formData.memo_text);
+    }
+  }
+
+  private static enterCategoryCode(formData: ScheduleFormData, alias: string) {
+    if (formData.category_code) {
+      PageUtils.dropdownSetValue('[inputid="category_code"]', formData.category_code, alias);
+    }
+  }
+
+  /*
+  
+  */
+
+  private static enterElection(formData: ScheduleFormData, alias: string) {
+    if (formData.electionType) {
+      PageUtils.dropdownSetValue('[inputid="electionType"]', formData.electionType, alias);
+    }
+    if (formData.electionYear) {
+      cy.get(alias).find('#electionYear').safeType(formData.electionYear);
+    }
+    if (formData.election_other_description) {
+      cy.get(alias).find('#election_other_description').safeType(formData.election_other_description);
+    }
+  }
+
+  private static enterPurpose(formData: ScheduleFormData, alias: string) {
+    if (formData.purpose_description) {
+      cy.get(alias).find('textarea#purpose_description').first().safeType(formData.purpose_description);
+    }
+  }
+
+  private static enterCommon(formData: ScheduleFormData, alias: string, includeMemo = true) {
+    if (includeMemo) this.enterMemo(formData, alias);
+    this.enterPurpose(formData, alias);
+    this.enterCategoryCode(formData, alias);
   }
 }

--- a/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.html
+++ b/front-end/src/app/reports/f3x/create-workflow/create-f3x-step1.component.html
@@ -59,6 +59,7 @@
           <p-selectButton
             data-test="report-type-category"
             [options]="getReportTypeCategories()"
+            [allowEmpty]="false"
             formControlName="report_type_category"
           ></p-selectButton>
           <app-error-messages fieldName="report_type_category" [formSubmitted]="formSubmitted"></app-error-messages>

--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.spec.ts
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.spec.ts
@@ -86,16 +86,17 @@ describe('ContactLookupComponent', () => {
         last_na2me: 'testLastName',
       } as unknown as FecfileCandidateLookupData,
     ];
-    spyOn(testContactService, 'candidateLookup').and.returnValue(of(testCandidateLookupResponse));
+    spyOn(testContactService, 'candidateLookup').and.returnValue(Promise.resolve(testCandidateLookupResponse));
     const testEvent = { query: 'hi' };
     component.contactTypeFormControl.setValue('CAN');
     component.onDropdownSearch(testEvent);
+    tick(500);
     expect(component.contactLookupList[1].items.length === 0).toBeTrue();
   }));
 
   it('#onDropdownSearch CAN undefined fecfile_candidates', fakeAsync(() => {
     const testCandidateLookupResponse = new CandidateLookupResponse();
-    spyOn(testContactService, 'candidateLookup').and.returnValue(of(testCandidateLookupResponse));
+    spyOn(testContactService, 'candidateLookup').and.returnValue(Promise.resolve(testCandidateLookupResponse));
     const testEvent = { query: 'hi' };
     component.contactTypeFormControl.setValue('CAN');
     component.onDropdownSearch(testEvent);
@@ -113,20 +114,20 @@ describe('ContactLookupComponent', () => {
         type: ContactTypes.CANDIDATE,
       } as unknown as FecfileCandidateLookupData),
     ];
-    spyOn(testContactService, 'candidateLookup').and.returnValue(of(testCandidateLookupResponse));
+    spyOn(testContactService, 'candidateLookup').and.returnValue(Promise.resolve(testCandidateLookupResponse));
     const testEvent = { query: 'hi' };
     component.contactTypeFormControl.setValue('CAN');
     component.onDropdownSearch(testEvent);
     tick(500);
     expect(
       JSON.stringify(component.contactLookupList) ===
-        JSON.stringify(testCandidateLookupResponse.toSelectItemGroups(true))
+        JSON.stringify(testCandidateLookupResponse.toSelectItemGroups(true)),
     ).toBeTrue();
     expect(
       JSON.stringify([
         { label: 'There are no matching candidates', items: [] },
         { label: 'There are no matching registered candidates', items: [] },
-      ]) === JSON.stringify(new CandidateLookupResponse().toSelectItemGroups(true))
+      ]) === JSON.stringify(new CandidateLookupResponse().toSelectItemGroups(true)),
     ).toBeTrue();
   }));
 
@@ -182,13 +183,13 @@ describe('ContactLookupComponent', () => {
     component.onDropdownSearch(testEvent);
     expect(
       JSON.stringify(component.contactLookupList) ===
-        JSON.stringify(testCommitteeLookupResponse.toSelectItemGroups(true))
+        JSON.stringify(testCommitteeLookupResponse.toSelectItemGroups(true)),
     ).toBeTrue();
     expect(
       JSON.stringify([
         { label: 'There are no matching committees', items: [] },
         { label: 'There are no matching registered committees', items: [] },
-      ]) === JSON.stringify(new CommitteeLookupResponse().toSelectItemGroups(true))
+      ]) === JSON.stringify(new CommitteeLookupResponse().toSelectItemGroups(true)),
     ).toBeTrue();
   }));
 
@@ -218,7 +219,7 @@ describe('ContactLookupComponent', () => {
     component.onDropdownSearch(testEvent);
     tick(500);
     expect(
-      JSON.stringify(component.contactLookupList) === JSON.stringify(testIndividualLookupResponse.toSelectItemGroups())
+      JSON.stringify(component.contactLookupList) === JSON.stringify(testIndividualLookupResponse.toSelectItemGroups()),
     ).toBeTrue();
     expect(
       JSON.stringify([
@@ -226,7 +227,7 @@ describe('ContactLookupComponent', () => {
           label: 'There are no matching individuals',
           items: [],
         },
-      ]) === JSON.stringify(new IndividualLookupResponse().toSelectItemGroups())
+      ]) === JSON.stringify(new IndividualLookupResponse().toSelectItemGroups()),
     ).toBeTrue();
   }));
 
@@ -256,7 +257,7 @@ describe('ContactLookupComponent', () => {
     tick(500);
     expect(
       JSON.stringify(component.contactLookupList) ===
-        JSON.stringify(testOrganizationLookupResponse.toSelectItemGroups())
+        JSON.stringify(testOrganizationLookupResponse.toSelectItemGroups()),
     ).toBeTrue();
     expect(
       JSON.stringify([
@@ -264,7 +265,7 @@ describe('ContactLookupComponent', () => {
           label: 'There are no matching organizations',
           items: [],
         },
-      ]) === JSON.stringify(new OrganizationLookupResponse().toSelectItemGroups())
+      ]) === JSON.stringify(new OrganizationLookupResponse().toSelectItemGroups()),
     ).toBeTrue();
   }));
 

--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.ts
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.ts
@@ -74,14 +74,14 @@ export class ContactLookupComponent extends DestroyerComponent implements OnInit
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onDropdownSearch(event: any) {
+  async onDropdownSearch(event: any) {
     const searchTerm = event.query;
     if (searchTerm) {
       this.searchTerm = searchTerm;
       switch (this.contactTypeFormControl.value) {
         case ContactTypes.CANDIDATE:
-          this.contactService
-            .candidateLookup(
+          this.contactLookupList = (
+            await this.contactService.candidateLookup(
               searchTerm,
               this.maxFecCommitteeResults,
               this.maxFecfileCommitteeResults,
@@ -89,9 +89,7 @@ export class ContactLookupComponent extends DestroyerComponent implements OnInit
               this.excludeFecIds,
               this.excludeIds,
             )
-            .subscribe((response) => {
-              this.contactLookupList = response && response.toSelectItemGroups(this.includeFecfileResults);
-            });
+          ).toSelectItemGroups(this.includeFecfileResults);
           break;
         case ContactTypes.COMMITTEE:
           this.contactService

--- a/front-end/src/app/shared/services/contact.service.spec.ts
+++ b/front-end/src/app/shared/services/contact.service.spec.ts
@@ -109,7 +109,7 @@ describe('ContactService', () => {
     httpTestingController.verify();
   });
 
-  it('#candidateLookup() happy path', () => {
+  it('#candidateLookup() happy path', async () => {
     const expectedRetval = new CandidateLookupResponse();
     const apiServiceGetSpy = spyOn(testApiService, 'get').and.returnValue(of(expectedRetval) as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     const testSearch = 'testSearch';
@@ -126,16 +126,15 @@ describe('ContactService', () => {
       exclude_ids: '',
     };
 
-    service
-      .candidateLookup(
-        testSearch,
-        testMaxFecResults,
-        testMaxFecfileResults,
-        undefined,
-        ['C000000001', 'C000000002'],
-        [],
-      )
-      .subscribe((value) => expect(value).toEqual(expectedRetval));
+    const value = await service.candidateLookup(
+      testSearch,
+      testMaxFecResults,
+      testMaxFecfileResults,
+      undefined,
+      ['C000000001', 'C000000002'],
+      [],
+    );
+    expect(value).toEqual(expectedRetval);
     expect(apiServiceGetSpy).toHaveBeenCalledOnceWith(expectedEndpoint, expectedParams);
   });
 


### PR DESCRIPTION
I was able to handle most of these issues via minor configuration changes, but the "Add a Memo" dropdown was a major blocker and was proving difficult to handle in a way that worked without breaking the appearance of dropdown. I ended up replacing the primeng dropdown with a bootstrap dropdown. This also gave some better keyboard control. But this section definitely needs a focus of the code review and testing.

As a note, this also includes a minor change update to primeng which led to some odd graphical changes that I was able to address with some css fixes. For example the Import button on the Contacts page was broken out to cssless file input which looks quite bad.