### PR TITLE
1652 qa updates

### DIFF
--- a/front-end/src/app/committee/select-committee/select-committee.component.html
+++ b/front-end/src/app/committee/select-committee/select-committee.component.html
@@ -9,7 +9,7 @@
   <div class="col-6 right-side">
     <div class="select-committee-box">
       <h2>Select a committee account</h2>
-      <ng-container *ngIf="!committees.length">
+      <ng-container *ngIf="committees?.length === 0">
         <div class="committee-card empty-card">
           <div class="empty-lens-img">
             <img alt="Magnifying lens" src="assets/img/magnifying_lens.svg" />
@@ -19,7 +19,7 @@
           </div>
         </div>
       </ng-container>
-      <ng-container *ngIf="committees.length">
+      <ng-container *ngIf="committees?.length">
         <div class="committee-list">
           <div class="committee-card" *ngFor="let committee of committees" (click)="activateCommittee(committee)">
             <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg" />

--- a/front-end/src/app/committee/select-committee/select-committee.component.ts
+++ b/front-end/src/app/committee/select-committee/select-committee.component.ts
@@ -6,7 +6,7 @@ import { CommitteeAccount } from 'app/shared/models/committee-account.model';
 import { CommitteeAccountService } from 'app/shared/services/committee-account.service';
 import { FecApiService } from 'app/shared/services/fec-api.service';
 import { setCommitteeAccountDetailsAction } from 'app/store/committee-account.actions';
-import { concatMap, forkJoin, map } from 'rxjs';
+import { concatMap, forkJoin, map, of } from 'rxjs';
 
 @Component({
   selector: 'app-select-committee',
@@ -14,7 +14,7 @@ import { concatMap, forkJoin, map } from 'rxjs';
   styleUrls: ['./select-committee.component.scss'],
 })
 export class SelectCommitteeComponent extends DestroyerComponent implements OnInit {
-  committees: CommitteeAccount[] = [];
+  committees?: CommitteeAccount[];
   constructor(
     protected committeeAccountService: CommitteeAccountService,
     protected fecApiService: FecApiService,
@@ -36,7 +36,7 @@ export class SelectCommitteeComponent extends DestroyerComponent implements OnIn
               })
             );
           });
-          return forkJoin(augmented);
+          return augmented.length ? forkJoin(augmented) : of([]);
         })
       )
       .subscribe((committees) => (this.committees = committees));


### PR DESCRIPTION
This addresses `Not currently active in any FECFile committee accounts` flashing before the list is displayed.  Now the list will just be empty until it is initialized.