### PR TITLE
feature/2381 - Update circle config to latest version to make sure lts version of node is used everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ version: 2.1
 
 # See: https://circleci.com/docs/2.0/orb-intro/
 orbs:
-  browser-tools: circleci/browser-tools@1.4.8
-  node: circleci/node@6.3.0
-  python: circleci/python@2.2.0
+  browser-tools: circleci/browser-tools@2.2.1
+  node: circleci/node@7.1.1
+  python: circleci/python@3.2.0
 
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
@@ -42,8 +42,8 @@ jobs:
     steps:
       - checkout
 
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install_chrome
+      - browser-tools/install_chromedriver
       - run:
           command: |
             google-chrome --version
@@ -157,7 +157,7 @@ jobs:
           destination: cypress/results
   deploy-job:
     docker:
-      - image: cimg/python:3.12-node
+      - image: cimg/python:3.13-node
     resource_class: large
     steps:
       - checkout
@@ -183,7 +183,7 @@ jobs:
 
   dependency-check:
     docker:
-      - image: cimg/python:3.12-node
+      - image: cimg/python:3.13-node
 
     steps:
       - checkout


### PR DESCRIPTION
Issue [FECFILE-2381](https://fecgov.atlassian.net/issues/?filter=10045&selectedIssue=FECFILE-2381)

API [PR1608](https://github.com/fecgov/fecfile-web-api/pull/1608)
Validate [PR377](https://github.com/fecgov/fecfile-validate/pull/377)

Simply updating the orbs and docker images led to breaking builds and I needed to make a few changes to get it to pass.