### PR TITLE
Fix linked report info icon offset

### DIFF
--- a/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.html
+++ b/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.html
@@ -1,13 +1,16 @@
 <form id="form" [formGroup]="form">
   <div class="field">
-    <label for="linkedF3x">LINKED REPORT</label>
-    <span
-      class="pi pi-info-circle circle-icon-tooltip"
-      pTooltip="{{ tooltipText }}"
-      [tooltipOptions]="{
-        tooltipPosition: 'top',
-      }"
-    ></span>
+    <label for="linkedF3x" class="flex">
+      <span class="align-content-center">LINKED REPORT</span>
+      <span
+        class="pi pi-info-circle circle-icon-tooltip"
+        pTooltip="{{ tooltipText }}"
+        [tooltipOptions]="{
+          tooltipPosition: 'top',
+        }"
+      ></span>
+    </label>
+
     <input type="text" [readonly]="true" class="readonly" pInputText id="linkedF3x" formControlName="linkedF3x" />
     <app-error-messages [form]="form" fieldName="linkedF3x" [formSubmitted]="formSubmitted"></app-error-messages>
   </div>


### PR DESCRIPTION
Fixed the Linked Report label. The icon was stacking instead of being inline.
Previous
![image](https://github.com/user-attachments/assets/c1e76ecc-b8e3-4af7-b508-5d47bbbb4824)

Fixed
![image](https://github.com/user-attachments/assets/0c4d7ecf-b5d5-40df-8011-c11effc0c296)

