### PR TITLE
feature/1718 - Fix loss of scrollbar PrimeNG modal issue

### DIFF
--- a/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.ts
+++ b/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.ts
@@ -8,6 +8,7 @@ import { TransactionFormUtils } from '../../transaction-type-base/transaction-fo
 import { BaseInputComponent } from '../base-input.component';
 import { ReportTypes } from 'app/shared/models/report.model';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
+import { DomHandler } from 'primeng/dom';
 
 @Component({
   selector: 'app-memo-code',
@@ -101,6 +102,7 @@ export class MemoCodeInputComponent extends BaseInputComponent implements OnInit
 
   closeOutOfDateDialog() {
     this.outOfDateDialogVisible = false;
+    DomHandler.unblockBodyScroll();
   }
 
   onMemoItemClick() {


### PR DESCRIPTION
Issue[FECFILE-1718](https://fecgov.atlassian.net/browse/FECFILE-1718)

Appears to be a variation on a known PrimeNG issue.
[Component: Calendar. After closing the calendar, the p-overflow-hidden class is not deleted](https://github.com/primefaces/primeng/issues/14012)
The way they fixed it is [here](https://github.com/primefaces/primeng/commit/bb91f63a3fb005f973cbb7d6c5be27c1df0ae3dd#diff-5e6894cc06cc1eea4dfcb185e1bea920ecc33c46970b15d21f45b83b5508a464R2946)
