### PR TITLE
feature/1977 - Fix issue with report list type label

### DIFF
--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -39,7 +39,7 @@
   </ng-template>
   <ng-template #body let-item>
     <td>{{ item.formLabel }}</td>
-    <td>{{ item.reportLabel }}</td>
+    <td>{{ item.report_code_label }}</td>
     <td>
       <ng-container *ngIf="item.coverage_from_date || item.coverage_through_date"
         >{{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}


### PR DESCRIPTION
#1977 

I missed a part in the html where in was using the old front-end generated report code label instead of the backend version, which led to some breaking e2e tests.
Fixed and double checked for other usages but this was the only one.
There's a passing e2e test on the previous build in circle.