### PR TITLE
Patch - Fix TSConfig file to get E2E tests running again

### DIFF
--- a/front-end/tsconfig.json
+++ b/front-end/tsconfig.json
@@ -29,5 +29,5 @@
         "strictInputAccessModifiers": true,
         "strictTemplates": true
     },
-    "exclude": ["./cypress.config.ts","cypress/**/*.ts",]
+    "exclude": ["./cypress.config.ts"]
 }


### PR DESCRIPTION
Reverts the exclusion of all cypress tests, since this prevents cypress tests from running

Ticket link: N/A

Related PRs:
