### PR TITLE
feature/1987 memo item should be required on redesignation from

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/reatt-redes-transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/reatt-redes-transaction-type-base.component.ts
@@ -34,14 +34,6 @@ export abstract class ReattRedesTransactionTypeBaseComponent
 
   override async ngOnInit(): Promise<void> {
     super.ngOnInit();
-    // If the parent is a reattribution/redesignation transaction, initialize
-    // its specialized validation rules and form element behavior.
-    ReattRedesUtils.overlayForms(
-      this.form,
-      this.transaction as SchATransaction | SchBTransaction,
-      this.childForm,
-      this.childTransaction as SchATransaction | SchBTransaction,
-    );
     this.childUpdateFormWithPrimaryContact({
       value: this.transaction?.reatt_redes?.contact_1,
     } as SelectItem);
@@ -60,7 +52,15 @@ export abstract class ReattRedesTransactionTypeBaseComponent
       } as SelectItem);
       this.updateElectionData();
     }
-    await this.initializePullForward();
+    this.initializePullForward();
+    // If the parent is a reattribution/redesignation transaction, initialize
+    // its specialized validation rules and form element behavior.
+    ReattRedesUtils.overlayForms(
+      this.form,
+      this.transaction as SchATransaction | SchBTransaction,
+      this.childForm,
+      this.childTransaction as SchATransaction | SchBTransaction,
+    );
   }
 
   override processPayload(payload: SchATransaction | SchBTransaction, navigationEvent: NavigationEvent) {

--- a/front-end/src/app/shared/utils/reatt-redes/redesignation-from.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/redesignation-from.utils.spec.ts
@@ -1,6 +1,6 @@
-import { getTestTransactionByType, testScheduleBTransaction } from '../unit-test.utils';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { SchBTransaction, ScheduleBTransactionTypes } from '../../models/schb-transaction.model';
+import { getTestTransactionByType, testScheduleBTransaction } from '../unit-test.utils';
 import { RedesignationFromUtils } from './redesignation-from.utils';
 
 describe('Redesignation From', () => {
@@ -44,6 +44,8 @@ describe('Redesignation From', () => {
       expect(fromForm.get('expenditure_purpose_descrip')?.enabled).toBeTrue();
       RedesignationFromUtils.overlayForm(fromForm, transaction, toForm);
       expect(fromForm.get('expenditure_purpose_descrip')?.enabled).toBeFalse();
+      expect(fromForm.get('memo_code')?.hasValidator(Validators.requiredTrue)).toBeTrue();
+      expect(fromForm.get('memo_code')?.value).toBeTrue();
 
       toForm.get('expenditure_amount')?.setValue('5');
       expect(fromForm.get('expenditure_amount')?.value).toBe(-5);

--- a/front-end/src/app/shared/utils/reatt-redes/redesignation-from.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/redesignation-from.utils.ts
@@ -1,8 +1,8 @@
-import { ReattRedesTypes } from './reatt-redes.utils';
-import { FormGroup } from '@angular/forms';
-import { TemplateMapKeyType } from '../../models/transaction-type.model';
+import { FormGroup, Validators } from '@angular/forms';
 import { SchBTransaction } from '../../models/schb-transaction.model';
+import { TemplateMapKeyType } from '../../models/transaction-type.model';
 import { DateUtils } from '../date.utils';
+import { ReattRedesTypes } from './reatt-redes.utils';
 
 export class RedesignationFromUtils {
   private static readOnlyFields = [
@@ -36,6 +36,7 @@ export class RedesignationFromUtils {
     'candidate_office',
     'candidate_state',
     'candidate_district',
+    'memo_code',
   ];
 
   public static overlayTransactionProperties(
@@ -85,6 +86,7 @@ export class RedesignationFromUtils {
     // Update purpose description for rules that are independent of the transaction date being in the report.
     purposeDescriptionControl?.clearValidators();
     fromForm.get('memo_code')?.clearValidators();
+    fromForm.get('memo_code')?.addValidators(Validators.requiredTrue);
     fromForm.get('memo_code')?.setValue(true);
 
     // Watch for changes to the "TO" transaction amount and copy the negative of it to the "FROM" transaction amount.


### PR DESCRIPTION
https://github.com/fecgov/fecfile-web-app/issues/1987

There were two fixes here:
1) to get the memo code to be readonly, we had to add it to the RedesignationFromUtils readOnlyFields
2) to get (OPTIONAL) to be removed from memo code, we had to add the required validator to memo code and move the overlayForms call after initializePullForward so the label is recalculated after the validator was added.