### PR TITLE
feature/691 -  Allow user to report Repayment of Debt Owed by Committee with Schedule F transactions 

### DIFF
--- a/front-end/cypress/e2e/F3X/debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/debts.cy.ts
@@ -1,7 +1,9 @@
 import { candidateFormData, committeeFormData, organizationFormData } from '../models/ContactFormModel';
 import { defaultDebtFormData as debtFormData } from '../models/TransactionFormModel';
+import { ContactListPage } from '../pages/contactListPage';
 import { Initialize } from '../pages/loginPage';
 import { currentYear, PageUtils } from '../pages/pageUtils';
+import { ReportListPage } from '../pages/reportListPage';
 import { TransactionDetailPage } from '../pages/transactionDetailPage';
 import { F3XSetup, Setup } from './f3x-setup';
 import { StartTransaction } from './utils/start-transaction/start-transaction';
@@ -68,7 +70,10 @@ describe('Debts', () => {
 
   it('should test Debt Owed By Committee loan - Report debt repayment', () => {
     PageUtils.switchCommittee('7c176dc0-7062-49b5-bc35-58b4ef050d08');
+    ReportListPage.deleteAllReports();
+    ContactListPage.deleteAllContacts();
     cy.location('pathname').should('include', '/reports');
+
     setupDebtOwedByCommittee({
       candidate: true,
       organization: true,
@@ -84,8 +89,9 @@ describe('Debts', () => {
     PageUtils.clickAccordion('CONTRIBUTIONS/EXPENDITURES TO REGISTERED FILERS');
     cy.contains('Coordinated Party Expenditure').click({ force: true });
     setupCoordinatedPartyExpenditure();
-
     PageUtils.urlCheck('/list');
     cy.contains('Coordinated Party Expenditure').should('exist');
+
+    PageUtils.switchCommittee('c94c5d1a-9e73-464d-ad72-b73b5d8667a9');
   });
 });

--- a/front-end/cypress/e2e/F3X/debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/debts.cy.ts
@@ -1,9 +1,9 @@
-import { Initialize } from '../pages/loginPage';
-import { PageUtils } from '../pages/pageUtils';
-import { TransactionDetailPage } from '../pages/transactionDetailPage';
+import { candidateFormData, committeeFormData, organizationFormData } from '../models/ContactFormModel';
 import { defaultDebtFormData as debtFormData } from '../models/TransactionFormModel';
-import { committeeFormData } from '../models/ContactFormModel';
-import { F3XSetup } from './f3x-setup';
+import { Initialize } from '../pages/loginPage';
+import { currentYear, PageUtils } from '../pages/pageUtils';
+import { TransactionDetailPage } from '../pages/transactionDetailPage';
+import { F3XSetup, Setup } from './f3x-setup';
 import { StartTransaction } from './utils/start-transaction/start-transaction';
 
 describe('Debts', () => {
@@ -11,8 +11,8 @@ describe('Debts', () => {
     Initialize();
   });
 
-  it('should test Debt Owed By Committee loan', () => {
-    F3XSetup({ committee: true });
+  function setupDebtOwedByCommittee(setup: Setup) {
+    F3XSetup(setup);
     StartTransaction.Debts().ByCommittee();
 
     PageUtils.urlCheck('DEBT_OWED_BY_COMMITTEE');
@@ -21,21 +21,50 @@ describe('Debts', () => {
     PageUtils.searchBoxInput(committeeFormData.committee_id);
     TransactionDetailPage.enterLoanFormData(debtFormData);
     PageUtils.clickButton('Save');
+  }
+
+  function setupCoordinatedPartyExpenditure() {
+    PageUtils.urlCheck('COORDINATED_PARTY_EXPENDITURE');
+    PageUtils.containedOnPage('Coordinated Party Expenditure');
+    PageUtils.dropdownSetValue('#entity_type_dropdown', organizationFormData.contact_type, '');
+    PageUtils.searchBoxInput(organizationFormData.name);
+    PageUtils.searchBoxInput(committeeFormData.committee_id, 'contact_3_lookup');
+    PageUtils.searchBoxInput(candidateFormData.candidate_id, 'contact_2_lookup');
+
+    TransactionDetailPage.enterDate(`[data-cy="expenditure_date"]`, new Date(currentYear, 4 - 1, 27));
+    cy.get("#general_election_year").safeType(currentYear);
+    cy.get('#amount').safeType(100.00);
+    cy.get('#purpose_description').first().safeType("test");
+
+    PageUtils.clickButton('Save');
+  }
+
+  it('should test Debt Owed By Committee loan', () => {
+    setupDebtOwedByCommittee({ committee: true });
     PageUtils.urlCheck('/list');
     cy.contains('Debt Owed By Committee').should('exist');
   });
 
-  it('should test Owed To Committee loan', () => {
-    F3XSetup({ committee: true });
-    StartTransaction.Debts().ToCommittee();
-
-    PageUtils.urlCheck('DEBT_OWED_TO_COMMITTEE');
-    PageUtils.containedOnPage('Debt Owed To Committee');
-
-    PageUtils.searchBoxInput(committeeFormData['committee_id']);
-    TransactionDetailPage.enterLoanFormData(debtFormData);
-    PageUtils.clickButton('Save');
+  it('should test Debt Owed By Committee loan - Report debt repayment', () => {
+    PageUtils.switchCommittee("7c176dc0-7062-49b5-bc35-58b4ef050d08")
+    cy.location('pathname').should('include', '/reports');
+    setupDebtOwedByCommittee({
+      candidate: true,
+      organization: true,
+      committee: true,
+    });
     PageUtils.urlCheck('/list');
-    cy.contains('Debt Owed To Committee').should('exist');
+    cy.contains('Debt Owed By Committee').should('exist');
+
+    PageUtils.clickElement('loans-and-debts-button');
+    cy.contains('Report debt repayment').click({ force: true });
+    PageUtils.urlCheck('select/disbursement?debt=');
+    cy.contains('CONTRIBUTIONS/EXPENDITURES TO REGISTERED FILERS').should('exist');
+    PageUtils.clickAccordion('CONTRIBUTIONS/EXPENDITURES TO REGISTERED FILERS');
+    cy.contains('Coordinated Party Expenditure').click({ force: true });
+    setupCoordinatedPartyExpenditure();
+
+    PageUtils.urlCheck('/list');
+    cy.contains('Coordinated Party Expenditure').should('exist');
   });
 });

--- a/front-end/cypress/e2e/F3X/debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/debts.cy.ts
@@ -32,9 +32,9 @@ describe('Debts', () => {
     PageUtils.searchBoxInput(candidateFormData.candidate_id, 'contact_2_lookup');
 
     TransactionDetailPage.enterDate(`[data-cy="expenditure_date"]`, new Date(currentYear, 4 - 1, 27));
-    cy.get("#general_election_year").safeType(currentYear);
-    cy.get('#amount').safeType(100.00);
-    cy.get('#purpose_description').first().safeType("test");
+    cy.get('#general_election_year').safeType(currentYear);
+    cy.get('#amount').safeType(100.0);
+    cy.get('#purpose_description').first().safeType('test');
 
     PageUtils.clickButton('Save');
   }
@@ -46,7 +46,7 @@ describe('Debts', () => {
   });
 
   it('should test Debt Owed By Committee loan - Report debt repayment', () => {
-    PageUtils.switchCommittee("7c176dc0-7062-49b5-bc35-58b4ef050d08")
+    PageUtils.switchCommittee('7c176dc0-7062-49b5-bc35-58b4ef050d08');
     cy.location('pathname').should('include', '/reports');
     setupDebtOwedByCommittee({
       candidate: true,

--- a/front-end/cypress/e2e/F3X/debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/debts.cy.ts
@@ -43,6 +43,13 @@ describe('Debts', () => {
     setupDebtOwedByCommittee({ committee: true });
     PageUtils.urlCheck('/list');
     cy.contains('Debt Owed By Committee').should('exist');
+
+    PageUtils.clickElement('loans-and-debts-button');
+    cy.contains('Report debt repayment').click({ force: true });
+    PageUtils.urlCheck('select/disbursement?debt=');
+    cy.contains('CONTRIBUTIONS/EXPENDITURES TO REGISTERED FILERS').should('exist');
+    PageUtils.clickAccordion('CONTRIBUTIONS/EXPENDITURES TO REGISTERED FILERS');
+    cy.contains('Coordinated Party Expenditure').should('not.exist'); // PAC committee
   });
 
   it('should test Debt Owed By Committee loan - Report debt repayment', () => {

--- a/front-end/cypress/e2e/F3X/debts.cy.ts
+++ b/front-end/cypress/e2e/F3X/debts.cy.ts
@@ -52,6 +52,20 @@ describe('Debts', () => {
     cy.contains('Coordinated Party Expenditure').should('not.exist'); // PAC committee
   });
 
+  it('should test Owed To Committee loan', () => {
+    F3XSetup({ committee: true });
+    StartTransaction.Debts().ToCommittee();
+
+    PageUtils.urlCheck('DEBT_OWED_TO_COMMITTEE');
+    PageUtils.containedOnPage('Debt Owed To Committee');
+
+    PageUtils.searchBoxInput(committeeFormData['committee_id']);
+    TransactionDetailPage.enterLoanFormData(debtFormData);
+    PageUtils.clickButton('Save');
+    PageUtils.urlCheck('/list');
+    cy.contains('Debt Owed To Committee').should('exist');
+  });
+
   it('should test Debt Owed By Committee loan - Report debt repayment', () => {
     PageUtils.switchCommittee('7c176dc0-7062-49b5-bc35-58b4ef050d08');
     cy.location('pathname').should('include', '/reports');

--- a/front-end/cypress/e2e/pages/pageUtils.ts
+++ b/front-end/cypress/e2e/pages/pageUtils.ts
@@ -176,7 +176,7 @@ export class PageUtils {
     cy.get(alias).find('.p-popover').contains('Switch Committees').click();
     cy.get('.committee-list .committee-info').get(`[id="${committeeId}"]`).click();
     cy.wait('@GetCommitteeMembers'); // Wait for the guard request to resolve
-    cy.wait(1000)
+    cy.wait(1000);
     this.enterSecondCommitteeEmailIfneeded();
   }
 
@@ -187,10 +187,10 @@ export class PageUtils {
       .then(($email) => {
         if ($email.length) {
           cy.contains('Welcome to FECfile').should('exist').click(); // Ensures that the modal is in focus
-          cy.get("#email").should('have.value', '');
-          cy.get("#email").clear().type('admin@admin.com'); // Clearing the field makes the typing behavior consistent
-          cy.get("#email").should('have.value', 'admin@admin.com');
-          cy.get("#email").click();
+          cy.get('#email').should('have.value', '');
+          cy.get('#email').clear().type('admin@admin.com'); // Clearing the field makes the typing behavior consistent
+          cy.get('#email').should('have.value', 'admin@admin.com');
+          cy.get('#email').click();
           PageUtils.clickButton('Save');
         }
       });

--- a/front-end/cypress/e2e/pages/pageUtils.ts
+++ b/front-end/cypress/e2e/pages/pageUtils.ts
@@ -109,8 +109,12 @@ export class PageUtils {
     );
   }
 
-  static searchBoxInput(input: string) {
-    cy.get('[id="searchBox"]').type(input.slice(0, 3));
+  static searchBoxInput(input: string, parentId?: string) {
+    if (parentId) {
+      cy.get(`[id="${parentId}"]`).find('[id="searchBox"]').type(input.slice(0, 3));
+    } else {
+      cy.get('[id="searchBox"]').type(input.slice(0, 3));
+    }
     cy.intercept({
       method: 'Get',
     }).as('search');
@@ -162,5 +166,34 @@ export class PageUtils {
 
   static clickKababItem(identifier: string, item: string) {
     PageUtils.getKabob(identifier).contains(item).first().click({ force: true });
+  }
+
+  static switchCommittee(committeeId: string) {
+    cy.intercept('GET', 'http://localhost:8080/api/v1/committee-members/').as('GetCommitteeMembers');
+    const alias = PageUtils.getAlias('');
+    cy.visit('/dashboard');
+    cy.get('#navbarProfileDropdownMenuLink').click();
+    cy.get(alias).find('.p-popover').contains('Switch Committees').click();
+    cy.get('.committee-list .committee-info').get(`[id="${committeeId}"]`).click();
+    cy.wait('@GetCommitteeMembers'); // Wait for the guard request to resolve
+    cy.wait(1000)
+    this.enterSecondCommitteeEmailIfneeded();
+  }
+
+  static enterSecondCommitteeEmailIfneeded() {
+    cy.get(PageUtils.getAlias(''))
+      .find('[id="second-committee-admin-dialog"]')
+      .should(Cypress._.noop) // No-op to avoid failure if it doesn't exist
+      .then(($email) => {
+        if ($email.length) {
+          cy.contains('Welcome to FECfile').should('exist').click(); // Ensures that the modal is in focus
+          cy.get("#email").should('have.value', '');
+          cy.get("#email").clear().type('admin@admin.com'); // Clearing the field makes the typing behavior consistent
+          cy.get("#email").should('have.value', 'admin@admin.com');
+          cy.get("#email").click();
+          PageUtils.clickButton('Save');
+        }
+      });
+    cy.contains('Welcome to FECfile').should('not.exist');
   }
 }

--- a/front-end/src/app/committee/select-committee/select-committee.component.html
+++ b/front-end/src/app/committee/select-committee/select-committee.component.html
@@ -21,7 +21,7 @@
       } @else if (committees?.length) {
         <div class="committee-list">
           @for (committee of committees; track committee) {
-            <div class="committee-card" (click)="activateCommittee(committee)">
+            <div id="{{committee.id}}" class="committee-card" (click)="activateCommittee(committee)">
               <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg" />
               <div class="committee-info">
                 <h3>

--- a/front-end/src/app/committee/select-committee/select-committee.component.html
+++ b/front-end/src/app/committee/select-committee/select-committee.component.html
@@ -21,7 +21,7 @@
       } @else if (committees?.length) {
         <div class="committee-list">
           @for (committee of committees; track committee) {
-            <div id="{{committee.id}}" class="committee-card" (click)="activateCommittee(committee)">
+            <div id="{{ committee.id }}" class="committee-card" (click)="activateCommittee(committee)">
               <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg" />
               <div class="committee-info">
                 <h3>

--- a/front-end/src/app/reports/transactions/transaction-input/transaction-input.component.html
+++ b/front-end/src/app/reports/transactions/transaction-input/transaction-input.component.html
@@ -10,6 +10,7 @@
       <div class="field">
         <label for="entity_type">LOOKUP</label>
         <app-transaction-contact-lookup
+          id="contact_1_lookup"
           contactProperty="contact_1"
           [transaction]="transaction"
           [form]="form"
@@ -172,6 +173,7 @@
       <div class="candidate_committee_lookup">
         <label for="contact_3">LOOKUP </label>
         <app-transaction-contact-lookup
+          id="contact_3_lookup"
           contactProperty="contact_3"
           [transaction]="transaction"
           [form]="form"
@@ -217,6 +219,7 @@
             }
           </label>
           <app-transaction-contact-lookup
+            id="contact_2_lookup"
             contactProperty="contact_2"
             [transaction]="transaction"
             [form]="form"

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.html
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.html
@@ -13,7 +13,7 @@
               @if (!isTransactionDisabled(transactionType)) {
                 <a
                   [routerLink]="getRouterLink(transactionType)"
-                  [queryParams]="debtId() ? { debt: debtId } : undefined"
+                  [queryParams]="debtId() ? { debt: debtId() } : undefined"
                 >
                   {{ transactionType | label: transactionTypeLabels }}
                 </a>

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -324,8 +324,8 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
 
     if (this.debtId()) {
       const debtPaymentLines = [
-        ...['SB21A', 'SB21B', 'SB22', 'SB23', 'SB24', 'SE', 'SB25', 'SB28A', 'SB28B', 'SB28C', 'SB29', 'H6', 'SB30B'],
-        ...['SA11AI', 'SA11B', 'SA11C', 'SA12', 'SA15', 'SA16', 'SA17', 'H3', 'SF'],
+        ...['SB21A', 'SB21B', 'SB22', 'SB23', 'SB24', 'SE', 'SF', 'SB25', 'SB28A', 'SB28B', 'SB28C', 'SB29', 'H6', 'SB30B'],
+        ...['SA11AI', 'SA11B', 'SA11C', 'SA12', 'SA15', 'SA16', 'SA17', 'H3'],
       ];
       return transactionTypes.filter((transactionType) => {
         if (this.isTransactionDisabled(transactionType)) return false;

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -317,7 +317,7 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
     if (this.debtId()) {
       const debtPaymentLines = [
         ...['SB21A', 'SB21B', 'SB22', 'SB23', 'SB24', 'SE', 'SB25', 'SB28A', 'SB28B', 'SB28C', 'SB29', 'H6', 'SB30B'],
-        ...['SA11AI', 'SA11B', 'SA11C', 'SA12', 'SA15', 'SA16', 'SA17', 'H3'],
+        ...['SA11AI', 'SA11B', 'SA11C', 'SA12', 'SA15', 'SA16', 'SA17', 'H3', 'SF'],
       ];
       return transactionTypes.filter((transactionType) => {
         if (this.isTransactionDisabled(transactionType)) return false;

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -324,7 +324,22 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
 
     if (this.debtId()) {
       const debtPaymentLines = [
-        ...['SB21A', 'SB21B', 'SB22', 'SB23', 'SB24', 'SE', 'SF', 'SB25', 'SB28A', 'SB28B', 'SB28C', 'SB29', 'H6', 'SB30B'],
+        ...[
+          'SB21A',
+          'SB21B',
+          'SB22',
+          'SB23',
+          'SB24',
+          'SE',
+          'SF',
+          'SB25',
+          'SB28A',
+          'SB28B',
+          'SB28C',
+          'SB29',
+          'H6',
+          'SB30B',
+        ],
         ...['SA11AI', 'SA11B', 'SA11C', 'SA12', 'SA15', 'SA16', 'SA17', 'H3'],
       ];
       return transactionTypes.filter((transactionType) => {

--- a/front-end/src/app/shared/components/second-committee-admin-dialog/second-committee-admin-dialog.component.html
+++ b/front-end/src/app/shared/components/second-committee-admin-dialog/second-committee-admin-dialog.component.html
@@ -18,7 +18,7 @@
     Please add the committee administrator to proceed.
   </p>
   <h2>Add a second committee administrator</h2>
-  <form [formGroup]="form">
+  <form id="second-committee-admin-dialog" [formGroup]="form">
     <div class="field">
       <label for="role">Role</label>
       <input class="p-disabled" id="role" name="role" pInputText formControlName="role" readonly />
@@ -32,6 +32,7 @@
   <ng-template #footer>
     <div class="flex w-full justify-content-end">
       <p-button
+        id="save"
         type="submit"
         (keydown.enter)="save()"
         (click)="save()"


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-691

Related PRs: https://github.com/fecgov/fecfile-web-api/pull/1428

almost all of this work is to support a new e2e tests for debt repayments w/ schedule F.  There is also a negative tests to confirm that coordinated party expenditure does not show in PAC committee debt repayment options.