### PR TITLE
Update python to 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.4.8
   node: circleci/node@6.3.0
-  python: circleci/python@2.1.1
+  python: circleci/python@2.2.0
 
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
@@ -182,7 +182,7 @@ jobs:
   dependency-check:
     docker:
       - image: cimg/node:lts-browsers
-      - image: cimg/python:3.10-node
+      - image: cimg/python:3.11-node
 
     steps:
       - checkout


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2037

- Update python to 3.11
- Update Circle orb to match API

Related PRs: https://github.com/fecgov/fecfile-web-api/pull/1489
