### PR TITLE
Feature/1467 - form 99 report management entries

### DIFF
--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -38,7 +38,12 @@
   </ng-template>
   <ng-template #body let-item>
     <td>{{ item.formLabel }}</td>
-    <td>{{ item.report_code_label }}</td>
+    <td *ngIf="item.form_type === 'F99'; else default_report_label">
+      {{ (item.formSubLabel || 'Miscellaneous Report to the FEC').toUpperCase() }}
+    </td>
+    <ng-template #default_report_label>
+      <td>{{ item.report_code_label }}</td>
+    </ng-template>
     <td>
       <ng-container *ngIf="item.coverage_from_date || item.coverage_through_date"
         >{{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}

--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -40,9 +40,10 @@
     <td>{{ item.formLabel }}</td>
     <td>{{ item.report_code_label }}</td>
     <td>
-      <ng-container *ngIf="item.coverage_from_date || item.coverage_through_date"
+      <ng-container *ngIf="item.coverage_from_date || item.coverage_through_date; else noCoverage"
         >{{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}
       </ng-container>
+      <ng-template #noCoverage> N/A </ng-template>
     </td>
     <td>{{ item.report_status }}</td>
     <td>{{ item.version_label }}</td>

--- a/front-end/src/app/shared/models/form-1m.model.spec.ts
+++ b/front-end/src/app/shared/models/form-1m.model.spec.ts
@@ -15,11 +15,12 @@ describe('Form-1M', () => {
     expect(form.formLabel).toEqual('FORM 1M');
   });
 
-  it('should display empty string for sub label', () => {
+  it('should display "NOTIFICATION OF MULTICANDIDATE STATUS" for sub label', () => {
     const data = {
       id: '999',
       form_type: F1MFormTypes.F1MN,
       committee_name: 'foo',
+      report_code_label: 'NOTIFICATION OF MULTICANDIDATE STATUS',
     };
     const form = Form1M.fromJSON(data);
     expect(form.formSubLabel).toEqual('NOTIFICATION OF MULTICANDIDATE STATUS');

--- a/front-end/src/app/shared/models/form-1m.model.spec.ts
+++ b/front-end/src/app/shared/models/form-1m.model.spec.ts
@@ -25,4 +25,15 @@ describe('Form-1M', () => {
     const form = Form1M.fromJSON(data);
     expect(form.formSubLabel).toEqual('NOTIFICATION OF MULTICANDIDATE STATUS');
   });
+
+  it('should display empty string for sub label', () => {
+    const data = {
+      id: '999',
+      form_type: F1MFormTypes.F1MN,
+      committee_name: 'foo',
+      report_code_label: undefined,
+    };
+    const form = Form1M.fromJSON(data);
+    expect(form.formSubLabel).toEqual('');
+  });
 });

--- a/front-end/src/app/shared/models/form-1m.model.ts
+++ b/front-end/src/app/shared/models/form-1m.model.ts
@@ -28,7 +28,7 @@ export class Form1M extends Report {
   }
 
   get formSubLabel() {
-    return 'NOTIFICATION OF MULTICANDIDATE STATUS';
+    return this.report_code_label ?? '';
   }
 
   committee_type?: CommitteeType;

--- a/front-end/src/app/shared/models/form-99.model.spec.ts
+++ b/front-end/src/app/shared/models/form-99.model.spec.ts
@@ -36,7 +36,7 @@ describe('Form99', () => {
         ['MST', 'Miscellaneous Report to the FEC'],
         [undefined, ''],
       ];
-      for (let [textCode, label] of valueLabelPairs) {
+      for (const [textCode, label] of valueLabelPairs) {
         const data = {
           id: '999',
           form_type: F99FormTypes.F99,

--- a/front-end/src/app/shared/models/form-99.model.spec.ts
+++ b/front-end/src/app/shared/models/form-99.model.spec.ts
@@ -29,26 +29,23 @@ describe('Form99', () => {
   });
 
   describe('formSubLabel', () => {
-    it("should return empty string if textCodes isn't found", () => {
-      const data = {
-        id: '999',
-        form_type: F99FormTypes.F99,
-        committee_name: 'foo',
-        text_code: undefined,
-      };
-      const form = Form99.fromJSON(data);
-      expect(form.formSubLabel).toEqual('');
-    });
-
-    it('should display the text_code label if text_code is found', () => {
-      const data = {
-        id: '999',
-        form_type: F99FormTypes.F99,
-        committee_name: 'foo',
-        text_code: 'MSI',
-      };
-      const form = Form99.fromJSON(data);
-      expect(form.formSubLabel).toEqual('Disavowal Response');
+    it('should display the correct labels for each text code', () => {
+      const valueLabelPairs: [string | undefined, string][] = [
+        ['MSI', 'Disavowal Response'],
+        ['MSM', 'Filing Frequency Change Notice'],
+        ['MST', 'Miscellaneous Report to the FEC'],
+        [undefined, ''],
+      ];
+      for (let [textCode, label] of valueLabelPairs) {
+        const data = {
+          id: '999',
+          form_type: F99FormTypes.F99,
+          committee_name: 'foo',
+          text_code: textCode,
+        };
+        const form = Form99.fromJSON(data);
+        expect(form.formSubLabel).toEqual(label);
+      }
     });
   });
 });


### PR DESCRIPTION
[Fecfile #1467](https://fecgov.atlassian.net/browse/FECFILE-1467?atlOrigin=eyJpIjoiMDdiMjk4MzFiMjMzNDIwZTgxYjliZmM4MTYyY2U2ZjIiLCJwIjoiaiJ9)

Dependent on [this PR](https://github.com/fecgov/fecfile-web-app/pull/2059/files) which added "N/A" coverage date values on the Manage Reports table.