### PR TITLE
feature/1465 - Update Form 1M to use the report_code_label now coming from api. Update Report list coverage to default to N/A when no coverage

### DIFF
--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -40,9 +40,10 @@
     <td>{{ item.formLabel }}</td>
     <td>{{ item.report_code_label }}</td>
     <td>
-      <ng-container *ngIf="item.coverage_from_date || item.coverage_through_date"
+      <ng-container *ngIf="item.coverage_from_date || item.coverage_through_date; else noCoverage"
         >{{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}
       </ng-container>
+      <ng-template #noCoverage> N/A </ng-template>
     </td>
     <td>{{ item.report_status }}</td>
     <td>{{ item.version_label }}</td>

--- a/front-end/src/app/shared/models/form-1m.model.spec.ts
+++ b/front-end/src/app/shared/models/form-1m.model.spec.ts
@@ -15,11 +15,12 @@ describe('Form-1M', () => {
     expect(form.formLabel).toEqual('FORM 1M');
   });
 
-  it('should display empty string for sub label', () => {
+  it('should display "NOTIFICATION OF MULTICANDIDATE STATUS" for sub label', () => {
     const data = {
       id: '999',
       form_type: F1MFormTypes.F1MN,
       committee_name: 'foo',
+      report_code_label: 'NOTIFICATION OF MULTICANDIDATE STATUS',
     };
     const form = Form1M.fromJSON(data);
     expect(form.formSubLabel).toEqual('NOTIFICATION OF MULTICANDIDATE STATUS');

--- a/front-end/src/app/shared/models/form-1m.model.spec.ts
+++ b/front-end/src/app/shared/models/form-1m.model.spec.ts
@@ -25,4 +25,15 @@ describe('Form-1M', () => {
     const form = Form1M.fromJSON(data);
     expect(form.formSubLabel).toEqual('NOTIFICATION OF MULTICANDIDATE STATUS');
   });
+
+  it('should display empty string for sub label', () => {
+    const data = {
+      id: '999',
+      form_type: F1MFormTypes.F1MN,
+      committee_name: 'foo',
+      report_code_label: undefined,
+    };
+    const form = Form1M.fromJSON(data);
+    expect(form.formSubLabel).toEqual('');
+  });
 });

--- a/front-end/src/app/shared/models/form-1m.model.ts
+++ b/front-end/src/app/shared/models/form-1m.model.ts
@@ -28,7 +28,7 @@ export class Form1M extends Report {
   }
 
   get formSubLabel() {
-    return 'NOTIFICATION OF MULTICANDIDATE STATUS';
+    return this.report_code_label ?? '';
   }
 
   committee_type?: CommitteeType;


### PR DESCRIPTION
Issue [FECFILE-1465](https://fecgov.atlassian.net/browse/FECFILE-1465)
API PR: [PR986](https://github.com/fecgov/fecfile-web-api/pull/986)