### PR TITLE
feature/1779 - Update redirects so initial login or heading to the base url after login, redirects you to the reports page.

### DIFF
--- a/front-end/src/app/app-routing.module.ts
+++ b/front-end/src/app/app-routing.module.ts
@@ -14,11 +14,14 @@ const routes: Routes = [
     resolve: { singleClick: SingleClickResolver },
     runGuardsAndResolvers: 'always',
     children: [
-      { path: 'committee', loadChildren: () => import('./committee/committee.module').then((m) => m.CommitteeModule) },
+      {
+        path: 'committee',
+        loadChildren: () => import('./committee/committee.module').then((m) => m.CommitteeModule),
+      },
       {
         path: '',
         pathMatch: 'full',
-        redirectTo: 'dashboard',
+        redirectTo: 'reports',
       },
       {
         path: 'dashboard',
@@ -74,4 +77,4 @@ const routes: Routes = [
   ],
   exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/front-end/src/app/committee/select-committee/select-committee.component.ts
+++ b/front-end/src/app/committee/select-committee/select-committee.component.ts
@@ -15,11 +15,12 @@ import { concatMap, forkJoin, map, of } from 'rxjs';
 })
 export class SelectCommitteeComponent extends DestroyerComponent implements OnInit {
   committees?: CommitteeAccount[];
+
   constructor(
     protected committeeAccountService: CommitteeAccountService,
     protected fecApiService: FecApiService,
     protected store: Store,
-    protected router: Router
+    protected router: Router,
   ) {
     super();
   }
@@ -33,19 +34,19 @@ export class SelectCommitteeComponent extends DestroyerComponent implements OnIn
             return this.fecApiService.getCommitteeDetails(committee.committee_id || '').pipe(
               map((fecCommittee: CommitteeAccount) => {
                 return { ...committee, ...fecCommittee } as CommitteeAccount;
-              })
+              }),
             );
           });
           return augmented.length ? forkJoin(augmented) : of([]);
-        })
+        }),
       )
       .subscribe((committees) => (this.committees = committees));
   }
 
   activateCommittee(committee: CommitteeAccount): void {
-    this.committeeAccountService.activateCommittee(committee.id).subscribe(() => {
+    this.committeeAccountService.activateCommittee(committee.id).subscribe(async () => {
       this.store.dispatch(setCommitteeAccountDetailsAction({ payload: committee }));
-      this.router.navigateByUrl(`dashboard`);
+      await this.router.navigateByUrl(``);
     });
   }
 }


### PR DESCRIPTION
Update base redirect to go to reports instead of dashboard and also update committee select to go to base page instead of dashboard