### PR TITLE
feature/858 - Update line_label_order_key to line_label sorting as the transaction tables display line_label

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-list/transaction-disbursements/transaction-disbursements.component.html
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-disbursements/transaction-disbursements.component.html
@@ -12,7 +12,7 @@
     [loading]="loading"
     currentPageReportTemplate="Showing {first} to {last} of {totalRecords} transactions"
     [showCurrentPageReport]="true"
-    sortField="line_label_order_key,created"
+    sortField="line_label,created"
     styleClass="p-datatable-striped"
   >
     <ng-template pTemplate="caption">
@@ -35,7 +35,7 @@
     </ng-template>
     <ng-template pTemplate="header">
       <tr role="row">
-        <th pSortableColumn="line_label_order_key" id="line-label-column" role="columnheader">
+        <th pSortableColumn="line_label" id="line-label-column" role="columnheader">
           Line
           <p-sortIcon field="line_label_order_key"></p-sortIcon>
         </th>

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-disbursements/transaction-disbursements.component.html
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-disbursements/transaction-disbursements.component.html
@@ -37,7 +37,7 @@
       <tr role="row">
         <th pSortableColumn="line_label" id="line-label-column" role="columnheader">
           Line
-          <p-sortIcon field="line_label_order_key"></p-sortIcon>
+          <p-sortIcon field="line_label"></p-sortIcon>
         </th>
         <th pSortableColumn="transaction_type_identifier" id="transaction-type-identifier-column" role="columnheader">
           Type

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.html
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.html
@@ -12,7 +12,7 @@
     [loading]="loading"
     currentPageReportTemplate="Showing {first} to {last} of {totalRecords} transactions"
     [showCurrentPageReport]="true"
-    sortField="line_label_order_key,created"
+    sortField="line_label,created"
     styleClass="p-datatable-striped"
   >
     <ng-template pTemplate="caption">

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-loans-and-debts/transaction-loans-and-debts.component.ts
@@ -25,7 +25,7 @@ export class TransactionLoansAndDebtsComponent extends TransactionListTableBaseC
   ];
 
   sortableHeaders = [
-    { field: 'line_label_order_key', label: 'Line' },
+    { field: 'line_label', label: 'Line' },
     { field: 'transaction_type_identifier', label: 'Type' },
     { field: 'name', label: 'Name' },
     { field: 'date', label: 'Date incurred' },

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.html
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.html
@@ -12,7 +12,7 @@
     [loading]="loading"
     currentPageReportTemplate="Showing {first} to {last} of {totalRecords} transactions"
     [showCurrentPageReport]="true"
-    sortField="line_label_order_key,created"
+    sortField="line_label,created"
     styleClass="p-datatable-striped"
   >
     <ng-template pTemplate="caption">
@@ -35,9 +35,9 @@
     </ng-template>
     <ng-template pTemplate="header">
       <tr role="row">
-        <th pSortableColumn="line_label_order_key" id="line-label-column" role="columnheader">
+        <th pSortableColumn="line_label" id="line-label-column" role="columnheader">
           Line
-          <p-sortIcon field="line_label_order_key"></p-sortIcon>
+          <p-sortIcon field="line_label"></p-sortIcon>
         </th>
         <th pSortableColumn="transaction_type_identifier" id="transaction-type-identifier-column" role="columnheader">
           Type

--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -60,7 +60,7 @@ describe('TransactionService', () => {
       });
 
       const req = httpTestingController.expectOne(
-        `${environment.apiUrl}/transactions/?page=1&ordering=line_label_order_key`,
+        `${environment.apiUrl}/transactions/?page=1&ordering=line_label`,
       );
       expect(req.request.method).toEqual('GET');
       req.flush(mockResponse);

--- a/front-end/src/app/shared/services/transaction.service.ts
+++ b/front-end/src/app/shared/services/transaction.service.ts
@@ -28,7 +28,7 @@ export class TransactionService implements TableListService<Transaction> {
     params: { [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean> } = {},
   ): Observable<ListRestResponse> {
     if (!ordering) {
-      ordering = 'line_label_order_key';
+      ordering = 'line_label';
     }
     return this.apiService
       .get<ListRestResponse>(`${this.tableDataEndpoint}/?page=${pageNumber}&ordering=${ordering}`, params)


### PR DESCRIPTION
Issue: [#858](https://github.com/fecgov/fecfile-web-api/issues/858)

API PR: [PR867](https://github.com/fecgov/fecfile-web-api/pull/867)