### PR TITLE
feature/1926 - Updated select button styling to match styleguide

### DIFF
--- a/front-end/src/assets/styles/theme.css
+++ b/front-end/src/assets/styles/theme.css
@@ -1655,9 +1655,14 @@ p-selectbutton.ng-dirty.ng-invalid > .p-selectbutton > .p-button {
   transition: height 0.15s;
 }
 
+.p-togglebutton-content {
+  padding: 8px 20px;
+}
+
 .p-togglebutton {
+  padding: 0;
   background: var(--p-content-background);
-  border: 3px solid var(--fec-grey-alt);
+  border: 2px solid var(--fec-grey-alt);
   color: var(--p-content-color);
   font-weight: 400;
   font-family: var(--karla);
@@ -1666,6 +1671,12 @@ p-selectbutton.ng-dirty.ng-invalid > .p-selectbutton > .p-button {
     background-color 0.15s,
     border-color 0.15s,
     box-shadow 0.15s;
+}
+.p-selectbutton .p-togglebutton:first-child:not(.p-togglebutton-checked) {
+  border-right: 0px;
+}
+.p-selectbutton .p-togglebutton:last-child:not(.p-togglebutton-checked) {
+  border-left: 0px;
 }
 .p-togglebutton .p-button-icon-left,
 .p-togglebutton .p-button-icon-right {
@@ -1910,8 +1921,7 @@ p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
   background: var(--surface-border);
   color: #5b616b;
 }
-.p-button:focus,
-.p-togglebutton:focus {
+.p-button:focus {
   outline: 0 none;
   outline-offset: 0;
   box-shadow: var(--focus-ring);

--- a/front-end/src/assets/styles/theme.css
+++ b/front-end/src/assets/styles/theme.css
@@ -1548,10 +1548,11 @@ p-radiobutton.ng-dirty.ng-invalid > .p-radiobutton > .p-radiobutton-box {
 
 .p-selectbutton {
   display: flex;
+  width: fit-content;
 }
 
 .p-selectbutton > p-togglebutton {
-  width: 50%;
+  width: fit-content;
   text-wrap-mode: nowrap;
 }
 


### PR DESCRIPTION
Issue [FECFILE-1926](https://fecgov.atlassian.net/browse/FECFILE-1926)

Updated to match [reference](https://fec-pattern-library.app.cloud.gov/components/detail/horizontal.html).
Key changes:
- Border width changed from 3px to 2px.
- Inner padding locked at  8px 20px
- Width of toggle buttons set by content rather than number of buttons
- removed focus ring that appeared when you clicked an option
- Removed left border from right option when selecting left option and removed right border from left option when selecting right option