### PR TITLE
feature/1786 - Fix issue with lined report. Accidentally passed 'date' instead of templateMap['date'] value

### DIFF
--- a/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.ts
@@ -38,7 +38,9 @@ export class LinkedReportInputComponent extends BaseInputComponent implements On
       (this.form.get(this.templateMap['date']) as SubscriptionFormControl) ?? new SubscriptionFormControl();
     const date2Control =
       (this.form.get(this.templateMap['date2']) as SubscriptionFormControl) ?? new SubscriptionFormControl();
-    this.linkedF3xControl.addValidators(buildCorrespondingForm3XValidator(this.form, 'date', 'date2'));
+    this.linkedF3xControl.addValidators(
+      buildCorrespondingForm3XValidator(this.form, this.templateMap['date'], this.templateMap['date2']),
+    );
 
     dateControl.valueChanges
       .pipe(


### PR DESCRIPTION
Issue [FECFILE-1786](https://fecgov.atlassian.net/browse/FECFILE-1786)