### PR TITLE
feature/1830 - Update canDelete to make sure loan and debt repayments can be deleted and to make sure loan receipts can NOT be deleted

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -18,6 +18,15 @@ import { selectActiveReport } from 'app/store/active-report.selectors';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { take, takeUntil } from 'rxjs';
 
+const loanReceipts = ['LOAN_RECEIVED_FROM_BANK_RECEIPT', 'LOAN_RECEIVED_FROM_INDIVIDUAL_RECEIPT', 'LOAN_MADE'];
+const loansDebts = [
+  'LOAN_RECEIVED_FROM_INDIVIDUAL',
+  'LOAN_RECEIVED_FROM_BANK',
+  'LOAN_BY_COMMITTEE',
+  'DEBT_OWED_BY_COMMITTEE',
+  'DEBT_OWED_TO_COMMITTEE',
+];
+
 @Component({
   template: '',
 })
@@ -336,18 +345,12 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
   }
 
   private canDelete(transaction: Transaction): boolean {
-    if (
-      transaction.transaction_type_identifier === undefined ||
-      ((transaction.loan_id || transaction.debt_id) &&
-        ![
-          'LOAN_RECEIVED_FROM_INDIVIDUAL',
-          'LOAN_RECEIVED_FROM_BANK',
-          'LOAN_BY_COMMITTEE',
-          'DEBT_OWED_BY_COMMITTEE',
-          'DEBT_OWED_TO_COMMITTEE',
-        ].includes(transaction.transaction_type_identifier || ''))
-    ) {
-      return false;
+    if (transaction.transaction_type_identifier) {
+      // Shouldn't be able to delete loan receipts
+      if (loanReceipts.includes(transaction.transaction_type_identifier)) return false;
+      // Shouldn't be able to delete pulled forward loans and debts
+      if (loansDebts.includes(transaction.transaction_type_identifier) && (transaction.loan_id || transaction.debt_id))
+        return false;
     }
 
     return !!transaction?.can_delete;

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
@@ -90,28 +90,28 @@ describe('TransactionReceiptsComponent', () => {
     const unitemizeAction = component.rowActions.find((ra) => ra.label === 'Unitemize');
     const reattributeAction = component.rowActions.find((ra) => ra.label === 'Reattribute');
     const deleteAction = component.rowActions.find((ra) => ra.label === 'Delete');
-    expect(viewAction?.isAvailable()).toEqual(true);
+    expect(viewAction?.isAvailable()).toBeTrue();
     expect(
       deleteAction?.isAvailable({
         can_delete: true,
         transactionType: { scheduleId: ScheduleIds.A },
       }),
-    ).toEqual(false);
-    expect(editAction?.isAvailable()).toEqual(false);
+    ).toBeFalse();
+    expect(editAction?.isAvailable()).toBeFalse();
     expect(
       aggregateAction?.isAvailable({ force_unaggregated: true, transactionType: { scheduleId: ScheduleIds.A } }),
-    ).toEqual(false);
+    ).toBeFalse();
     expect(
       unaggregateAction?.isAvailable({
         force_unaggregated: false,
         transactionType: { scheduleId: ScheduleIds.A },
       }),
-    ).toEqual(false);
-    expect(itemizeAction?.isAvailable({ itemized: false })).toEqual(false);
-    expect(unitemizeAction?.isAvailable({ itemized: true })).toEqual(false);
+    ).toBeFalse();
+    expect(itemizeAction?.isAvailable({ itemized: false })).toBeFalse();
+    expect(unitemizeAction?.isAvailable({ itemized: true })).toBeFalse();
     component.reportIsEditable = true;
-    expect(viewAction?.isAvailable()).toEqual(false);
-    expect(editAction?.isAvailable()).toEqual(true);
+    expect(viewAction?.isAvailable()).toBeFalse();
+    expect(editAction?.isAvailable()).toBeTrue();
     expect(
       deleteAction?.isAvailable({
         can_delete: true,
@@ -126,16 +126,38 @@ describe('TransactionReceiptsComponent', () => {
         loan_id: 'test',
         transactionType: { scheduleId: ScheduleIds.A },
       }),
+    ).toBeTrue();
+    expect(
+      deleteAction?.isAvailable({
+        can_delete: true,
+        transaction_type_identifier: 'LOAN_RECEIVED_FROM_BANK_RECEIPT',
+        transactionType: { scheduleId: ScheduleIds.A },
+      }),
     ).toBeFalse();
     expect(
+      deleteAction?.isAvailable({
+        can_delete: true,
+        transaction_type_identifier: 'LOAN_RECEIVED_FROM_INDIVIDUAL',
+        loan_id: 'test',
+        transactionType: { scheduleId: ScheduleIds.A },
+      }),
+    ).toBeFalse();
+    expect(
+      deleteAction?.isAvailable({
+        can_delete: true,
+        transaction_type_identifier: undefined,
+        transactionType: { scheduleId: ScheduleIds.A },
+      }),
+    ).toBeTrue();
+    expect(
       aggregateAction?.isAvailable({ force_unaggregated: true, transactionType: { scheduleId: ScheduleIds.A } }),
-    ).toEqual(true);
+    ).toBeTrue();
     expect(
       unaggregateAction?.isAvailable({
         force_unaggregated: false,
         transactionType: { scheduleId: ScheduleIds.A },
       }),
-    ).toEqual(true);
+    ).toBeTrue();
     expect(itemizeAction?.isAvailable({ itemized: false, transactionType: { scheduleId: ScheduleIds.A } })).toEqual(
       true,
     );
@@ -145,14 +167,14 @@ describe('TransactionReceiptsComponent', () => {
     expect(reattributeAction?.isAvailable({ itemized: false, transactionType: { scheduleId: ScheduleIds.A } })).toEqual(
       true,
     );
-    expect(viewAction?.isEnabled({})).toEqual(true);
-    expect(editAction?.isEnabled({})).toEqual(true);
-    expect(deleteAction?.isEnabled({})).toEqual(true);
-    expect(aggregateAction?.isEnabled({})).toEqual(true);
-    expect(unaggregateAction?.isEnabled({})).toEqual(true);
-    expect(itemizeAction?.isEnabled({})).toEqual(true);
-    expect(unitemizeAction?.isEnabled({})).toEqual(true);
-    expect(reattributeAction?.isEnabled({})).toEqual(true);
+    expect(viewAction?.isEnabled({})).toBeTrue();
+    expect(editAction?.isEnabled({})).toBeTrue();
+    expect(deleteAction?.isEnabled({})).toBeTrue();
+    expect(aggregateAction?.isEnabled({})).toBeTrue();
+    expect(unaggregateAction?.isEnabled({})).toBeTrue();
+    expect(itemizeAction?.isEnabled({})).toBeTrue();
+    expect(unitemizeAction?.isEnabled({})).toBeTrue();
+    expect(reattributeAction?.isEnabled({})).toBeTrue();
   });
 
   it('test forceAggregate', fakeAsync(() => {

--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -196,7 +196,7 @@ describe('TransactionService', () => {
         expect(true).toBeTrue();
       });
 
-      const req = httpTestingController.expectOne(`${environment.apiUrl}/transactions/1`);
+      const req = httpTestingController.expectOne(`${environment.apiUrl}/transactions/1/`);
       expect(req.request.method).toEqual('DELETE');
       req.flush(mockResponse);
       httpTestingController.verify();

--- a/front-end/src/app/shared/services/transaction.service.ts
+++ b/front-end/src/app/shared/services/transaction.service.ts
@@ -156,7 +156,7 @@ export class TransactionService implements TableListService<Transaction> {
   }
 
   public delete(transaction: Transaction): Observable<null> {
-    return this.apiService.delete<null>(`${transaction.transactionType?.apiEndpoint}/${transaction.id}`);
+    return this.apiService.delete<null>(`${transaction.transactionType?.apiEndpoint}/${transaction.id}/`);
   }
 
   public multiSaveReattRedes(transactions: Transaction[]): Observable<Transaction[]> {


### PR DESCRIPTION
Issue [FECFILE-1830](https://fecgov.atlassian.net/browse/FECFILE-1830)