### PR TITLE
feature/2308 - Fix missing flex-direction:column which broke pages with main-content class

### DIFF
--- a/front-end/src/app/layout/layout.component.scss
+++ b/front-end/src/app/layout/layout.component.scss
@@ -23,6 +23,7 @@
   width: fit-content;
   flex: 1;
   display: flex;
+  flex-direction: column;
 }
 
 .sidebar-content-container > .main-content {


### PR DESCRIPTION
Issue [FECFILE-2308](https://fecgov.atlassian.net/browse/FECFILE-2308)

Somehow forgot to add the flex-direction: column to the main-content page which made all the pages with that load as a row instead 🤦🏼‍♀️ 