### PR TITLE
2128 - Move labels for component, fix phone E2E tests

### DIFF
--- a/front-end/src/app/committee/committee-info/committee-info.component.html
+++ b/front-end/src/app/committee/committee-info/committee-info.component.html
@@ -162,8 +162,8 @@
         <label id="telephone-label" for="treasurer_phone">TELEPHONE</label>
         <app-fec-international-phone-input
           [disabled]="true"
-          id="treasurer_phone"
-          formControlName="treasurer_phone"
+          fieldId="treasurer_phone"
+          fieldFormControlName="treasurer_phone"
           labelName="telephone-label"
         >
         </app-fec-international-phone-input>

--- a/front-end/src/app/committee/committee-info/committee-info.component.html
+++ b/front-end/src/app/committee/committee-info/committee-info.component.html
@@ -162,8 +162,8 @@
         <label id="telephone-label" for="treasurer_phone">TELEPHONE</label>
         <app-fec-international-phone-input
           [disabled]="true"
-          fieldId="treasurer_phone"
-          fieldFormControlName="treasurer_phone"
+          id="treasurer_phone"
+          formControlName="treasurer_phone"
           labelName="telephone-label"
         >
         </app-fec-international-phone-input>

--- a/front-end/src/app/shared/components/contact-dialog/contact-dialog.component.html
+++ b/front-end/src/app/shared/components/contact-dialog/contact-dialog.component.html
@@ -197,7 +197,7 @@
         <div class="col-6">
           <div class="field">
             <label id="telephone-label" for="telephone">TELEPHONE (OPTIONAL)</label>
-            <app-fec-international-phone-input> </app-fec-international-phone-input>
+            <app-fec-international-phone-input formControlName="telephone"> </app-fec-international-phone-input>
             <app-error-messages
               [form]="form"
               fieldName="telephone"

--- a/front-end/src/app/shared/components/contact-dialog/contact-dialog.component.html
+++ b/front-end/src/app/shared/components/contact-dialog/contact-dialog.component.html
@@ -197,8 +197,7 @@
         <div class="col-6">
           <div class="field">
             <label id="telephone-label" for="telephone">TELEPHONE (OPTIONAL)</label>
-            <app-fec-international-phone-input id="telephone" formControlName="telephone" labelName="telephone-label">
-            </app-fec-international-phone-input>
+            <app-fec-international-phone-input> </app-fec-international-phone-input>
             <app-error-messages
               [form]="form"
               fieldName="telephone"

--- a/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.html
+++ b/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.html
@@ -4,9 +4,9 @@
     [class.p-disabled]="disabled"
     #internationalPhoneInput
     type="tel"
-    id="telephone"
-    formControlName="telephone"
-    labelName="telephone-label"
+    [id]="fieldId"
+    [attr.formControlName]="fieldFormControlName"
+    [attr.labelName]="labelName"
     (keyup)="onKey($event)"
     (blur)="onBlur($event)"
   />

--- a/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.html
+++ b/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.html
@@ -4,6 +4,9 @@
     [class.p-disabled]="disabled"
     #internationalPhoneInput
     type="tel"
+    id="telephone"
+    formControlName="telephone"
+    labelName="telephone-label"
     (keyup)="onKey($event)"
     (blur)="onBlur($event)"
   />

--- a/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.html
+++ b/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.html
@@ -4,8 +4,7 @@
     [class.p-disabled]="disabled"
     #internationalPhoneInput
     type="tel"
-    [id]="fieldId"
-    [attr.formControlName]="fieldFormControlName"
+    [id]="id"
     [attr.labelName]="labelName"
     (keyup)="onKey($event)"
     (blur)="onBlur($event)"

--- a/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.ts
+++ b/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.ts
@@ -17,6 +17,8 @@ import intlTelInput, { Iti } from 'intl-tel-input';
   styleUrls: ['./fec-international-phone-input.component.scss'],
 })
 export class FecInternationalPhoneInputComponent implements AfterViewInit, OnChanges, OnDestroy, ControlValueAccessor {
+  @Input() fieldId = 'telephone';
+  @Input() fieldFormControlName = 'telephone';
   @Input() disabled = false;
   @Input() labelName = '';
   @ViewChild('internationalPhoneInput') internationalPhoneInputChild: ElementRef<HTMLInputElement> | undefined;

--- a/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.ts
+++ b/front-end/src/app/shared/components/fec-international-phone-input/fec-international-phone-input.component.ts
@@ -17,8 +17,7 @@ import intlTelInput, { Iti } from 'intl-tel-input';
   styleUrls: ['./fec-international-phone-input.component.scss'],
 })
 export class FecInternationalPhoneInputComponent implements AfterViewInit, OnChanges, OnDestroy, ControlValueAccessor {
-  @Input() fieldId = 'telephone';
-  @Input() fieldFormControlName = 'telephone';
+  @Input() id = 'telephone';
   @Input() disabled = false;
   @Input() labelName = '';
   @ViewChild('internationalPhoneInput') internationalPhoneInputChild: ElementRef<HTMLInputElement> | undefined;


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2128

I'm not sure how these tests were passing in Circle.

**Note**
I noticed `telephone` was missing some labels in the html 

```
<input _ngcontent-ng-c3418061334="" type="tel" aria-labelledby="telephone-label" class="iti__tel-input" autocomplete="off" data-intl-tel-input-id="0" style="padding-left: 75px;">

<input _ngcontent-ng-c1258949998="" type="text" pinputtext="" id="zip" formcontrolname="zip" class="p-inputtext p-component ng-untouched ng-pristine ng-invalid" ng-reflect-name="zip" pc38="">
```
