### PR TITLE
feature/1719 - If date control that memo is tracking is disabled, don't track changes to determine if modal warning should appear

### DIFF
--- a/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.ts
+++ b/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.ts
@@ -46,10 +46,13 @@ export class MemoCodeInputComponent extends BaseInputComponent implements OnInit
         this.report = report as Form3X;
       });
 
-    (this.form.get(this.templateMap.date) as SubscriptionFormControl)?.addSubscription((date: Date) => {
-      this.coverageDate = date;
-      this.updateMemoItemWithDate(date);
-    }, this.destroy$);
+    const dateControl = this.form.get(this.templateMap.date) as SubscriptionFormControl;
+    if (dateControl?.enabled) {
+      dateControl.addSubscription((date: Date) => {
+        this.coverageDate = date;
+        this.updateMemoItemWithDate(date);
+      }, this.destroy$);
+    }
 
     this.memoCodeReadOnly = TransactionFormUtils.isMemoCodeReadOnly(this.transaction?.transactionType);
     if (this.overrideMemoItemHelpText) this.memoItemHelpText = this.overrideMemoItemHelpText;
@@ -118,6 +121,7 @@ export class MemoCodeInputComponent extends BaseInputComponent implements OnInit
       if (date && (date < this.report.coverage_from_date || date > this.report.coverage_through_date)) {
         this.memoControl.addValidators(Validators.requiredTrue);
         this.memoControl.markAsTouched();
+        this.memoControl.markAsDirty();
         this.memoControl.updateValueAndValidity();
         this.dateIsOutsideReport = true;
         if (!this.memoControl.value) {

--- a/front-end/src/app/shared/utils/schema.utils.ts
+++ b/front-end/src/app/shared/utils/schema.utils.ts
@@ -40,6 +40,7 @@ export class SchemaUtils {
     'support_oppose_code',
     'userCertified',
     'secured',
+    'memo_code',
   ];
 
   static getFormGroupFieldsNoBlur(properties: string[]) {


### PR DESCRIPTION
Issues: 
- [FECFILE-1719](https://fecgov.atlassian.net/browse/FECFILE-1719)
- [FECFILE-1718](https://fecgov.atlassian.net/browse/FECFILE-1718)

So, the problem was that we had two memo controls, both of which subscribe to the date's valueChanges.
The problem is changing the date on one date control, updates the second to mirror, causing both valueChange subscriptions to trigger, causing 2 modals to appear. However, the second one is kind of hidden inside the Autopopulate collapsed panel. This is also why the scrolling was still disabled. Because when the modals are created they disable scrolling, and when they go away they re-enable scrolling, but there was still a hidden active modal so scrolling was still disabled. 
Solution was to not have disabled dates have their valueChanges subscribed to in this situation. This prevents the second warning from happening.

I also fixed an issue with the Memo Item checkbox. It was defaulting to blur when it should update on change.