### PR TITLE
feature/1464 - Fix confirmation dialog getting activated multiple times when more than one table on page.

### DIFF
--- a/front-end/src/app/app.component.html
+++ b/front-end/src/app/app.component.html
@@ -1,4 +1,5 @@
 <div>
   <router-outlet></router-outlet>
+  <p-confirmDialog></p-confirmDialog>
   <app-download-tray></app-download-tray>
 </div>

--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { SharedModule } from './shared/shared.module';
 import { UsersModule } from './users/users.module';
 import { SchedulerAction, asyncScheduler } from 'rxjs';
 import { ReportsModule } from './reports/reports.module';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 
 // Save ngrx store to localStorage dynamically
 function localStorageSyncReducer(reducer: ActionReducer<AppState>): ActionReducer<AppState> {
@@ -127,6 +128,7 @@ const metaReducers: Array<MetaReducer<AppState, Action>> = [localStorageSyncRedu
     OverlayPanelModule,
     SharedModule,
     ReportsModule,
+    ConfirmDialogModule,
   ],
   providers: [
     CookieService,

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -256,6 +256,7 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
 
   public forceItemization(transaction: Transaction, itemized: boolean) {
     this.confirmationService.confirm({
+      key: 'transaction-itemization-dialog',
       message:
         'Changing the itemization status of this transaction will affect its associated transactions (such as memos).',
       header: 'Heads up!',

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list.component.html
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list.component.html
@@ -37,7 +37,7 @@
   ></app-transaction-loans-and-debts>
 </div>
 
-<p-confirmDialog #cd [style]="{ width: '450px' }">
+<p-confirmDialog #cd [style]="{ width: '450px' }" key="transaction-itemization-dialog">
   <ng-template pTemplate="footer">
     <span class="confirm-footer">
       <button type="button" pButton class="p-button-secondary" label="Cancel" (click)="cd.reject()"></button>

--- a/front-end/src/app/shared/components/table/table.component.html
+++ b/front-end/src/app/shared/components/table/table.component.html
@@ -130,4 +130,3 @@
 </div>
 
 <p-toast></p-toast>
-<p-confirmDialog></p-confirmDialog>


### PR DESCRIPTION
Issue: [FECFILE-1464](https://fecgov.atlassian.net/browse/FECFILE-1464)

The underlying problem was that the refactored Table component had a Confirmation Dialog inside of it. Which was fine if there was only ever a single table on the page or if you didn't want to style it. This was a problem for the Table List page as we had 3 tables on the page, leading to all three triggering an instance of the Table's Confirmation Dialog.

To fix this I removed the Confirmation Dialog from the Table and placed a default/fallback instance of the Confirmation Dialog at the top App level. Now, there would only be one instance. I also added a key to the Confirmation Dialog on the Table List page so it would specifically open that version, which has the correctly customized footer.