### PR TITLE
feature/1457 - Fix issue with e2e populating Candidate district field

### DIFF
--- a/front-end/src/app/shared/components/inputs/candidate-office-input/candidate-office-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/candidate-office-input/candidate-office-input.component.ts
@@ -90,9 +90,12 @@ export class CandidateOfficeInputComponent extends BaseInputComponent implements
         } else {
           this.candidateDistrictOptions = [];
         }
-        this.form
-          .get(this.districtFormControlName)
-          ?.setValue(this.candidateDistrictOptions.length === 1 ? this.candidateDistrictOptions[0].value : null);
+        const currentDistrictValue = this.form.get(this.districtFormControlName)?.value;
+        if (!this.candidateDistrictOptions.map((option) => option.value).includes(currentDistrictValue)) {
+          this.form
+            .get(this.districtFormControlName)
+            ?.setValue(this.candidateDistrictOptions.length === 1 ? this.candidateDistrictOptions[0].value : null);
+        }
       });
 
     // Run election_code, office, and state valueChange logic when initializing form elements


### PR DESCRIPTION
Issue [FECFILE-1457](https://fecgov.atlassian.net/jira/software/c/projects/FECFILE/issues/FECFILE-1457)

When that form gets autopopulated by the system it was populating both field values, but then the event change would happen and clear out the district choice if there was more than one option.