### PR TITLE
[Sprint 66] feature/2328 - Append datepicker to body to prevent overlay issue when datepicker is near bottom of the component

### DIFF
--- a/front-end/src/app/shared/components/calendar/calendar.component.html
+++ b/front-end/src/app/shared/components/calendar/calendar.component.html
@@ -1,6 +1,7 @@
 <div class="field">
   <label [for]="fieldName" [innerHTML]="label"></label>
   <p-datepicker
+    appendTo="body"
     (onFocus)="calendarOpened = true"
     (onClose)="validateDate(false)"
     (onBlur)="validateDate(calendarOpened)"


### PR DESCRIPTION
Issue [FECFILE-2328](https://fecgov.atlassian.net/browse/FECFILE-2328)