### PR TITLE
Feature/1481 Remove child and granchild purpose description updates from front end

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
@@ -248,9 +248,6 @@ export class TransactionFormUtils {
       payload['report_ids'] = [activeReportId, secondaryReportId];
     }
 
-    if (payload.children) {
-      payload.children = payload.updateChildren();
-    }
     // Reorganize the payload if this transaction type can update its parent transaction
     // This will break the scenario where the user creates a grandparent, then child, then tries
     // to create a grandchild transaction because we won't know which child transaction of the grandparent

--- a/front-end/src/app/shared/models/scha-transaction.model.spec.ts
+++ b/front-end/src/app/shared/models/scha-transaction.model.spec.ts
@@ -22,19 +22,6 @@ describe('SchATransaction', () => {
     expect(schATransaction.election_code).toBe(undefined);
   });
 
-  it('Updates the purpose description of a child transaction', () => {
-    const parentTransaction = getTestTransactionByType(
-      ScheduleATransactionTypes.INDIVIDUAL_NATIONAL_PARTY_CONVENTION_ACCOUNT,
-    ) as SchATransaction;
-    const childTransaction = getTestTransactionByType(
-      ScheduleATransactionTypes.INDIVIDUAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO,
-    ) as SchATransaction;
-    parentTransaction.children = [childTransaction];
-    parentTransaction.contributor_organization_name = 'Test Committee';
-    parentTransaction.updateChildren();
-    expect(childTransaction.contribution_purpose_descrip).toContain('Test Committee');
-  });
-
   it('Creates a transaction object from JSON', () => {
     const json = {
       transaction_type_identifier: 'EARMARK_RECEIPT',

--- a/front-end/src/app/shared/models/scha-transaction.model.spec.ts
+++ b/front-end/src/app/shared/models/scha-transaction.model.spec.ts
@@ -1,5 +1,4 @@
-import { getTestTransactionByType } from '../utils/unit-test.utils';
-import { SchATransaction, ScheduleATransactionTypes } from './scha-transaction.model';
+import { SchATransaction } from './scha-transaction.model';
 
 describe('SchATransaction', () => {
   it('should create an instance', () => {

--- a/front-end/src/app/shared/models/transaction.model.ts
+++ b/front-end/src/app/shared/models/transaction.model.ts
@@ -119,31 +119,6 @@ export abstract class Transaction extends BaseModel {
   }
 
   /**
-   * updateChildren()
-   * @returns
-   *    An array of Transaction objects whose contribution_purpose_descriptions
-   *    have been re-generated to account for changes to their parent
-   *
-   */
-  updateChildren(): Transaction[] {
-    const outChildren: Transaction[] = [];
-    if (this.children) {
-      for (const child of this.children as SchATransaction[]) {
-        // Modify the purpose description this to reflect the changes to child transactions
-        if (child?.transactionType?.generatePurposeDescription) {
-          child.parent_transaction = this;
-          const newDescrip = child.transactionType.generatePurposeDescriptionWrapper(child);
-          const key = child.transactionType.templateMap.purpose_description as keyof ScheduleTransaction;
-          ((child as ScheduleTransaction)[key] as string) = newDescrip;
-          child.updateChildren();
-        }
-        outChildren.push(child);
-      }
-    }
-    return outChildren;
-  }
-
-  /**
    * Returns a transaction payload with the parent of the original payload
    * swapped in as the main payload and the original main payload is a child
    * @returns
@@ -167,7 +142,6 @@ export abstract class Transaction extends BaseModel {
     if (!childDeleted) {
       payload.children.push(this);
     }
-    payload.children = payload.updateChildren();
 
     // Update the purpose description
     if (payload.transactionType?.generatePurposeDescription) {


### PR DESCRIPTION
Example: 
A JOINT_FUNDRAISING_TRANSFER with an INDIVIDUAL_JF_TRANSFER_MEMO child and
a PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO grandchild is updated.  The description for
the child will be "JF Memo: Committee Name" and the description for the grandchild will be
"JF Memo: Committee Name (Partnership Attribution)".  

This Branch removes that responsibility from the front end

Works with https://github.com/fecgov/fecfile-web-api/pull/1004