### PR TITLE
Fix committee select underline and confirmation info button alignment

### DIFF
--- a/front-end/src/app/committee/select-committee/select-committee.component.html
+++ b/front-end/src/app/committee/select-committee/select-committee.component.html
@@ -4,7 +4,7 @@
     <h5 class="font-karla-bold">LET'S FILE YOUR FEC REPORT WITH FECFILE...</h5>
     <p-divider></p-divider>
 
-    <img src="assets/img/person-filing.jpg" draggable="false" alt="Person filing image"/>
+    <img src="assets/img/person-filing.jpg" draggable="false" alt="Person filing image" />
   </div>
   <div class="col-6 right-side">
     <div class="select-committee-box">
@@ -12,7 +12,7 @@
       <ng-container *ngIf="committees?.length === 0">
         <div class="committee-card empty-card">
           <div class="empty-lens-img">
-            <img alt="Magnifying lens" src="assets/img/magnifying_lens.svg"/>
+            <img alt="Magnifying lens" src="assets/img/magnifying_lens.svg" />
           </div>
           <div class="empty-verbiage">
             <p class="font-karla-bold">Not currently active in any FECFile committee accounts</p>
@@ -22,9 +22,11 @@
       <ng-container *ngIf="committees?.length">
         <div class="committee-list">
           <div class="committee-card" *ngFor="let committee of committees" (click)="activateCommittee(committee)">
-            <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg"/>
+            <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg" />
             <div class="committee-info">
-              <h3>{{ committee.name }}</h3>
+              <h3>
+                <span>{{ committee.name }}</span>
+              </h3>
               <h5 class="font-karla-bold">{{ committee.committee_id }}</h5>
             </div>
           </div>
@@ -36,7 +38,7 @@
     <div class="create-committee-card font-karla-bold" routerLink="/login/register-committee">
       <div class="blue-box">
         <div class="plus">
-          <img src="assets/img/blue-plus.png"/>
+          <img src="assets/img/blue-plus.png" />
         </div>
       </div>
 

--- a/front-end/src/app/committee/select-committee/select-committee.component.scss
+++ b/front-end/src/app/committee/select-committee/select-committee.component.scss
@@ -1,92 +1,92 @@
-
 .committee-card {
-    margin: 20px 3px;
-    padding: 20px 10px;
-    display: flex;
-    flex-direction: row;
-    background-color: #ffffff;
-    box-shadow: 0 0 4px 0px #d1d1d1
+  margin: 20px 3px;
+  padding: 20px 10px;
+  display: flex;
+  flex-direction: row;
+  background-color: #ffffff;
+  box-shadow: 0 0 4px 0px #d1d1d1;
 }
 .empty-card {
-    height: 200px;
-    flex-direction: column;
+  height: 200px;
+  flex-direction: column;
 }
 .empty-lens-img {
-    height: 95px;
-    display: flex;
+  height: 95px;
+  display: flex;
 }
 .empty-verbiage {
-    width: 65%;
-    align-self: center;
-    margin-top: 10px;
+  width: 65%;
+  align-self: center;
+  margin-top: 10px;
 }
 .empty-verbiage p {
-    text-align: center;
-    font-size: x-large; 
-    line-height: normal;
+  text-align: center;
+  font-size: x-large;
+  line-height: normal;
 }
 .left-side {
-    flex-direction: column;
+  flex-direction: column;
 }
 .right-side {
-    flex-direction: column;
+  flex-direction: column;
 }
 .select-committee-box {
-    display: flex;
-    background-color: #f1f1f1;
-    flex-direction: column;
-    padding: 15px;
-    border-radius: 5px;
+  display: flex;
+  background-color: #f1f1f1;
+  flex-direction: column;
+  padding: 15px;
+  border-radius: 5px;
 }
-.select-committee-columns{
-    display: flex;
-    flex-direction: row;
+.select-committee-columns {
+  display: flex;
+  flex-direction: row;
 }
 .create-committee-card {
-    border-radius: 5px;
-    background-color: #f1f1f1;
-    margin-top: 20px;
-    font-size: large;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
+  border-radius: 5px;
+  background-color: #f1f1f1;
+  margin-top: 20px;
+  font-size: large;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
 
-    .blue-box{
-        padding: 15px;
-        background-color: #132947;
-        border-radius: 5px 0px 0px 5px;
-    }
-    .plus {
-        background-color: #ffffff;
-        padding: 13px;
-        border-radius: 100px;
-    }
-    .create-text {
-        padding:20px;
-        font-size: medium;
-        text-transform: uppercase;
-    }
+  .blue-box {
+    padding: 15px;
+    background-color: #132947;
+    border-radius: 5px 0px 0px 5px;
+  }
+  .plus {
+    background-color: #ffffff;
+    padding: 13px;
+    border-radius: 100px;
+  }
+  .create-text {
+    padding: 20px;
+    font-size: medium;
+    text-transform: uppercase;
+  }
 }
 
-
 .committee-list {
-    max-height: 500px;
-    overflow-y: auto;
+  max-height: 500px;
+  overflow-y: auto;
 }
 
 .committee-info {
-    padding-left: 10px;
-    h3 {
-        border-bottom: dotted 2px;
-        border-color: #d1d1d1;
-        margin:0;
-        cursor: pointer;
-    }
+  padding-left: 10px;
+  h3 {
+    margin: 0;
+    cursor: pointer;
+  }
+  span {
+    border-bottom: dotted 2px;
+    border-color: #d1d1d1;
+  }
 }
 
 h2 {
-    margin:0;
+  margin: 0;
 }
 h5 {
-    margin-bottom:0;
+  margin-bottom: 0;
 }

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -1,13 +1,12 @@
 @import 'intl-tel-input/build/css/intlTelInput.css';
 
-
 p {
   max-width: 100%;
   line-height: 1.5;
 }
 
 hr {
-  margin: .5rem .5rem 1rem 0;
+  margin: 0.5rem 0 1rem 0;
   color: inherit;
   border: 0;
   border-top: 2px solid;
@@ -118,12 +117,30 @@ label.disabled {
 }
 
 .font-karla {
-  font-family: karla, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  font-family:
+    karla,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
 }
 
 .font-karla-bold {
-  font-family: karla-bold, karla, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
-  Segoe UI Symbol;
+  font-family:
+    karla-bold,
+    karla,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
 }
 
 .fec-background-gradient {


### PR DESCRIPTION
Fixes for:

1. The underline of the committees on the select committee page was not wrapping properly with the name of the committee.
2. The alignment of the "Confirmation information" button on the CONFIRMATION INFO page for a report was not in proper vertical alignment with the hard rules on the page.