### PR TITLE
feature/1889 - Move version_label from front end to back to allow for sorting

### DIFF
--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -57,9 +57,9 @@
           Status
           <p-sortIcon field="report_status"></p-sortIcon>
         </th>
-        <th pSortableColumn="form_type" id="version" role="columnheader">
+        <th pSortableColumn="version_label" id="version" role="columnheader">
           Version
-          <p-sortIcon field="form_type"></p-sortIcon>
+          <p-sortIcon field="version_label"></p-sortIcon>
         </th>
         <th pSortableColumn="upload_submission__created" id="date-filed-column" role="columnheader">
           Date filed
@@ -78,7 +78,7 @@
           </ng-container>
         </td>
         <td>{{ item.report_status }}</td>
-        <td>{{ item.versionLabel }}</td>
+        <td>{{ item.version_label }}</td>
         <td>{{ item.upload_submission?.created | fecDate }}</td>
         <td>
           <app-table-actions-button

--- a/front-end/src/app/shared/models/form-1m.model.spec.ts
+++ b/front-end/src/app/shared/models/form-1m.model.spec.ts
@@ -24,28 +24,4 @@ describe('Form-1M', () => {
     const form = Form1M.fromJSON(data);
     expect(form.formSubLabel).toEqual('NOTIFICATION OF MULTICANDIDATE STATUS');
   });
-
-  describe('versionLabel', () => {
-    it('should return just version label if report version is undefined', () => {
-      const data = {
-        id: '999',
-        form_type: F1MFormTypes.F1MN,
-        committee_name: 'foo',
-        report_version: undefined,
-      };
-      const form = Form1M.fromJSON(data);
-      expect(form.versionLabel).toEqual('Original');
-    });
-
-    it('should also display report version if defined', () => {
-      const data = {
-        id: '999',
-        form_type: F1MFormTypes.F1MN,
-        committee_name: 'foo',
-        report_version: '1',
-      };
-      const form = Form1M.fromJSON(data);
-      expect(form.versionLabel).toEqual('Original 1');
-    });
-  });
 });

--- a/front-end/src/app/shared/models/form-1m.model.ts
+++ b/front-end/src/app/shared/models/form-1m.model.ts
@@ -14,11 +14,6 @@ export enum F1MFormTypes {
   F1MA = 'F1MA',
 }
 
