### PR TITLE
feature/1786 - Fixed issue with interest rate and due date being cleared when loaded from backend

### DIFF
--- a/front-end/src/app/shared/components/app-destroyer.component.ts
+++ b/front-end/src/app/shared/components/app-destroyer.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
   template: '',
 })
 export abstract class DestroyerComponent implements OnDestroy {
-  protected destroy$ = new Subject();
+  protected destroy$ = new Subject<undefined>();
   ngOnDestroy(): void {
     this.destroy$.next(undefined);
     this.destroy$.complete();

--- a/front-end/src/app/shared/components/calendar/calendar.component.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.ts
@@ -18,24 +18,12 @@ export class CalendarComponent extends DestroyerComponent implements OnInit {
   @Input() requiredErrorMessage = 'This is a required field.';
 
   calendarOpened = false;
-  control!: SubscriptionFormControl;
+  control!: SubscriptionFormControl<Date | null>;
 
   ngOnInit(): void {
     const originalControl = this.form?.get(this.fieldName) as SubscriptionFormControl;
     const date = DateUtils.parseDate(originalControl.value);
-    this.control = new SubscriptionFormControl(date, {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      validators: (originalControl as any)._rawValidators,
-      asyncValidators: originalControl.asyncValidator,
-      updateOn: 'submit',
-    });
-
-    if (originalControl.disabled) this.control.disable();
-    originalControl.subscriptions.forEach((sub) => {
-      this.control.addSubscription(sub, this.destroy$);
-    });
-    if (originalControl.touched) this.control.markAsTouched();
-    if (originalControl.dirty) this.control.markAsDirty();
+    this.control = originalControl.copy<Date | null>(date, 'submit');
     this.form.setControl(this.fieldName, this.control);
   }
 

--- a/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.html
+++ b/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.html
@@ -26,8 +26,8 @@
         ></app-error-messages>
       </div>
     </div>
-    <ng-container *ngIf="this.form.get(templateMap['due_date_setting'])?.value === termFieldSettings.USER_DEFINED">
-      <div class="col-6">
+    <div class="col-6" [ngSwitch]="dueDateSetting">
+      <ng-container *ngSwitchCase="termFieldSettings.USER_DEFINED">
         <div class="field">
           <label for="due_date">DATE DUE (USER DEFINED)</label>
           <input type="text" pInputText inputId="due_date" [formControlName]="templateMap['due_date']" />
@@ -37,21 +37,18 @@
             [formSubmitted]="formSubmitted"
           ></app-error-messages>
         </div>
-      </div>
-    </ng-container>
-    <ng-container *ngIf="this.form.get(templateMap['due_date_setting'])?.value === termFieldSettings.SPECIFIC_DATE">
-      <div class="col-6">
+      </ng-container>
+      <ng-container *ngSwitchCase="termFieldSettings.SPECIFIC_DATE">
         <app-calendar
           [fieldName]="templateMap['due_date']"
           [form]="form"
           [formSubmitted]="formSubmitted"
           label="SPECIFIC DATE"
         ></app-calendar>
-      </div>
-    </ng-container>
-    <ng-container *ngIf="!this.form.get(templateMap['due_date_setting'])?.value">
-      <div class="col-6"></div>
-    </ng-container>
+      </ng-container>
+      <ng-container *ngSwitchDefault> </ng-container>
+    </div>
+
     <div class="col-6">
       <div class="field">
         <label for="interest_rate_setting">INTEREST RATE</label>
@@ -70,8 +67,8 @@
         </app-error-messages>
       </div>
     </div>
-    <ng-container *ngIf="this.form.get(templateMap['interest_rate_setting'])?.value === termFieldSettings.USER_DEFINED">
-      <div class="col-6">
+    <div class="col-6" [ngSwitch]="interestRateSetting">
+      <ng-container *ngSwitchCase="termFieldSettings.USER_DEFINED">
         <div class="field">
           <label for="interest_rate">INTEREST RATE (USER DEFINED)</label>
           <input type="text" pInputText id="interest_rate" [formControlName]="templateMap['interest_rate']" />
@@ -81,12 +78,8 @@
             [formSubmitted]="formSubmitted"
           ></app-error-messages>
         </div>
-      </div>
-    </ng-container>
-    <ng-container
-      *ngIf="this.form.get(templateMap['interest_rate_setting'])?.value === termFieldSettings.EXACT_PERCENTAGE"
-    >
-      <div class="col-6">
+      </ng-container>
+      <ng-container *ngSwitchCase="termFieldSettings.EXACT_PERCENTAGE">
         <div class="field">
           <label for="interest_rate">EXACT PERCENTAGE (%)</label>
           <input
@@ -103,10 +96,8 @@
             patternErrorMessage="The interest rate must be a valid percentage with no more than 5 decimal places."
           ></app-error-messages>
         </div>
-      </div>
-    </ng-container>
-    <ng-container *ngIf="!this.form.get(templateMap['interest_rate_setting'])?.value">
-      <div class="col-6"></div>
-    </ng-container>
+      </ng-container>
+      <ng-container *ngSwitchDefault> </ng-container>
+    </div>
   </div>
 </div>

--- a/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.spec.ts
@@ -56,73 +56,113 @@ describe('LoanTermsDatesInputComponent', () => {
     expect(control?.status).toBe('VALID');
   });
 
-  it('should handle interest_rate inputs correctly', () => {
-    const settingField = component.form.get(component.templateMap.interest_rate_setting);
-    const rateField = component.form.get(component.templateMap.interest_rate);
-
+  it('should handle interest_rate inputs correctly when clearValuesOnChange is true', () => {
     // Changing the interest rate setting to USER_DEFINED should clear the value
-    rateField?.setValue('12.3%');
-    settingField?.setValue(component.termFieldSettings.USER_DEFINED);
-    expect(rateField?.value).toBeNull();
+    component.interestRate = '12.3%';
+
+    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
+    expect(component.interestRate).toBe('');
 
     // While USER_DEFINED, non-percentage values should go unchanged
-    rateField?.setValue('12.3');
-    expect(rateField?.value).toEqual('12.3');
+    component.interestRate = '12.3';
+    expect(component.interestRate).toEqual('12.3');
 
     // Changing the interest rate setting to EXACT_PERCENTAGE should clear the value
-    settingField?.setValue(component.termFieldSettings.EXACT_PERCENTAGE);
-    expect(rateField?.value).toBeNull();
+    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
+    expect(component.interestRate).toBe('');
 
     // You should be unable to delete the % symbol
-    rateField?.setValue('12.3');
-    expect(rateField?.value).toEqual('12.3%');
+    component.interestRate = '12.3';
+    expect(component.interestRate).toEqual('12.3%');
 
     // If the value would only be '%', clear the field
-    rateField?.setValue('%');
-    expect(rateField?.value).toEqual('');
+    component.interestRate = '%';
+    expect(component.interestRate).toEqual('');
 
     // Changing back and forth between field settings should clear the value
-    rateField?.setValue('12.3%');
-    settingField?.setValue(component.termFieldSettings.USER_DEFINED);
-    settingField?.setValue(component.termFieldSettings.EXACT_PERCENTAGE);
-    expect(rateField?.value).toBeNull();
+    component.interestRate = '12.3%';
+    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
+    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
+    expect(component.interestRate).toBe('');
+  });
+
+  it('should handle interest_rate inputs correctly when clearValuesOnChange is false ', () => {
+    component.clearValuesOnChange = false;
+
+    // Changing the interest rate setting to USER_DEFINED should clear the value
+    component.interestRate = '12.3%';
+    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
+
+    expect(component.interestRate).toBe('12.3%');
+
+    // While USER_DEFINED, non-percentage values should go unchanged
+    component.interestRate = '12.3';
+    expect(component.interestRate).toEqual('12.3');
+
+    // Changing the interest rate setting to EXACT_PERCENTAGE should clear the value
+    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
+    expect(component.interestRate).toBe('12.3%');
+
+    // You should be unable to delete the % symbol
+    component.interestRate = '12.3';
+    expect(component.interestRate).toEqual('12.3%');
+
+    // If the value would only be '%', clear the field
+    component.interestRate = '%';
+    expect(component.interestRate).toEqual('');
+
+    // Changing back and forth between field settings should clear the value
+    component.interestRate = '12.3%';
+    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
+    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
+    expect(component.interestRate).toBe('12.3%');
   });
 
   it('should add and remove the percentage pattern validator', () => {
-    const settingField = component.form.get(component.templateMap.interest_rate_setting);
-    const rateField = component.form.get(component.templateMap.interest_rate);
-    settingField?.setValue(component.termFieldSettings.USER_DEFINED);
-    expect(rateField?.hasValidator(percentageValidator)).toBeFalse();
-    settingField?.setValue(component.termFieldSettings.EXACT_PERCENTAGE);
-    expect(rateField?.hasValidator(percentageValidator)).toBeTrue();
+    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
+    expect(component.interestRateField?.hasValidator(percentageValidator)).toBeFalse();
+    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
+    expect(component.interestRateField?.hasValidator(percentageValidator)).toBeTrue();
   });
 
-  it('should handle due_date inputs correctly', fakeAsync(() => {
-    const settingField = component.form.get(component.templateMap.due_date_setting);
-    let dateField = component.form.get(component.templateMap.due_date);
-
+  it('should handle due_date inputs correctly when clearValuesOnChange is true', fakeAsync(() => {
     // Changing the due_date setting to USER_DEFINED should clear value
-    dateField?.setValue(new Date('10/31/2010 00:00'));
-    settingField?.setValue(component.termFieldSettings.USER_DEFINED);
-    dateField = component.form.get(component.templateMap.due_date);
-    expect(dateField?.value).toBe('');
+    component.dueDate = new Date('10/31/2010 00:00');
+    component.dueDateSetting = component.termFieldSettings.USER_DEFINED;
+    expect(component.dueDate as unknown as string).toBe('');
 
     // When changing to the SPECIFIC_DATE setting should clear value
-    settingField?.setValue(component.termFieldSettings.SPECIFIC_DATE);
-    dateField = component.form.get(component.templateMap.due_date);
-    expect(dateField?.value).toBeNull();
+    component.dueDateSetting = component.termFieldSettings.SPECIFIC_DATE;
+    expect(component.dueDate).toBeNull();
 
     // When switch settings, it will fall back to clearing the date field
-    settingField?.setValue(component.termFieldSettings.USER_DEFINED);
-    dateField = component.form.get(component.templateMap.due_date);
-    dateField?.setValue('A user-entered string');
-    settingField?.setValue(component.termFieldSettings.SPECIFIC_DATE);
-    fixture.detectChanges();
-    dateField = component.form.get(component.templateMap.due_date);
-    expect(dateField?.value).toBeNull();
-    dateField?.setValue('Not a Date instance');
-    settingField?.setValue(component.termFieldSettings.USER_DEFINED);
-    dateField = component.form.get(component.templateMap.due_date);
-    expect(dateField?.value).toEqual('');
+    component.dueDateSetting = component.termFieldSettings.USER_DEFINED;
+    component.dueDate = 'A user-entered string';
+    component.dueDateSetting = component.termFieldSettings.SPECIFIC_DATE;
+    expect(component.dueDate).toBeNull();
+    component.dueDate = 'Not a Date instance';
+    component.dueDateSetting = component.termFieldSettings.USER_DEFINED;
+    expect(component.dueDate).toEqual('');
+  }));
+
+  it('should handle due_date inputs correctly when clearValuesOnChange is false', fakeAsync(() => {
+    component.clearValuesOnChange = false;
+    // Changing the due_date setting to USER_DEFINED should clear value
+    component.dueDate = new Date('10/31/2010 00:00');
+    component.dueDateSetting = component.termFieldSettings.USER_DEFINED;
+    expect(component.dueDate as unknown as string).toBe('2010-10-31');
+
+    // When changing to the SPECIFIC_DATE setting should clear value
+    component.dueDateSetting = component.termFieldSettings.SPECIFIC_DATE;
+    expect(component.dueDate instanceof Date).toBeTrue();
+
+    // When switch settings, it will fall back to clearing the date field
+    component.dueDateSetting = component.termFieldSettings.USER_DEFINED;
+    component.dueDate = 'A user-entered string';
+    component.dueDateSetting = component.termFieldSettings.SPECIFIC_DATE;
+    expect(component.dueDate).toBeNull();
+    component.dueDate = 'Not a Date instance';
+    component.dueDateSetting = component.termFieldSettings.USER_DEFINED;
+    expect(component.dueDate).toEqual('Not a Date instance');
   }));
 });

--- a/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.spec.ts
@@ -43,6 +43,13 @@ describe('LoanTermsDatesInputComponent', () => {
     fixture.detectChanges();
   });
 
+  function testInterest(value: string, expectedValue: string, startSetting: string, toggleSetting?: string): void {
+    if (component.interestRateSetting !== startSetting) component.interestRateSetting = startSetting;
+    component.interestRate = value;
+    if (toggleSetting && startSetting !== toggleSetting) component.interestRateSetting = toggleSetting;
+    expect(component.interestRate).toBe(expectedValue);
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -58,60 +65,41 @@ describe('LoanTermsDatesInputComponent', () => {
 
   it('should handle interest_rate inputs correctly when clearValuesOnChange is true', () => {
     // Changing the interest rate setting to USER_DEFINED should clear the value
-    component.interestRate = '12.3%';
-
-    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
-    expect(component.interestRate).toBe('');
-
+    testInterest('12.3%', '', component.termFieldSettings.EXACT_PERCENTAGE, component.termFieldSettings.USER_DEFINED);
     // While USER_DEFINED, non-percentage values should go unchanged
-    component.interestRate = '12.3';
-    expect(component.interestRate).toEqual('12.3');
-
+    testInterest('12.3', '12.3', component.termFieldSettings.USER_DEFINED);
     // Changing the interest rate setting to EXACT_PERCENTAGE should clear the value
-    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
-    expect(component.interestRate).toBe('');
-
-    // You should be unable to delete the % symbol
-    component.interestRate = '12.3';
-    expect(component.interestRate).toEqual('12.3%');
-
+    testInterest('12.3', '', component.termFieldSettings.USER_DEFINED, component.termFieldSettings.EXACT_PERCENTAGE);
+    // You should be unable to delete the % symbol on EXACT_PERCENTAGE
+    testInterest('12.3', '12.3%', component.termFieldSettings.EXACT_PERCENTAGE);
     // If the value would only be '%', clear the field
-    component.interestRate = '%';
-    expect(component.interestRate).toEqual('');
-
-    // Changing back and forth between field settings should clear the value
-    component.interestRate = '12.3%';
-    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
-    component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
-    expect(component.interestRate).toBe('');
+    testInterest('%', '', component.termFieldSettings.EXACT_PERCENTAGE);
   });
 
   it('should handle interest_rate inputs correctly when clearValuesOnChange is false ', () => {
     component.clearValuesOnChange = false;
 
-    // Changing the interest rate setting to USER_DEFINED should clear the value
-    component.interestRate = '12.3%';
-    component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
-
-    expect(component.interestRate).toBe('12.3%');
+    // Changing the interest rate setting to USER_DEFINED should NOT clear the value
+    testInterest(
+      '12.3%',
+      '12.3%',
+      component.termFieldSettings.EXACT_PERCENTAGE,
+      component.termFieldSettings.USER_DEFINED,
+    );
 
     // While USER_DEFINED, non-percentage values should go unchanged
-    component.interestRate = '12.3';
-    expect(component.interestRate).toEqual('12.3');
+    testInterest('12.3', '12.3', component.termFieldSettings.USER_DEFINED);
 
-    // Changing the interest rate setting to EXACT_PERCENTAGE should clear the value
+    // Changing the interest rate setting to EXACT_PERCENTAGE should NOT clear the value and add %
+    testInterest(
+      '12.3',
+      '12.3%',
+      component.termFieldSettings.USER_DEFINED,
+      component.termFieldSettings.EXACT_PERCENTAGE,
+    );
+
+    // Changing back and forth between field settings should NOT clear the value
     component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;
-    expect(component.interestRate).toBe('12.3%');
-
-    // You should be unable to delete the % symbol
-    component.interestRate = '12.3';
-    expect(component.interestRate).toEqual('12.3%');
-
-    // If the value would only be '%', clear the field
-    component.interestRate = '%';
-    expect(component.interestRate).toEqual('');
-
-    // Changing back and forth between field settings should clear the value
     component.interestRate = '12.3%';
     component.interestRateSetting = component.termFieldSettings.USER_DEFINED;
     component.interestRateSetting = component.termFieldSettings.EXACT_PERCENTAGE;

--- a/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.ts
@@ -182,11 +182,7 @@ export class LoanTermsDatesInputComponent extends BaseInputComponent implements 
     if (newDueDateSetting === LoanTermsFieldSettings.SPECIFIC_DATE) {
       this.dueDate = null;
     } else if (newDueDateSetting === LoanTermsFieldSettings.USER_DEFINED) {
-      this.dueDateField = new SubscriptionFormControl<string>('', {
-        validators: this.dueDateField?.validator,
-        asyncValidators: this.dueDateField?.asyncValidator,
-        updateOn: 'blur',
-      });
+      this.dueDateField = this.dueDateField!.copy<string>('');
     }
   }
 
@@ -207,11 +203,7 @@ export class LoanTermsDatesInputComponent extends BaseInputComponent implements 
     } else if (newDueDateSetting === LoanTermsFieldSettings.USER_DEFINED) {
       const value =
         previous_due_date instanceof Date ? DateUtils.convertDateToFecFormat(previous_due_date) : previous_due_date;
-      this.dueDateField = new SubscriptionFormControl<string>(value ?? '', {
-        validators: this.dueDateField?.validator,
-        asyncValidators: this.dueDateField?.asyncValidator,
-        updateOn: 'blur',
-      });
+      this.dueDateField = this.dueDateField!.copy<string>(value ?? '');
     }
   }
 

--- a/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/loan-terms-dates-input/loan-terms-dates-input.component.ts
@@ -5,11 +5,12 @@ import { isPulledForwardLoan } from 'app/shared/models/transaction.model';
 import { LabelUtils } from 'app/shared/utils/label.utils';
 import { selectActiveReport } from 'app/store/active-report.selectors';
 import { InputText } from 'primeng/inputtext';
-import { take, takeUntil } from 'rxjs';
+import { take } from 'rxjs';
 import { BaseInputComponent } from '../base-input.component';
 import { Form3X } from 'app/shared/models/form-3x.model';
 import { buildWithinReportDatesValidator, percentageValidator } from 'app/shared/utils/validators.utils';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
+import { DateUtils } from 'app/shared/utils/date.utils';
 
 enum LoanTermsFieldSettings {
   SPECIFIC_DATE = 'specific-date',
@@ -23,6 +24,7 @@ enum LoanTermsFieldSettings {
 })
 export class LoanTermsDatesInputComponent extends BaseInputComponent implements OnInit, AfterViewInit {
   @ViewChild('interestRatePercentage') interestInput!: InputText;
+  clearValuesOnChange = true;
 
   constructor(private store: Store) {
     super();
@@ -41,6 +43,11 @@ export class LoanTermsDatesInputComponent extends BaseInputComponent implements 
   ]);
 
   ngOnInit(): void {
+    this.addValidators();
+    this.addSubscriptions();
+  }
+
+  addValidators() {
     // Add the date range validation check to the DATE INCURRED input
     if (!isPulledForwardLoan(this.transaction) && !isPulledForwardLoan(this.transaction?.parent_transaction)) {
       this.store
@@ -58,105 +65,96 @@ export class LoanTermsDatesInputComponent extends BaseInputComponent implements 
         });
     }
 
-    this.form.get(this.templateMap.interest_rate_setting)?.addValidators([Validators.required]);
-    this.form.get(this.templateMap.due_date_setting)?.addValidators([Validators.required]);
+    this.interestRateSettingField?.addValidators([Validators.required]);
+    this.dueDateSettingField?.addValidators([Validators.required]);
+  }
 
-    this.form.get(this.templateMap['due_date_setting'])?.valueChanges?.subscribe((dueDateSetting) => {
+  addSubscriptions() {
+    this.dueDateSettingField?.addSubscription((dueDateSetting) => {
       this.convertDueDate(dueDateSetting);
     });
 
-    this.onInterestRateInput(this.form.get(this.templateMap.interest_rate)?.value);
-    this.form.get(this.templateMap['interest_rate_setting'])?.valueChanges?.subscribe((interestRateSetting) => {
-      const interestRateField = this.form.get(this.templateMap['interest_rate']);
-      if (interestRateField) {
-        if (interestRateSetting === LoanTermsFieldSettings.EXACT_PERCENTAGE) {
-          interestRateField.addValidators(percentageValidator);
-        } else if (interestRateSetting === LoanTermsFieldSettings.USER_DEFINED) {
-          interestRateField.removeValidators(percentageValidator);
-        }
-
-        interestRateField.setValue(null);
-        interestRateField.markAsPristine();
-        interestRateField.markAsUntouched();
+    this.onInterestRateInput(this.interestRate);
+    this.interestRateSettingField?.addSubscription((interestRateSetting) => {
+      if (!this.interestRateField) return;
+      if (interestRateSetting === LoanTermsFieldSettings.EXACT_PERCENTAGE) {
+        this.interestRateField.addValidators(percentageValidator);
+      } else if (interestRateSetting === LoanTermsFieldSettings.USER_DEFINED) {
+        this.interestRateField.removeValidators(percentageValidator);
+      }
+      if (this.clearValuesOnChange) {
+        this.interestRate = '';
+        this.interestRateField.markAsPristine();
+        this.interestRateField.markAsUntouched();
+      } else {
+        this.onInterestRateInput(interestRateSetting);
       }
     });
 
     // Watch changes to purpose description to make sure prefix is maintained
-    this.form
-      .get(this.templateMap['interest_rate'])
-      ?.valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe(() => {
-        this.onInterestRateInput(this.form.get(this.templateMap.interest_rate_setting)?.value);
-      });
+    this.interestRateField?.addSubscription(() => this.onInterestRateInput(this.interestRateSetting), this.destroy$);
   }
 
   ngAfterViewInit(): void {
-    const interest_rate_field = this.form.get(this.templateMap['interest_rate']);
-    const interest_rate_setting_field = this.form.get(this.templateMap['interest_rate_setting']);
+    this.clearValuesOnChange = false;
     // If the interest rate converts nicely to a percentage field, then do so
-    if (!interest_rate_setting_field?.value && interest_rate_field?.value) {
-      const starting_interest_rate = interest_rate_field?.value;
-      interest_rate_setting_field?.setValue(LoanTermsFieldSettings.EXACT_PERCENTAGE);
+    if (!this.interestRateSetting && this.interestRate) {
+      const starting_interest_rate = this.interestRate;
+
+      this.interestRateSetting = LoanTermsFieldSettings.EXACT_PERCENTAGE;
       // Otherwise, set the field setting to user-defined and restore the original value
-      if (starting_interest_rate !== interest_rate_field?.value) {
-        interest_rate_setting_field?.setValue(LoanTermsFieldSettings.USER_DEFINED);
-        interest_rate_field.setValue(starting_interest_rate);
+      if (starting_interest_rate !== this.interestRate) {
+        this.interestRateSetting = LoanTermsFieldSettings.USER_DEFINED;
+        this.interestRate = starting_interest_rate;
       }
     }
 
-    const due_date_field = this.form.get(this.templateMap['due_date']);
-    const due_date_setting_field = this.form.get(this.templateMap['due_date_setting']);
     // If the due date converts nicely to a Date object, then do so
-    if (!due_date_setting_field?.value && due_date_field?.value) {
-      const starting_due_date = due_date_field?.value;
-      due_date_setting_field?.setValue(LoanTermsFieldSettings.SPECIFIC_DATE);
+    if (!this.dueDateSetting && this.dueDate) {
+      const starting_due_date = this.dueDate;
+      this.dueDateSetting = LoanTermsFieldSettings.SPECIFIC_DATE;
       // Otherwise, set the field setting to user-defined and restore the original value
-      if (!(due_date_field?.value instanceof Date)) {
-        due_date_setting_field?.setValue(LoanTermsFieldSettings.USER_DEFINED);
-        due_date_field?.setValue(starting_due_date);
+      if (!(this.dueDate instanceof Date)) {
+        this.dueDateSetting = LoanTermsFieldSettings.USER_DEFINED;
+        this.dueDate = starting_due_date;
       }
     }
+    this.clearValuesOnChange = true;
   }
 
-  onInterestRateInput(newInterestRateSetting: string) {
-    const interestField = this.form.get(this.templateMap.interest_rate);
-    if (interestField) {
-      const previousInterestRate = interestField.value;
+  private onInterestRateInput(newInterestRateSetting: string) {
+    const previousInterestRate = this.interestRate;
+    if (newInterestRateSetting === LoanTermsFieldSettings.EXACT_PERCENTAGE) {
       let newInterestRate = previousInterestRate ?? '';
-      if (newInterestRateSetting === LoanTermsFieldSettings.EXACT_PERCENTAGE) {
-        let textInput!: HTMLInputElement;
-        let initialSelectionStart = 0;
-        let initialSelectionEnd = 0;
-        if (this.interestInput) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          textInput = (this.interestInput as any).nativeElement as HTMLInputElement;
-          initialSelectionStart = textInput.selectionStart ?? 0;
-          initialSelectionEnd = textInput.selectionEnd ?? 0;
-        }
+      let textInput!: HTMLInputElement;
+      let initialSelectionStart = 0;
+      let initialSelectionEnd = 0;
+      if (this.interestInput) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        textInput = (this.interestInput as any).nativeElement as HTMLInputElement;
+        initialSelectionStart = textInput.selectionStart ?? 0;
+        initialSelectionEnd = textInput.selectionEnd ?? 0;
+      }
 
-        const validNumber = newInterestRate.replaceAll(/[^0-9.%]/g, '');
-        if (validNumber !== newInterestRate) {
-          interestField.setValue(validNumber);
-          const lengthDifference = newInterestRate.length - validNumber.length;
-          newInterestRate = validNumber;
+      const validNumber = newInterestRate.replaceAll(/[^0-9.%]/g, '');
+      if (validNumber !== newInterestRate) {
+        this.interestRate = validNumber;
+        const lengthDifference = newInterestRate.length - validNumber.length;
+        newInterestRate = validNumber;
 
-          textInput?.setSelectionRange(
-            initialSelectionStart - lengthDifference,
-            initialSelectionEnd - lengthDifference,
-          );
-          interestField.markAsTouched();
-        }
+        textInput?.setSelectionRange(initialSelectionStart - lengthDifference, initialSelectionEnd - lengthDifference);
+        this.interestRateField?.markAsTouched();
+      }
 
-        if (newInterestRate.length > 0) {
-          if (!newInterestRate.endsWith('%')) {
-            interestField.setValue(newInterestRate + '%');
-            textInput?.setSelectionRange(newInterestRate.length, newInterestRate.length);
-            interestField.markAsTouched();
-          }
+      if (newInterestRate.length > 0) {
+        if (!newInterestRate.endsWith('%')) {
+          this.interestRate = newInterestRate + '%';
+          textInput?.setSelectionRange(newInterestRate.length, newInterestRate.length);
+          this.interestRateField?.markAsTouched();
         }
-        if (interestField.value === '%') {
-          interestField.setValue('');
-        }
+      }
+      if (this.interestRate === '%') {
+        this.interestRate = '';
       }
     }
   }
@@ -169,21 +167,108 @@ export class LoanTermsDatesInputComponent extends BaseInputComponent implements 
    * @param newDueDateSetting
    */
   convertDueDate(newDueDateSetting: string) {
-    const due_date_field = this.form.get(this.templateMap['due_date']);
-    if (due_date_field) {
-      if (newDueDateSetting === LoanTermsFieldSettings.SPECIFIC_DATE) {
-        due_date_field.setValue(null);
-        due_date_field.markAsPristine();
-        due_date_field.markAsUntouched();
-      } else if (newDueDateSetting === LoanTermsFieldSettings.USER_DEFINED) {
-        const stringDueDate = new SubscriptionFormControl<string>('', {
-          validators: due_date_field.validator,
-          asyncValidators: due_date_field.asyncValidator,
-          updateOn: 'blur',
-        });
-        stringDueDate.markAsPristine();
-        this.form.setControl(this.templateMap['due_date'], stringDueDate);
-      }
+    if (this.clearValuesOnChange) {
+      this.clearDueDate(newDueDateSetting);
+    } else {
+      this.convertDueDateProper(newDueDateSetting);
     }
+  }
+
+  /**
+   * If clearValuesOnChange is true, values are set to null or empty string
+   * @param newDueDateSetting
+   */
+  private clearDueDate(newDueDateSetting: string) {
+    if (newDueDateSetting === LoanTermsFieldSettings.SPECIFIC_DATE) {
+      this.dueDate = null;
+    } else if (newDueDateSetting === LoanTermsFieldSettings.USER_DEFINED) {
+      this.dueDateField = new SubscriptionFormControl<string>('', {
+        validators: this.dueDateField?.validator,
+        asyncValidators: this.dueDateField?.asyncValidator,
+        updateOn: 'blur',
+      });
+    }
+  }
+
+  /**
+   * If clearValuesOnChange is false, values are converted properly
+   * clearValuesOnChange is false when loading from backend, otherwise always true
+   * @param newDueDateSetting
+   */
+  private convertDueDateProper(newDueDateSetting: string) {
+    const fecDateFormat = /^\d{4}-\d{2}-\d{2}$/;
+    const previous_due_date = this.dueDate;
+    if (newDueDateSetting === LoanTermsFieldSettings.SPECIFIC_DATE) {
+      if (typeof previous_due_date === 'string' && previous_due_date.search(fecDateFormat) !== -1) {
+        this.dueDate = DateUtils.convertFecFormatToDate(previous_due_date);
+      } else {
+        this.dueDate = null;
+      }
+    } else if (newDueDateSetting === LoanTermsFieldSettings.USER_DEFINED) {
+      const value =
+        previous_due_date instanceof Date ? DateUtils.convertDateToFecFormat(previous_due_date) : previous_due_date;
+      this.dueDateField = new SubscriptionFormControl<string>(value ?? '', {
+        validators: this.dueDateField?.validator,
+        asyncValidators: this.dueDateField?.asyncValidator,
+        updateOn: 'blur',
+      });
+    }
+  }
+
+  get dueDateField(): SubscriptionFormControl | null {
+    return this.form.get(this.templateMap['due_date']) as SubscriptionFormControl;
+  }
+
+  set dueDateField(control: SubscriptionFormControl) {
+    control.markAsPristine();
+    this.form.setControl(this.templateMap['due_date'], control);
+  }
+
+  get dueDate(): Date | string | null {
+    return this.dueDateField?.value ?? null;
+  }
+
+  set dueDate(value: Date | string | null) {
+    this.dueDateField?.setValue(value);
+    if (value === null) {
+      this.dueDateField?.markAsPristine();
+      this.dueDateField?.markAsUntouched();
+    }
+  }
+
+  get dueDateSettingField(): SubscriptionFormControl | null {
+    return this.form.get(this.templateMap.due_date_setting) as SubscriptionFormControl;
+  }
+
+  get dueDateSetting(): string {
+    return this.dueDateSettingField?.value ?? '';
+  }
+
+  set dueDateSetting(value: string) {
+    this.dueDateSettingField?.setValue(value);
+  }
+
+  get interestRateField(): SubscriptionFormControl | null {
+    return this.form.get(this.templateMap['interest_rate']) as SubscriptionFormControl;
+  }
+
+  get interestRate(): string {
+    return this.interestRateField?.value ?? '';
+  }
+
+  set interestRate(value: string) {
+    this.interestRateField?.setValue(value);
+  }
+
+  get interestRateSettingField(): SubscriptionFormControl | null {
+    return this.form.get(this.templateMap['interest_rate_setting']) as SubscriptionFormControl;
+  }
+
+  get interestRateSetting(): string {
+    return this.interestRateSettingField?.value ?? '';
+  }
+
+  set interestRateSetting(value: string) {
+    this.interestRateSettingField?.setValue(value);
   }
 }

--- a/front-end/src/app/shared/utils/schema.utils.ts
+++ b/front-end/src/app/shared/utils/schema.utils.ts
@@ -39,6 +39,7 @@ export class SchemaUtils {
     'change_of_address',
     'support_oppose_code',
     'userCertified',
+    'secured',
   ];
 
   static getFormGroupFieldsNoBlur(properties: string[]) {

--- a/front-end/src/app/shared/utils/subscription-form-control.ts
+++ b/front-end/src/app/shared/utils/subscription-form-control.ts
@@ -2,14 +2,38 @@ import { FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+export interface Subscription {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  action: (value: any) => void;
+  destroy$?: Subject<undefined> | Subject<boolean>;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class SubscriptionFormControl<TValue = any> extends FormControl {
-  subscriptions: ((value: TValue) => void)[] = [];
+  subscriptions: Subscription[] = [];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  addSubscription(action: (value: TValue) => void, destroy$?: Subject<any>) {
-    this.subscriptions.push(action);
+  addSubscription(action: (value: TValue) => void, destroy$?: Subject<undefined> | Subject<boolean>) {
+    this.subscriptions.push({ action, destroy$ });
     if (destroy$) this.valueChanges.pipe(takeUntil(destroy$)).subscribe(action);
     else this.valueChanges.subscribe(action);
+  }
+
+  copy<T>(value: T, updateOn: 'blur' | 'change' | 'submit' | undefined = 'blur'): SubscriptionFormControl<T> {
+    const control = new SubscriptionFormControl<T>(value, {
+      validators: this.validator,
+      asyncValidators: this.asyncValidator,
+      updateOn,
+    });
+
+    this.subscriptions.forEach((sub) => {
+      control.addSubscription(sub.action, sub.destroy$);
+    });
+
+    if (this.disabled) control.disable();
+    if (this.touched) control.markAsTouched();
+    if (this.dirty) control.markAsDirty();
+    if (this.errors) control.setErrors(this.errors);
+
+    return control;
   }
 }


### PR DESCRIPTION
Issue [FECFILE-1786](https://fecgov.atlassian.net/browse/FECFILE-1786)

Issue was that we were clearing the due date and interest rate fields when the corresponding setting field changed. Which is what we normally want now. However this was also happening on load from the backend.
Added a new component variable clearValuesOnChange  which is always true except for when loading data from backend.

I also cleaned up the code to make it a bit easier to work with by making some getters and setters for the fields and field values.

And one other thing I noticed, there was  bit of a wierd blip in validation with the secured radio button. Since it was validating on blur, you would click the button, and then briefly see a required validation when you blurred away. Added it to the onChange list, which I imagine all radio button inputs probably should be validating on change rather than blur.