### PR TITLE
feature/2184 - Fix broken unit tests in the Additional Info and Report Level Memo components

### DIFF
--- a/front-end/src/app/reports/shared/report-level-memo/report-level-memo.component.spec.ts
+++ b/front-end/src/app/reports/shared/report-level-memo/report-level-memo.component.spec.ts
@@ -3,10 +3,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { provideMockStore } from '@ngrx/store/testing';
-import { testMockStore } from 'app/shared/utils/unit-test.utils';
-import { Report, MemoText } from 'app/shared/models';
+import { MemoText, Report } from 'app/shared/models';
 import { MemoTextService } from 'app/shared/services/memo-text.service';
+import { testMockStore } from 'app/shared/utils/unit-test.utils';
 
+import { provideHttpClient } from '@angular/common/http';
+import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
 import { MessageService, ToastMessageOptions } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -14,8 +16,6 @@ import { TextareaModule } from 'primeng/textarea';
 import { ToastModule } from 'primeng/toast';
 import { of } from 'rxjs';
 import { ReportLevelMemoComponent } from './report-level-memo.component';
-import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
-import { provideHttpClient } from '@angular/common/http';
 
 describe('ReportLevelMemoComponent', () => {
   let component: ReportLevelMemoComponent;
@@ -58,7 +58,7 @@ describe('ReportLevelMemoComponent', () => {
     fixture.detectChanges();
   });
 
-  xit('should create', () => {
+  it('should create', () => {
     const testText4kValue = 'testText4k';
     const testMemoText: MemoText = new MemoText();
     testMemoText.id = '4';
@@ -73,7 +73,7 @@ describe('ReportLevelMemoComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  xit('save for existing memo text happy path', async () => {
+  it('save for existing memo text happy path', async () => {
     const expectedMessage: ToastMessageOptions = {
       severity: 'success',
       summary: 'Successful',
@@ -91,7 +91,7 @@ describe('ReportLevelMemoComponent', () => {
     expect(testMessageServiceSpy).toHaveBeenCalledOnceWith(expectedMessage);
   });
 
-  xit('save for new memo text happy path', async () => {
+  it('save for new memo text happy path', async () => {
     const expectedMessage: ToastMessageOptions = {
       severity: 'success',
       summary: 'Successful',

--- a/front-end/src/app/shared/components/inputs/additional-info-input/additional-info-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/additional-info-input/additional-info-input.component.spec.ts
@@ -42,11 +42,11 @@ describe('AdditionalInfoInputComponent', () => {
     fixture.detectChanges();
   });
 
-  xit('should create', () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  xit('should have a read-only cpd if system generated', () => {
+  it('should have a read-only cpd if system generated', () => {
     if (component.transaction?.transactionType)
       component.transaction.transactionType.generatePurposeDescription = () => 'description';
     fixture.detectChanges();
@@ -60,7 +60,7 @@ describe('AdditionalInfoInputComponent', () => {
     expect(cpd.classes['readonly']).toBeFalsy();
   });
 
-  xit('should trigger the purposeDescriptionPrefix callbacks', () => {
+  it('should trigger the purposeDescriptionPrefix callbacks', () => {
     component.form.patchValue({
       [testTemplateMap.purpose_description]: 'abc',
     });
@@ -76,7 +76,7 @@ describe('AdditionalInfoInputComponent', () => {
     );
   });
 
-  xit('should detect memo prefixes', () => {
+  it('should detect memo prefixes', () => {
     expect(component.form.get(testTemplateMap.text4000)?.value).toEqual('');
     if (component.transaction) {
       component.transaction.memo_text = MemoText.fromJSON({

--- a/front-end/src/app/shared/components/inputs/additional-info-input/additional-info-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/additional-info-input/additional-info-input.component.spec.ts
@@ -1,13 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { TextareaModule } from 'primeng/textarea';
-import { ErrorMessagesComponent } from '../../error-messages/error-messages.component';
-import { testScheduleATransaction, testTemplateMap } from 'app/shared/utils/unit-test.utils';
-import { AdditionalInfoInputComponent } from './additional-info-input.component';
 import { MemoText } from 'app/shared/models/memo-text.model';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
+import { testScheduleATransaction, testTemplateMap } from 'app/shared/utils/unit-test.utils';
+import { TextareaModule } from 'primeng/textarea';
+import { ErrorMessagesComponent } from '../../error-messages/error-messages.component';
 import { DesignatedSubordinateInputComponent } from '../designated-subordinate-input/designated-subordinate-input.component';
+import { AdditionalInfoInputComponent } from './additional-info-input.component';
 
 describe('AdditionalInfoInputComponent', () => {
   let component: AdditionalInfoInputComponent;
@@ -54,9 +54,11 @@ describe('AdditionalInfoInputComponent', () => {
     expect(cpd.classes['readonly']).toBeTruthy();
   });
 
-  xit('should have a mutable cpd if not system generated', () => {
-    const cpd = fixture.debugElement.query(By.css('#purpose_description'));
+  it('should have a mutable cpd if not system generated', () => {
+    if (component.transaction?.transactionType)
+      component.transaction.transactionType.generatePurposeDescription = undefined;
     fixture.detectChanges();
+    const cpd = fixture.debugElement.query(By.css('#purpose_description'));
     expect(cpd.classes['readonly']).toBeFalsy();
   });
 


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2184

Related PRs:

After local testing and circleci testing, I could only reproduce one of the unit test failures.  This failure (for CPD readonly attribute) needed a small change to fix.  Otherwise, just removed xit from the unit tests.
