### PR TITLE
feature/588 - Update all references to gandhi and karla to use var(). Updated submit-report-status to use corrected font size.

### DIFF
--- a/front-end/src/app/committee/committee-info/committee-info.component.scss
+++ b/front-end/src/app/committee/committee-info/committee-info.component.scss
@@ -9,7 +9,7 @@
 }
 
 input {
-  font-family: karla-bold, serif;
+  font-family: var(--karla-bold);
   font-size: 14px;
   color: #212121;
   height: 42px;
@@ -21,7 +21,7 @@ input {
   }
 
   .p-select > .p-inputtext {
-    font-family: karla-bold, serif;
+    font-family: var(--karla-bold);
     font-size: 14px;
     color: #212121;
   }
@@ -29,7 +29,7 @@ input {
   #treasurer_phone,
   #treasurer_phone input {
     height: 42px;
-    font-family: karla-bold, serif;
+    font-family: var(--karla-bold);
     font-size: 14px;
     color: #212121;
   }

--- a/front-end/src/app/committee/create-committee/create-committee.component.scss
+++ b/front-end/src/app/committee/create-committee/create-committee.component.scss
@@ -79,14 +79,14 @@
 }
 .unable-verbiage-p1 {
   text-align: center;
-  font-family: karla-bold, serif;
+  font-family: var(--karla-bold);
   font-size: x-large;
   line-height: normal;
   margin-bottom: 10px;
 }
 .unable-verbiage-p2 {
   text-align: center;
-  font-family: karla-bold, serif;
+  font-family: var(--karla-bold);
   font-size: small;
   line-height: normal;
 }

