### PR TITLE
feature/1841 - Fix 508 aria issues and the inability to close dialog when hitting escape key

### DIFF
--- a/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.html
+++ b/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.html
@@ -14,18 +14,20 @@
       </div>
       <div class="dialog-body">
         <div class="dropdown">
-          <label id="type-label" for="typeDropdown">FORM TYPE</label>
+          <span id="type-label">FORM TYPE</span>
           <button
             class="btn dropdown-toggle focus-ring"
             type="button"
             id="typeDropdown"
             [autofocus]="true"
             data-bs-toggle="dropdown"
+            (keydown.escape)="closeDialog()"
             aria-expanded="false"
+            aria-label="Possible report types"
             #dropdownElement
             [innerHTML]="dropdownButtonText"
           ></button>
-          <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+          <ul class="dropdown-menu" aria-labelledby="typeDropdown">
             <li *ngFor="let type of formTypeOptions" [attr.data-cy-form-type]="type">
               <button class="dropdown-item" (click)="updateSelected(type)" (select)="updateSelected(type)">
                 <span class="option">

--- a/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.scss
+++ b/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.scss
@@ -37,7 +37,12 @@ dialog {
   margin-right: 25px;
 }
 
-label {
+#type-label {
+  display: block;
+}
+
+label,
+#type-label {
   font-family: karla, Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   font-weight: bold;
   font-size: 14px;

--- a/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.ts
+++ b/front-end/src/app/reports/form-type-dialog/form-type-dialog.component.ts
@@ -122,6 +122,10 @@ export class FormTypeDialogComponent extends DestroyerComponent implements OnCha
     else this.selectedForm24Type = item;
   }
 
+  closeDialog() {
+    this.dialog?.nativeElement.close();
+  }
+
   @HostListener('keydown', ['$event'])
   handleTabKey(event: KeyboardEvent) {
     if (!this.firstElement) return;


### PR DESCRIPTION
Issue [FECFILE-1841](https://fecgov.atlassian.net/browse/FECFILE-1841)

Fixed aria issues. One of the aria issues was because we were using a <label> but this isn't a form element, so I changed it to a span .
The second issue was because the aria-labelledby was the wrong thing. It was dropdownMenuButton1 which should have been typeDropdown.

For the escape issue, it was only not working when focused on the dropdown button. There was some logic to allow you to use the escape key to close out of the dropdown, but that was preventing the dialog escape from working. Got it so both function correctly now.