### PR TITLE
hotfix/843 - Update 'Itemize' option to include when value was stored as null

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -70,7 +70,7 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
       'Itemize',
       this.forceItemize.bind(this),
       (transaction: Transaction) =>
-        transaction.itemized === false &&
+        !transaction.itemized &&
         this.reportIsEditable &&
         this.report?.report_type !== ReportTypes.F24 &&
         !transaction.parent_transaction &&


### PR DESCRIPTION
Issue [FECFILE-1458](https://fecgov.atlassian.net/browse/FECFILE-1458)

The issue with why 'Itemize' wasn't showing up as an option was because the _itemize field was being stored in the sql view as NULL instead of False. And on the front-end we were specifically evaluating against false instead of falsy, which would include null or undefined.