-export const F1MFormVersionLabels: { [key in F1MFormTypes]: string } = {
-  [F1MFormTypes.F1MN]: 'Original',
-  [F1MFormTypes.F1MA]: 'Amendment',
-};
-
 export type CommitteeType = CommitteeTypes.STATE_PTY | CommitteeTypes.OTHER;
 
 export class Form1M extends Report {
@@ -38,10 +33,6 @@ export class Form1M extends Report {
 
   get reportLabel(): string {
     return '';
-  }
-
-  get versionLabel() {
-    return `${F1MFormVersionLabels[this.form_type]} ${this.report_version ?? ''}`.trim();
   }
 
   committee_type?: CommitteeType;

--- a/front-end/src/app/shared/models/form-24.model.spec.ts
+++ b/front-end/src/app/shared/models/form-24.model.spec.ts
@@ -38,30 +38,6 @@ describe('Form24', () => {
     expect(form.formSubLabel).toEqual('');
   });
 
-  describe('versionLabel', () => {
-    it('should return just version label if report version is undefined', () => {
-      const data = {
-        id: '999',
-        form_type: F24FormTypes.F24N,
-        committee_name: 'foo',
-        report_version: undefined,
-      };
-      const form = Form24.fromJSON(data);
-      expect(form.versionLabel).toEqual('Original');
-    });
-
-    it('should also display report version if defined', () => {
-      const data = {
-        id: '999',
-        form_type: F24FormTypes.F24N,
-        committee_name: 'foo',
-        report_version: '1',
-      };
-      const form = Form24.fromJSON(data);
-      expect(form.versionLabel).toEqual('Original 1');
-    });
-  });
-
   describe('getReportLabel', () => {
     it('should return 24 or 48 depending upon 24_48 prop', () => {
       const data = {

--- a/front-end/src/app/shared/models/form-24.model.ts
+++ b/front-end/src/app/shared/models/form-24.model.ts
@@ -10,11 +10,6 @@ export enum F24FormTypes {
 
 export type F24FormType = F24FormTypes.F24N | F24FormTypes.F24A;
 
-export const F24FormVersionLabels: { [key in F24FormTypes]: string } = {
-  [F24FormTypes.F24N]: 'Original',
-  [F24FormTypes.F24A]: 'Amendment',
-};
-
 export class Form24 extends Report {
   schema = f24Schema;
   report_type = ReportTypes.F24;
@@ -30,10 +25,6 @@ export class Form24 extends Report {
 
   get reportLabel(): string {
     return `${this.report_type_24_48} HOUR`;
-  }
-
-  get versionLabel() {
-    return `${F24FormVersionLabels[this.form_type]} ${this.report_version ?? ''}`.trim();
   }
 
   override get canAmend(): boolean {

--- a/front-end/src/app/shared/models/form-3x.model.spec.ts
+++ b/front-end/src/app/shared/models/form-3x.model.spec.ts
@@ -80,28 +80,4 @@ describe('Form3X', () => {
       expect(form3X.formSubLabel).toEqual('APRIL 15 QUARTERLY REPORT (Q1)');
     });
   });
-
-  describe('versionLabel', () => {
-    it('should return just version label if report version is undefined', () => {
-      const data = {
-        id: '999',
-        form_type: F3xFormTypes.F3XN,
-        committee_name: 'foo',
-        report_version: undefined,
-      };
-      const form3X = Form3X.fromJSON(data);
-      expect(form3X.versionLabel).toEqual('Original');
-    });
-
-    it('should also display report version if defined', () => {
-      const data = {
-        id: '999',
-        form_type: F3xFormTypes.F3XN,
-        committee_name: 'foo',
-        report_version: '1',
-      };
-      const form3X = Form3X.fromJSON(data);
-      expect(form3X.versionLabel).toEqual('Original 1');
-    });
-  });
 });

--- a/front-end/src/app/shared/models/form-3x.model.ts
+++ b/front-end/src/app/shared/models/form-3x.model.ts
@@ -12,12 +12,6 @@ export enum F3xFormTypes {
 
 export type F3xFormType = F3xFormTypes.F3XN | F3xFormTypes.F3XA | F3xFormTypes.F3XT;
 
-export const F3xFormVersionLabels: { [key in F3xFormTypes]: string } = {
-  [F3xFormTypes.F3XN]: 'Original',
-  [F3xFormTypes.F3XA]: 'Amendment',
-  [F3xFormTypes.F3XT]: 'Termination',
-};
-
 export class F3xCoverageDates {
   @Transform(BaseModel.dateTransform) coverage_from_date: Date | undefined;
   @Transform(BaseModel.dateTransform) coverage_through_date: Date | undefined;
@@ -176,10 +170,6 @@ export class Form3X extends Report {
 
   get reportLabel(): string {
     return getReportCodeLabel(this.reportCode) ?? '';
-  }
-
-  get versionLabel() {
-    return `${F3xFormVersionLabels[this.form_type]} ${this.report_version ?? ''}`.trim();
   }
 
   static fromJSON(json: unknown): Form3X {

--- a/front-end/src/app/shared/models/form-99.model.spec.ts
+++ b/front-end/src/app/shared/models/form-99.model.spec.ts
@@ -34,7 +34,7 @@ describe('Form99', () => {
         id: '999',
         form_type: F99FormTypes.F99,
         committee_name: 'foo',
-        text_code: undefined
+        text_code: undefined,
       };
       const form = Form99.fromJSON(data);
       expect(form.formSubLabel).toEqual('');
@@ -45,34 +45,10 @@ describe('Form99', () => {
         id: '999',
         form_type: F99FormTypes.F99,
         committee_name: 'foo',
-        text_code: 'MSI'
+        text_code: 'MSI',
       };
       const form = Form99.fromJSON(data);
       expect(form.formSubLabel).toEqual('Disavowal Response');
-    });
-  });
-
-  describe('versionLabel', () => {
-    it('should return just version label if report version is undefined', () => {
-      const data = {
-        id: '999',
-        form_type: F99FormTypes.F99,
-        committee_name: 'foo',
-        report_version: undefined
-      };
-      const form = Form99.fromJSON(data);
-      expect(form.versionLabel).toEqual('Original');
-    });
-
-    it('should also display report version if defined', () => {
-      const data = {
-        id: '999',
-        form_type: F99FormTypes.F99,
-        committee_name: 'foo',
-        report_version: '1'
-      };
-      const form = Form99.fromJSON(data);
-      expect(form.versionLabel).toEqual('Original 1');
     });
   });
 });

--- a/front-end/src/app/shared/models/form-99.model.ts
+++ b/front-end/src/app/shared/models/form-99.model.ts
@@ -9,10 +9,6 @@ export enum F99FormTypes {
 
 export type F99FormType = F99FormTypes.F99;
 
-export const F99FormVersionLabels: { [key in F99FormTypes]: string } = {
-  [F99FormTypes.F99]: 'Original',
-};
-
 export class Form99 extends Report {
   schema = f99Schema;
   report_type = ReportTypes.F99;
@@ -30,10 +26,6 @@ export class Form99 extends Report {
 
   get reportLabel(): string {
     return '';
-  }
-
-  get versionLabel() {
-    return `${F99FormVersionLabels[this.form_type]} ${this.report_version ?? ''}`.trim();
   }
 
   treasurer_last_name: string | undefined;

--- a/front-end/src/app/shared/models/report.model.ts
+++ b/front-end/src/app/shared/models/report.model.ts
@@ -39,12 +39,11 @@ export abstract class Report extends BaseModel {
   @Transform(BaseModel.dateTransform)
   updated: Date | undefined;
   can_delete = false;
+  version_label?: string;
 
   abstract get formLabel(): string;
 
   abstract get formSubLabel(): string;
-
-  abstract get versionLabel(): string;
 
   abstract get reportLabel(): string;
 


### PR DESCRIPTION
Issue #1889 
API PR [PR868](https://github.com/fecgov/fecfile-web-api/pull/868)