### PR TITLE
Feature/1987 - Fix issue where committee admin isn't seeing popup immediately after creating committee

### DIFF
--- a/front-end/cypress/e2e/F24/reports-f24-independent-expenditures.cy.ts
+++ b/front-end/cypress/e2e/F24/reports-f24-independent-expenditures.cy.ts
@@ -7,7 +7,7 @@ import {
   DisbursementFormData,
 } from '../models/TransactionFormModel';
 import { F3XSetup } from '../F3X/f3x-setup';
-import { StartTransaction } from '../F3X/start-transaction/start-transaction';
+import { StartTransaction } from '../F3X/utils/start-transaction/start-transaction';
 import { faker } from '@faker-js/faker';
 import { F24Setup } from './f24-setup';
 import { ReportListPage } from '../pages/reportListPage';

--- a/front-end/cypress/e2e/F3X/debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/debts.cy.ts
@@ -4,7 +4,7 @@ import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import { defaultDebtFormData as debtFormData } from '../models/TransactionFormModel';
 import { committeeFormData } from '../models/ContactFormModel';
 import { F3XSetup } from './f3x-setup';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 
 describe('Debts', () => {
   beforeEach(() => {

--- a/front-end/cypress/e2e/F3X/disbursements.cy.ts
+++ b/front-end/cypress/e2e/F3X/disbursements.cy.ts
@@ -12,7 +12,7 @@ import {
   formTransactionDataForSchedule,
 } from '../models/TransactionFormModel';
 import { F3XSetup } from './f3x-setup';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 import { faker } from '@faker-js/faker';
 import { ReportListPage } from '../pages/reportListPage';
 import { F24Setup } from '../F24/f24-setup';

--- a/front-end/cypress/e2e/F3X/loans-bank.cy.ts
+++ b/front-end/cypress/e2e/F3X/loans-bank.cy.ts
@@ -4,7 +4,7 @@ import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
 import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 import { F3XSetup, reportFormDataApril, reportFormDataJuly, Setup } from './f3x-setup';
 
 const formData = {

--- a/front-end/cypress/e2e/F3X/loans-committee.cy.ts
+++ b/front-end/cypress/e2e/F3X/loans-committee.cy.ts
@@ -4,7 +4,7 @@ import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import { defaultLoanFormData } from '../models/TransactionFormModel';
 import { committeeFormData, defaultFormData as individualContactFormData } from '../models/ContactFormModel';
 import { F3XSetup } from './f3x-setup';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 
 const formData = {
   ...defaultLoanFormData,

--- a/front-end/cypress/e2e/F3X/loans-individual.cy.ts
+++ b/front-end/cypress/e2e/F3X/loans-individual.cy.ts
@@ -1,10 +1,10 @@
 import { Initialize } from '../pages/loginPage';
-import { currentYear, PageUtils } from '../pages/pageUtils';
+import { PageUtils } from '../pages/pageUtils';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import { defaultLoanFormData } from '../models/TransactionFormModel';
 import { defaultFormData as individualContactFormData } from '../models/ContactFormModel';
 import { F3XSetup } from './f3x-setup';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 
 const formData = {
   ...defaultLoanFormData,

--- a/front-end/cypress/e2e/F3X/reattributions.cy.ts
+++ b/front-end/cypress/e2e/F3X/reattributions.cy.ts
@@ -9,10 +9,10 @@ import {
   createContact,
   defaultFormData as individualContactFormData,
 } from '../models/ContactFormModel';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 import { F3XSetup, reportFormDataApril, reportFormDataJuly } from './f3x-setup';
 import { ScheduleFormData } from '../models/TransactionFormModel';
-import { Individual } from './start-transaction/receipts';
+import { Individual } from './utils/start-transaction/receipts';
 import { faker } from '@faker-js/faker';
 
 const APRIL_15 = 'APRIL 15';

--- a/front-end/cypress/e2e/F3X/receipts.cy.ts
+++ b/front-end/cypress/e2e/F3X/receipts.cy.ts
@@ -6,7 +6,7 @@ import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import { defaultFormData as defaultContactFormData } from '../models/ContactFormModel';
 import { defaultScheduleFormData, formTransactionDataForSchedule } from '../models/TransactionFormModel';
 import { F3XSetup } from './f3x-setup';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 
 const scheduleData = {
   ...defaultScheduleFormData,

--- a/front-end/cypress/e2e/F3X/redesignations.cy.ts
+++ b/front-end/cypress/e2e/F3X/redesignations.cy.ts
@@ -3,13 +3,13 @@ import { PageUtils } from '../pages/pageUtils';
 import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import { candidateFormData, committeeFormData } from '../models/ContactFormModel';
-import { StartTransaction } from './start-transaction/start-transaction';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
 import { F3XSetup, reportFormDataApril, reportFormDataJuly } from './f3x-setup';
 import {
   ContributionFormData,
   defaultScheduleFormData as defaultTransactionFormData,
 } from '../models/TransactionFormModel';
-import { Contributions } from './start-transaction/disbursements';
+import { Contributions } from './utils/start-transaction/disbursements';
 
 const APRIL_15 = 'APRIL 15';
 

--- a/front-end/cypress/e2e/F3X/review-report.cy.ts
+++ b/front-end/cypress/e2e/F3X/review-report.cy.ts
@@ -1,6 +1,5 @@
 import { defaultFormData as defaultContactFormData } from '../models/ContactFormModel';
 import { defaultScheduleFormData } from '../models/TransactionFormModel';
-import { ContactListPage } from '../pages/contactListPage';
 import { Initialize } from '../pages/loginPage';
 import { PageUtils, currentYear } from '../pages/pageUtils';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
@@ -46,7 +45,7 @@ describe('Receipt Transactions', () => {
     cy.get('[id="searchBox"]').type(defaultContactFormData['last_name'].slice(0, 1));
     cy.contains(defaultContactFormData['last_name']).should('exist');
     cy.contains(defaultContactFormData['last_name']).click({ force: true });
-    TransactionDetailPage.enterScheduleFormData(scheduleData);
+    TransactionDetailPage.enterScheduleFormData(scheduleData, false, '', true, 'contribution_date');
     PageUtils.clickButton('Save');
 
     // Go to summary and verify summary calc runs

--- a/front-end/cypress/e2e/F3X/review-report.cy.ts
+++ b/front-end/cypress/e2e/F3X/review-report.cy.ts
@@ -1,0 +1,76 @@
+import { defaultFormData as defaultContactFormData } from '../models/ContactFormModel';
+import { defaultScheduleFormData } from '../models/TransactionFormModel';
+import { ContactListPage } from '../pages/contactListPage';
+import { Initialize } from '../pages/loginPage';
+import { PageUtils, currentYear } from '../pages/pageUtils';
+import { TransactionDetailPage } from '../pages/transactionDetailPage';
+import { F3XSetup } from './f3x-setup';
+import { ReviewReport } from './utils/review-report';
+import { StartTransaction } from './utils/start-transaction/start-transaction';
+
+const scheduleData = {
+  ...defaultScheduleFormData,
+  ...{
+    electionYear: undefined,
+    electionType: undefined,
+    date_received: new Date(currentYear, 4 - 1, 27),
+  },
+};
+
+describe('Receipt Transactions', () => {
+  beforeEach(() => {
+    Initialize();
+  });
+
+  it('should calculate summary values on first visit', () => {
+    // Create report and check summary calc runs
+    F3XSetup();
+    ReviewReport.Summary();
+    cy.get('img.fec-loader-image').should('exist');
+
+    // Leave summary and come back to verify calc does NOT run
+    PageUtils.clickSidebarItem('ENTER A TRANSACTION');
+    PageUtils.clickSidebarItem('Manage your transactions');
+    ReviewReport.Summary();
+    cy.get('img.fec-loader-image').should('not.exist');
+  });
+
+  it('should recalculate after transaction created or updated', () => {
+    // Create report and check summary calc runs
+    F3XSetup({ individual: true });
+    ReviewReport.Summary();
+    cy.get('img.fec-loader-image').should('exist');
+
+    // Create transaction
+    StartTransaction.Receipts().Individual().IndividualReceipt();
+    cy.get('[id="searchBox"]').type(defaultContactFormData['last_name'].slice(0, 1));
+    cy.contains(defaultContactFormData['last_name']).should('exist');
+    cy.contains(defaultContactFormData['last_name']).click({ force: true });
+    TransactionDetailPage.enterScheduleFormData(scheduleData);
+    PageUtils.clickButton('Save');
+
+    // Go to summary and verify summary calc runs
+    ReviewReport.Summary();
+    cy.get('img.fec-loader-image').should('exist');
+
+    // Verify summary calc doesn't run again
+    PageUtils.clickSidebarItem('ENTER A TRANSACTION');
+    PageUtils.clickSidebarItem('Manage your transactions');
+    ReviewReport.Summary();
+    cy.get('img.fec-loader-image').should('not.exist');
+
+    // Update transaction
+    PageUtils.clickSidebarItem('ENTER A TRANSACTION');
+    PageUtils.clickSidebarItem('Manage your transactions');
+    cy.get('tr').should('contain', 'Individual Receipt');
+    PageUtils.clickLink('Individual Receipt');
+    const alias = PageUtils.getAlias('');
+    cy.get(alias).find('#amount').clear().safeType(123.45);
+    PageUtils.clickButton('Save');
+    cy.get('tr').should('contain', '$123.45');
+
+    // Return to summary page and verify summary calc runs
+    ReviewReport.Summary();
+    cy.get('img.fec-loader-image').should('exist');
+  });
+});

--- a/front-end/cypress/e2e/F3X/utils/review-report.ts
+++ b/front-end/cypress/e2e/F3X/utils/review-report.ts
@@ -1,0 +1,23 @@
+import { PageUtils } from '../../pages/pageUtils';
+
+export class ReviewReport {
+  static Summary() {
+    PageUtils.clickSidebarItem('REVIEW A REPORT');
+    PageUtils.clickSidebarItem('View summary page');
+  }
+
+  static DSP() {
+    PageUtils.clickSidebarItem('REVIEW A REPORT');
+    PageUtils.clickSidebarItem('View detailed summary page');
+  }
+
+  static PrintPreview() {
+    PageUtils.clickSidebarItem('REVIEW A REPORT');
+    PageUtils.clickSidebarItem('View print preview');
+  }
+
+  static AddReportLevelMemo() {
+    PageUtils.clickSidebarItem('REVIEW A REPORT');
+    PageUtils.clickSidebarItem('Add a report level memo');
+  }
+}

--- a/front-end/cypress/e2e/F3X/utils/start-transaction/debts.ts
+++ b/front-end/cypress/e2e/F3X/utils/start-transaction/debts.ts
@@ -1,4 +1,4 @@
-import { PageUtils } from '../../pages/pageUtils';
+import { PageUtils } from '../../../pages/pageUtils';
 
 export class Debts {
   static ByCommittee() {

--- a/front-end/cypress/e2e/F3X/utils/start-transaction/disbursements.ts
+++ b/front-end/cypress/e2e/F3X/utils/start-transaction/disbursements.ts
@@ -1,4 +1,4 @@
-import { PageUtils } from '../../pages/pageUtils';
+import { PageUtils } from '../../../pages/pageUtils';
 
 export class Disbursements {
   static Contributions() {

--- a/front-end/cypress/e2e/F3X/utils/start-transaction/loans.ts
+++ b/front-end/cypress/e2e/F3X/utils/start-transaction/loans.ts
@@ -1,4 +1,4 @@
-import { PageUtils } from '../../pages/pageUtils';
+import { PageUtils } from '../../../pages/pageUtils';
 
 export class Loans {
   static FromBank() {

--- a/front-end/cypress/e2e/F3X/utils/start-transaction/receipts.ts
+++ b/front-end/cypress/e2e/F3X/utils/start-transaction/receipts.ts
@@ -1,4 +1,4 @@
-import { PageUtils } from '../../pages/pageUtils';
+import { PageUtils } from '../../../pages/pageUtils';
 
 export class Receipts {
   static Individual() {

--- a/front-end/cypress/e2e/F3X/utils/start-transaction/start-transaction.ts
+++ b/front-end/cypress/e2e/F3X/utils/start-transaction/start-transaction.ts
@@ -1,4 +1,4 @@
-import { PageUtils } from '../../pages/pageUtils';
+import { PageUtils } from '../../../pages/pageUtils';
 import { Receipts } from './receipts';
 import { Disbursements, Independent } from './disbursements';
 import { Loans } from './loans';

--- a/front-end/cypress/support/e2e.ts
+++ b/front-end/cypress/support/e2e.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../node_modules/cypress/types/index.d.ts" />
 /*
 
   The index file imports commands and adds them to Cypress
@@ -7,3 +8,16 @@
 import { safeType, overwrite } from './commands';
 Cypress.Commands.add('safeType', { prevSubject: true }, safeType);
 Cypress.Commands.add('overwrite', { prevSubject: true }, overwrite);
+
+declare global {
+  namespace Cypress {
+    interface Chainable<Subject = any> {
+      /**
+       * Custom command to select DOM element by data-cy attribute.
+       * @example cy.dataCy('greeting')
+       */
+      safeType(value: string | number): Chainable<JQuery<HTMLElement>>;
+      overwrite(value: string | number): Chainable<JQuery<HTMLElement>>;
+    }
+  }
+}

--- a/front-end/cypress/tsconfig.json
+++ b/front-end/cypress/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": "../tsconfig.json",
-  "include": ["**/*.ts"],
-  "compilerOptions": {
-    "sourceMap": false,
-    "types": ["cypress"],
-    "target": "ES6"
-  }
+    "extends": "../tsconfig.json",
+    "include": ["**/*.ts", "./support/e2e.ts"],
+    "compilerOptions": {
+        "sourceMap": false,
+        "target": "ES2024",
+        "lib": ["ES2024", "dom"],
+        "types": ["node"]
+    }
 }

--- a/front-end/src/app/committee/create-committee/create-committee.component.ts
+++ b/front-end/src/app/committee/create-committee/create-committee.component.ts
@@ -13,6 +13,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { Dialog } from 'primeng/dialog';
 import { CheckboxModule } from 'primeng/checkbox';
 import { ButtonModule } from 'primeng/button';
+import { UsersService } from 'app/shared/services/users.service';
+import { userLoginDataRetrievedAction } from 'app/store/user-login-data.actions';
 
 @Component({
   selector: 'app-create-committee',
@@ -23,16 +25,16 @@ import { ButtonModule } from 'primeng/button';
 export class CreateCommitteeComponent extends DestroyerComponent {
   private readonly router = inject(Router);
   protected readonly store = inject(Store);
+  protected readonly committeeAccountService = inject(CommitteeAccountService);
+  protected readonly messageService = inject(MessageService);
+  protected readonly confirmationService = inject(ConfirmationService);
+  private readonly userService = inject(UsersService);
   suggestions?: FecFiling[];
   selectedCommittee?: CommitteeAccount;
   explanationVisible = false;
   unableToCreateAccount = false;
 
   searchBoxFormControl = new SubscriptionFormControl('');
-
-  protected readonly committeeAccountService = inject(CommitteeAccountService);
-  protected readonly messageService = inject(MessageService);
-  protected readonly confirmationService = inject(ConfirmationService);
 
   search(committeeId: string | null) {
     this.selectedCommittee = undefined;
@@ -67,6 +69,8 @@ export class CreateCommitteeComponent extends DestroyerComponent {
       });
       await this.committeeAccountService.activateCommittee(committeeAccount.id);
       this.store.dispatch(setCommitteeAccountDetailsAction({ payload: committeeAccount }));
+      const userLoginData = await this.userService.getCurrentUser();
+      this.store.dispatch(userLoginDataRetrievedAction({ payload: userLoginData }));
       await this.router.navigateByUrl(``);
     } catch {
       this.handleFailedSearch();


### PR DESCRIPTION
Issue [FECFILE-1987](https://fecgov.atlassian.net/browse/FECFILE-1987)

I wasn't able to replicate this issue on local because we can't create a committee the same way as dev or stage, however the problem is that when you go through the create committee process it wasn't refetching the user login data, so when you got into the system your role was null. Logging out and back in fixed the issue because it *does* refetch the user login data as part of selecting a committee. 