### PR TITLE
feature/2234 - zip code field getting scrambled when refreshing any page

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -21,7 +21,7 @@
                 "intl-tel-input": "^23.0.4",
                 "lodash": "^4.17.21",
                 "luxon": "^3.5.0",
-                "ngrx-store-localstorage": "~19.0.0",
+                "ngrx-store-localstorage": "19.0.0",
                 "ngx-cookie-service": "^19.1.2",
                 "ngx-logger": "^5.0.12",
                 "primeflex": "^4.0.0",
@@ -12222,10 +12222,10 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
         "node_modules/ngrx-store-localstorage": {
-            "version": "19.0.1",
-            "resolved": "https://registry.npmjs.org/ngrx-store-localstorage/-/ngrx-store-localstorage-19.0.1.tgz",
-            "integrity": "sha512-DXltn2IahkUK7kYNd3V58xUBrF/j2KHrviqOWAhjgeejWwTQ3Hirao7AEFaJRSEmZia5uWu51HauW55e5nlncQ==",
-            "deprecated": "Date parsing logic incorrectly treats some numbers as dates. See https://github.com/btroncone/ngrx-store-localstorage/issues/275",
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/ngrx-store-localstorage/-/ngrx-store-localstorage-19.0.0.tgz",
+            "integrity": "sha512-aONkwb2oW8BI9p6Hqyc6UvB8N51LgPSPg6ogg/ypYCQqRP/p8CDgDuYfkXyQktO1WS+2wKV4lPvGdjfb8dJwEw==",
+            "license": "MIT",
             "dependencies": {
                 "deepmerge": "^4.2.2",
                 "tslib": "^2.3.0"

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -39,7 +39,7 @@
         "luxon": "^3.5.0",
         "@types/lodash": "^4.17.14",
         "@types/luxon": "^3.4.2",
-        "ngrx-store-localstorage": "~19.0.0",
+        "ngrx-store-localstorage": "19.0.0",
         "ngx-cookie-service": "^19.1.2",
         "ngx-logger": "^5.0.12",
         "primeflex": "^4.0.0",


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2234

Related PRs:

As noted in the ticket comments, this is a known issue with our ngrx-store-localstorage dependency and v19.0.1 has been deprecated as a result.
![image](https://github.com/user-attachments/assets/a2770609-dbb6-4df2-b828-52df301a45d4)

A follow-up ticket to unpin the dependency has been added [here](https://fecgov.atlassian.net/browse/FECFILE-2244).