### PR TITLE
feature/2308 - Fix layout issue with login page and sidebar pages

### DIFF
--- a/front-end/src/app/layout/layout.component.html
+++ b/front-end/src/app/layout/layout.component.html
@@ -24,7 +24,7 @@
           </div>
         </div>
         <div class="flex-grow-1 flex flex-column">
-          <div class="flex-grow-1" [style.minHeight]="'64px'"></div>
+          <div class="flex-grow-1 footer-spacer"></div>
           <app-footer [showSidebar]="true"></app-footer>
         </div>
       </div>

--- a/front-end/src/app/layout/layout.component.html
+++ b/front-end/src/app/layout/layout.component.html
@@ -24,7 +24,7 @@
           </div>
         </div>
         <div class="flex-grow-1 flex flex-column">
-          <div class="flex-grow-1"></div>
+          <div class="flex-grow-1" [style.minHeight]="'64px'"></div>
           <app-footer [showSidebar]="true"></app-footer>
         </div>
       </div>

--- a/front-end/src/app/layout/layout.component.scss
+++ b/front-end/src/app/layout/layout.component.scss
@@ -44,6 +44,10 @@ app-footer {
   padding: 0;
 }
 
+.footer-spacer {
+  min-height: 64px;
+}
+
 .sidebar-content-container {
   min-height: calc(100vh - 2rem);
   width: calc(100% - 250px);

--- a/front-end/src/app/login/login/login.component.scss
+++ b/front-end/src/app/login/login/login.component.scss
@@ -1,7 +1,3 @@
-:root {
-  --scrollbar-width: 0px; /* Default value, will be updated by JavaScript if needed */
-}
-
 .login-box-header {
   font-family: var(--karla-bold);
   font-size: 32px;
@@ -83,6 +79,7 @@
   position: relative;
   padding-bottom: 64px;
   height: calc(100% - 301px);
+  flex: 1;
 }
 
 .blue-background {

--- a/front-end/src/app/login/login/login.component.ts
+++ b/front-end/src/app/login/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { AfterViewChecked, Component, inject, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { userLoginDataDiscardedAction } from 'app/store/user-login-data.actions';
 import { CookieService } from 'ngx-cookie-service';
@@ -11,7 +11,7 @@ import { NgOptimizedImage } from '@angular/common';
   styleUrls: ['./login.component.scss'],
   imports: [NgOptimizedImage],
 })
-export class LoginComponent implements OnInit {
+export class LoginComponent implements OnInit, AfterViewChecked {
   private readonly store = inject(Store);
   private readonly cookieService = inject(CookieService);
   public loginDotGovAuthUrl: string | undefined;
@@ -22,8 +22,11 @@ export class LoginComponent implements OnInit {
     this.store.dispatch(userLoginDataDiscardedAction());
     this.loginDotGovAuthUrl = environment.loginDotGovAuthUrl;
 
-    this.updateScrollbarWidth();
     window.addEventListener('resize', this.updateScrollbarWidth);
+  }
+
+  ngAfterViewChecked() {
+    this.updateScrollbarWidth();
   }
 
   navigateToLoginDotGov() {

--- a/front-end/src/assets/styles/_variables.scss
+++ b/front-end/src/assets/styles/_variables.scss
@@ -142,4 +142,6 @@
   --orange: #f77b42;
 
   color-scheme: light;
+
+  --scrollbar-width: 0px;
 }

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -517,3 +517,9 @@ table {
   font-size: 1.5rem;
   margin-left: 0.5rem;
 }
+
+app-login {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}


### PR DESCRIPTION
Issue [FECFIL-2308](https://fecgov.atlassian.net/browse/FECFILE-2308)

Every time I think I have it I find something else. So the reason I must've taken that column flex-direction off was because it broke the login page, but I eventually found the problem was because the internal element wasn't growing to fill when it was set to column, so the blue background portion wasn't stretching as it should have. I got that fixed. 
And as I was messing around with all the other pages to make sure nothing us was broken I noticed 2 other things.
1. The scrollbar fix wasn't happening at the right time. I needed to  move the variable into the _variables sheet where it belonged. And tell it to run after the view is checked. (This fix is mostly for the blue background of the login page so it adjust the width of the full width to account for the scrollbar which varies from browser to browser.)
2. The 64px minimum padding that's supposed to be on every page was missing on the pages with a sidebar now. That was easily fixed by setting the grow div to have a minimum height of 64px.