--- a/front-end/src/app/layout/banner/banner.component.scss
+++ b/front-end/src/app/layout/banner/banner.component.scss
@@ -21,7 +21,7 @@
 
 .usa-banner__content {
   p {
-    font-family: karla, sans-serif;
+    font-family: var(--karla);
   }
   margin-left: auto;
   margin-right: auto;
@@ -77,7 +77,7 @@
 }
 
 .usa-banner__header-text {
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   margin-bottom: 0;
   margin-top: 0;
   font-size: 13px;

--- a/front-end/src/app/layout/committee-banner/committee-banner.component.scss
+++ b/front-end/src/app/layout/committee-banner/committee-banner.component.scss
@@ -1,15 +1,6 @@
 .committee-name,
 .sub-banner-item {
-  font-family:
-    karla,
-    Segoe UI,
-    Roboto,
-    Helvetica,
-    Arial,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
+  font-family: var(--karla);
   color: #212121;
   margin: 0;
   text-transform: uppercase;
@@ -25,14 +16,6 @@
 .sub-banner-item {
   font-weight: bold;
   font-size: 14px;
-}
-
-.pipe-separator {
-  font-family: ghandi-bold, serif;
-  font-weight: lighter;
-  font-size: 18px;
-  padding-left: 8px;
-  padding-right: 8px;
 }
 
 .status-circle {

--- a/front-end/src/app/layout/feedback-overlay/feedback-overlay.component.scss
+++ b/front-end/src/app/layout/feedback-overlay/feedback-overlay.component.scss
@@ -81,6 +81,6 @@
   }
 
   .p-popover .p-popover-content * {
-    font-family: karla, sans-serif;
+    font-family: var(--karla);
   }
 }

--- a/front-end/src/app/layout/header/header-links/header-links.component.scss
+++ b/front-end/src/app/layout/header/header-links/header-links.component.scss
@@ -13,7 +13,7 @@
   align-items: center;
   padding: 8px;
   font-size: 12px;
-  font-family: 'karla-bold', sans-serif;
+  font-family: var(--karla-bold);
   text-transform: uppercase;
   cursor: pointer;
   gap: 4px;

--- a/front-end/src/app/login/login/login.component.scss
+++ b/front-end/src/app/login/login/login.component.scss
@@ -1,5 +1,5 @@
 .login-box-header {
-  font-family: 'karla-bold', Sans-serif;
+  font-family: var(--karla-bold);
   font-size: 32px;
   padding: 0px;
 }
@@ -49,7 +49,7 @@
 }
 
 .learn-more-link {
-  font-family: 'karla-bold', Sans-serif;
+  font-family: var(--karla-bold);
   font-size: 14px;
   color: #112e51;
   border-bottom: 1px dotted #112e51;

--- a/front-end/src/app/login/security-notice/security-notice.component.scss
+++ b/front-end/src/app/login/security-notice/security-notice.component.scss
@@ -34,7 +34,7 @@ p + ul {
 :host ::ng-deep {
   .p-checkbox-label {
     font-style: italic;
-    font-family: gandhi-regular, serif;
+    font-family: var(--gandhi-regular);
   }
 }
 
@@ -43,7 +43,7 @@ p + ul {
   top: 64px;
   right: 32px;
   font-size: 18px;
-  font-family: 'karla-bold', sans-serif;
+  font-family: var(--karla-bold);
   text-transform: uppercase;
   text-shadow: #000000 1px 0 10px;
   color: white !important;

--- a/front-end/src/app/reports/submission-workflow/submit-report-status.component.scss
+++ b/front-end/src/app/reports/submission-workflow/submit-report-status.component.scss
@@ -1,36 +1,33 @@
 .submission-status-heading {
-  font-family: ghandi, serif;
-  font-size: 36px;
   margin-bottom: 14px;
 }
 
 .submission-status-text {
-  font-family: karla, sans-serif;
-  font-size: 20px;
+  font-size: 18px;
   margin-bottom: 18px;
 }
 
 .submission-info-heading {
-  font-family: karla-bold, serif;
+  font-family: var(--karla-bold);
   font-size: 20px;
   margin: 0px;
 }
 
 .submission-info-text {
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   font-size: 14px;
   margin-bottom: 14px;
 }
 
 .assistance-heading {
-  font-family: karla-bold, serif;
+  font-family: var(--karla-bold);
   font-size: 16px;
   margin-top: 0px;
   margin-bottom: 6px;
 }
 
 .assistance-text {
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   font-size: 14px;
   margin-bottom: 30px;
 }
@@ -40,7 +37,7 @@
 }
 
 .error-text {
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   font-size: 16px;
   margin-bottom: 28px;
 }

--- a/front-end/src/app/reports/transactions/transaction.scss
+++ b/front-end/src/app/reports/transactions/transaction.scss
@@ -44,7 +44,7 @@
 }
 
 .subtitle {
-  font-family: karla-bold, serif;
+  font-family: var(--karla-bold);
   font-size: 14px;
   color: #212121;
   padding-top: 8px;
@@ -55,16 +55,7 @@
 }
 
 .read-only-tag {
-  font-family:
-    karla,
-    Segoe UI,
-    Roboto,
-    Helvetica,
-    Arial,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
+  font-family: var(--karla);
   color: gray;
   text-transform: uppercase;
   margin-bottom: 2.5em;

--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.scss
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.scss
@@ -14,7 +14,7 @@
 
   .p-select-label {
     color: #212121;
-    font-family: karla-bold, sans-serif;
+    font-family: var(--karla-bold);
     font-size: 16px;
     width: 132px;
     height: 42px;
@@ -75,7 +75,7 @@
 .add-contact-container {
   padding: 0 0 0 10px;
   font-size: 1.2em;
-  font-family: karla-bold, sans-serif;
+  font-family: var(--karla-bold);
   align-content: center;
 }
 

--- a/front-end/src/app/shared/components/download-tray/download-tray.component.scss
+++ b/front-end/src/app/shared/components/download-tray/download-tray.component.scss
@@ -1,5 +1,5 @@
 .download-text {
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   color: #112e51;
   font-size: 12px;
 }

--- a/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.scss
+++ b/front-end/src/app/shared/components/inputs/amount-input/amount-input.component.scss
@@ -13,7 +13,7 @@
 #out-of-date-dialog-text {
   padding-left: 40px;
   padding-right: 40px;
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   font-size: 14px;
   line-height: 1.3;
   color: #212121;

--- a/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.scss
+++ b/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.scss
@@ -14,7 +14,7 @@
 #out-of-date-dialog-text {
   padding-left: 40px;
   padding-right: 40px;
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   font-size: 14px;
   line-height: 1.3;
   color: #212121;

--- a/front-end/src/assets/styles/_variables.scss
+++ b/front-end/src/assets/styles/_variables.scss
@@ -95,6 +95,9 @@
 
   /* Font */
   --karla: karla, Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  --karla-bold:
+    karla-bold, karla, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol;
   --gandhi-bold: 'gandhi-bold', serif;
   --gandhi-regular: gandhi-regular, serif;
 

--- a/front-end/src/assets/styles/typography.css
+++ b/front-end/src/assets/styles/typography.css
@@ -109,7 +109,7 @@ input[type='file'] {
 }
 label {
   margin: 0;
-  font-family: karla-bold, sans-serif;
+  font-family: var(--karla-bold);
 }
 input,
 select,

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -29,7 +29,7 @@ hr.black-line {
 }
 
 .p-drawer-header {
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
   font-weight: bold;
   color: #112e51;
   font-size: 16px;
@@ -73,7 +73,7 @@ label.disabled {
 
 .label-note {
   color: grey;
-  font-family: karla, sans-serif;
+  font-family: var(--karla);
 }
 
 .bold {
@@ -128,33 +128,6 @@ label.disabled {
   color: #aeb0b5;
 }
 
-.font-karla {
-  font-family:
-    karla,
-    Segoe UI,
-    Roboto,
-    Helvetica,
-    Arial,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
-}
-
-.font-karla-bold {
-  font-family:
-    karla-bold,
-    karla,
-    Segoe UI,
-    Roboto,
-    Helvetica,
-    Arial,
-    sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
-}
-
 .fec-background-gradient {
   background-image: linear-gradient(to bottom right, #1a4f82, #112e51);
 }
@@ -199,11 +172,6 @@ label.disabled {
 
 .form-type-dialog p-select {
   display: flex;
-}
-
-.title1 {
-  font-family: ghandi-bold, serif;
-  font-size: 32px;
 }
 
 .add-button {

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -128,6 +128,14 @@ label.disabled {
   color: #aeb0b5;
 }
 
+.font-karla {
+  font-family: var(--karla);
+}
+
+.font-karla-bold {
+  font-family: var(--karla-bold);
+}
+
 .fec-background-gradient {
   background-image: linear-gradient(to bottom right, #1a4f82, #112e51);
 }


### PR DESCRIPTION
Issue [FECFILE-588](https://fecgov.atlassian.net/browse/FECFILE-588)
Issue [FECFILE-1131](https://fecgov.atlassian.net/browse/FECFILE-1131)

Updated the h2 (Report submission received) to default to the h2 font-family and font-size (gandhi-bold and 24px)
Updated the submission status (Your submission to the FEC has been received.) to have a font-size of 18px and to default to the paragraph tag for font-family (gandhi-regular).

I also went through to find other misspellings. There were a couple but thankfully they were for "dead" style classes which weren't used anywhere in the code. 

As a preventative measure I updated everywhere where we were manually declaring the font-family to use the declared variables. This should hopefully help prevent misspellings in the future by leading people to use the variable and also future proofing it so if, for whatever reason, we decide to change font-families we'd only need to change it in one place.