### PR TITLE
1872 - Use cloud.gov buildpack instead of pulling from cloudfoundry GitHub link

### DIFF
--- a/deploy-config/fecfile-web-app-dev-manifest.yml
+++ b/deploy-config/fecfile-web-app-dev-manifest.yml
@@ -2,7 +2,7 @@ applications:
   - name: fecfile-web-app
     instances: 2
     memory: 1G
-    buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+    buildpack: nginx_buildpack
     stack: cflinuxfs4
 
     routes:

--- a/deploy-config/fecfile-web-app-prod-manifest.yml
+++ b/deploy-config/fecfile-web-app-prod-manifest.yml
@@ -2,7 +2,7 @@ applications:
   - name: fecfile-web-app
     instances: 2
     memory: 1G
-    buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+    buildpack: nginx_buildpack
     stack: cflinuxfs4
 
     routes:

--- a/deploy-config/fecfile-web-app-stage-manifest.yml
+++ b/deploy-config/fecfile-web-app-stage-manifest.yml
@@ -2,7 +2,7 @@ applications:
   - name: fecfile-web-app
     instances: 2
     memory: 1G
-    buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+    buildpack: nginx_buildpack
     stack: cflinuxfs4
 
     routes:

--- a/deploy-config/front-end-nginx-config/buildpack.yml
+++ b/deploy-config/front-end-nginx-config/buildpack.yml
@@ -1,3 +1,0 @@
----
-nginx:
-  version: mainline

--- a/deploy-config/front-end-nginx-config/manifest.yml
+++ b/deploy-config/front-end-nginx-config/manifest.yml
@@ -1,6 +1,0 @@
-applications:
- - name: fecfile-online-frontend
-   instances: 1
-   memory: 256M
-   buildpack: paketo-buildpacks/nginx
-


### PR DESCRIPTION
Issue #1872

We should be using cloud.gov's `nginx_buildpack` because it's reviewed by cloud.gov to make sure there are no breaking changes or build errors. When we pull directly from cloud foundry, the deploy automatically pulls the latest buildpack without checking for errors. 