### PR TITLE
feature/1987 e2e test fix: Add delay to login check for second committee popup to make sure it isn't missed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - run:
           name: start fecfile-web-api
           command: |
-            git checkout develop
+            git checkout ${CIRCLE_BRANCH}
             docker-compose down
             DB_DOCKERFILE="Dockerfile-e2e" WORKER_DOCKERFILE="Worker_Dockerfile-e2e" API_DOCKERFILE="Dockerfile-e2e" FECFILE_TEST_DB_NAME="postgres"  DJANGO_SECRET_KEY=${E2E_DJANGO_SECRET_KEY} DATABASE_URL=${E2E_DATABASE_URL} FEC_API=${E2E_FEC_API} FEC_API_KEY=${E2E_FEC_API_KEY} MOCK_EFO="True" docker-compose up --build -d
             docker container run --network container:fecfile-api-proxy \
@@ -151,7 +151,6 @@ jobs:
             rm -rf /tmp/cypress
             mkdir -p /tmp/cypress/results
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/results/. /tmp/cypress/results
-            docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/videos/. /tmp/cypress/videos
             docker rm fecfile-web-app-e2e
       - store_artifacts:
           path: /tmp/cypress/results
@@ -218,7 +217,10 @@ workflows:
       - lint
       - test
       - dependency-check
-      - e2e-test
+      - e2e-test:
+          filters:
+            branches:
+              only: /develop|release\/sprint-[\.\d]+|release\/test|main/
       - deploy-job: # Deploy job even when e2e tests fail
           name: deploy-even-if-e2e-job-fails
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - run:
           name: start fecfile-web-api
           command: |
-            git checkout ${CIRCLE_BRANCH}
+            git checkout develop
             docker-compose down
             DB_DOCKERFILE="Dockerfile-e2e" WORKER_DOCKERFILE="Worker_Dockerfile-e2e" API_DOCKERFILE="Dockerfile-e2e" FECFILE_TEST_DB_NAME="postgres"  DJANGO_SECRET_KEY=${E2E_DJANGO_SECRET_KEY} DATABASE_URL=${E2E_DATABASE_URL} FEC_API=${E2E_FEC_API} FEC_API_KEY=${E2E_FEC_API_KEY} MOCK_EFO="True" docker-compose up --build -d
             docker container run --network container:fecfile-api-proxy \
@@ -151,6 +151,7 @@ jobs:
             rm -rf /tmp/cypress
             mkdir -p /tmp/cypress/results
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/results/. /tmp/cypress/results
+            docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/videos/. /tmp/cypress/videos
             docker rm fecfile-web-app-e2e
       - store_artifacts:
           path: /tmp/cypress/results
@@ -217,10 +218,7 @@ workflows:
       - lint
       - test
       - dependency-check
-      - e2e-test:
-          filters:
-            branches:
-              only: /develop|release\/sprint-[\.\d]+|release\/test|main/
+      - e2e-test
       - deploy-job: # Deploy job even when e2e tests fail
           name: deploy-even-if-e2e-job-fails
           requires:

