### PR TITLE
feature-593 - Don't autopopulate treasurer if signatory last name already present indicating this is an existing transaction

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -131,7 +131,11 @@ export abstract class TransactionTypeBaseComponent extends FormComponent impleme
       }
     });
 
-    if (this.committeeAccount && this.transactionType instanceof SchETransactionType) {
+    if (
+      this.committeeAccount &&
+      this.transactionType instanceof SchETransactionType &&
+      !this.form.get(this.templateMap['signatory_1_last_name'])?.value
+    ) {
       this.form.patchValue({
         [this.templateMap['signatory_1_last_name']]: this.committeeAccount.treasurer_name_2,
         [this.templateMap['signatory_1_first_name']]: this.committeeAccount.treasurer_name_1,


### PR DESCRIPTION
Issue [FECFILE-593](https://fecgov.atlassian.net/browse/FECFILE-593)