--- a/front-end/cypress/e2e/pages/loginPage.ts
+++ b/front-end/cypress/e2e/pages/loginPage.ts
@@ -58,6 +58,7 @@ function loginDotGovLogin() {
   cy.intercept('GET', 'http://localhost:8080/api/v1/oidc/login-redirect').as('GetLoggedIn');
   cy.intercept('GET', 'http://localhost:8080/api/v1/committees/').as('GetCommitteeAccounts');
   cy.intercept('POST', 'http://localhost:8080/api/v1/committees/*/activate/').as('ActivateCommittee');
+  cy.intercept('GET', 'http://localhost:8080/api/v1/committee-members/').as('GetCommitteeMembers');
 
   cy.visit('/');
   cy.get('#loginButton').click();
@@ -72,16 +73,19 @@ function loginDotGovLogin() {
   // Wait for the reports page to load
   cy.contains('Manage reports').should('exist');
 
-  // Create second create admin after logging in to make pop-up go away
-  cy.wait(500);
-  const alias = PageUtils.getAlias('');
-  cy.get(alias)
+  // Creates a second create admin after logging in if necessary
+  cy.wait('@GetCommitteeMembers'); // Wait for the guard request to resolve
+  cy.get(PageUtils.getAlias(''))
     .find('[data-cy="second-committee-email"]')
     .should(Cypress._.noop) // No-op to avoid failure if it doesn't exist
     .then(($email) => {
       if ($email.length) {
-        cy.wrap($email).type('admin@admin.com');
-        cy.get('[data-cy="second-committee-save"]').click();
+        cy.contains('Welcome to FECfile').should('exist').click(); // Ensures that the modal is in focus
+        cy.wrap($email).should('have.value', '');
+        cy.wrap($email).clear().type('admin@admin.com'); // Clearing the field makes the typing behavior consistent
+        cy.wrap($email).should('have.value', 'admin@admin.com');
+        cy.wrap($email).click();
+        PageUtils.clickButton('Save');
       }
     });
   cy.contains('Welcome to FECfile').should('not.exist');

--- a/front-end/cypress/e2e/pages/loginPage.ts
+++ b/front-end/cypress/e2e/pages/loginPage.ts
@@ -58,7 +58,6 @@ function loginDotGovLogin() {
   cy.intercept('GET', 'http://localhost:8080/api/v1/oidc/login-redirect').as('GetLoggedIn');
   cy.intercept('GET', 'http://localhost:8080/api/v1/committees/').as('GetCommitteeAccounts');
   cy.intercept('POST', 'http://localhost:8080/api/v1/committees/*/activate/').as('ActivateCommittee');
-  cy.intercept('GET', 'http://localhost:8080/api/v1/committee-members/').as('GetCommitteeMembers');
 
   cy.visit('/');
   cy.get('#loginButton').click();
@@ -72,19 +71,17 @@ function loginDotGovLogin() {
 
   // Wait for the reports page to load
   cy.contains('Manage reports').should('exist');
-  cy.wait('@GetCommitteeMembers');
 
   // Create second create admin after logging in to make pop-up go away
+  cy.wait(500);
   const alias = PageUtils.getAlias('');
   cy.get(alias)
     .find('[data-cy="second-committee-email"]')
     .should(Cypress._.noop) // No-op to avoid failure if it doesn't exist
     .then(($email) => {
       if ($email.length) {
-        cy.contains('Welcome to FECfile').should('exist'); // Checks that the modal has rendered
         cy.wrap($email).type('admin@admin.com');
         cy.get('[data-cy="second-committee-save"]').click();
-        cy.pause();
       }
     });
   cy.contains('Welcome to FECfile').should('not.exist');

--- a/front-end/cypress/e2e/pages/loginPage.ts
+++ b/front-end/cypress/e2e/pages/loginPage.ts
@@ -73,6 +73,7 @@ function loginDotGovLogin() {
   cy.contains('Manage reports').should('exist');
 
   // Create second create admin after logging in to make pop-up go away
+  cy.wait(500);
   const alias = PageUtils.getAlias('');
   cy.get(alias)
     .find('[data-cy="second-committee-email"]')

--- a/front-end/cypress/e2e/pages/loginPage.ts
+++ b/front-end/cypress/e2e/pages/loginPage.ts
@@ -58,6 +58,7 @@ function loginDotGovLogin() {
   cy.intercept('GET', 'http://localhost:8080/api/v1/oidc/login-redirect').as('GetLoggedIn');
   cy.intercept('GET', 'http://localhost:8080/api/v1/committees/').as('GetCommitteeAccounts');
   cy.intercept('POST', 'http://localhost:8080/api/v1/committees/*/activate/').as('ActivateCommittee');
+  cy.intercept('GET', 'http://localhost:8080/api/v1/committee-members/').as('GetCommitteeMembers');
 
   cy.visit('/');
   cy.get('#loginButton').click();
@@ -71,17 +72,19 @@ function loginDotGovLogin() {
 
   // Wait for the reports page to load
   cy.contains('Manage reports').should('exist');
+  cy.wait('@GetCommitteeMembers');
 
   // Create second create admin after logging in to make pop-up go away
-  cy.wait(500);
   const alias = PageUtils.getAlias('');
   cy.get(alias)
     .find('[data-cy="second-committee-email"]')
     .should(Cypress._.noop) // No-op to avoid failure if it doesn't exist
     .then(($email) => {
       if ($email.length) {
+        cy.contains('Welcome to FECfile').should('exist'); // Checks that the modal has rendered
         cy.wrap($email).type('admin@admin.com');
         cy.get('[data-cy="second-committee-save"]').click();
+        cy.pause();
       }
     });
   cy.contains('Welcome to FECfile').should('not.exist');


### PR DESCRIPTION
Issue [FECFILE-1987](https://fecgov.atlassian.net/browse/FECFILE-1987)

I noticed all the e2e tests had been failing and seeing it was EVERY test, I figured it was related to the second committee popup. It looks like it was running into issues where the committee admin popup wasn't popping up fast enough so it was assuming you'd already completed that step.
I just added a delay to resolve it. Was able to test just fine after that.