### PR TITLE
feature/2458 - Update so outer contact gets cleared when saved

### DIFF
--- a/front-end/src/app/contacts/contact-list/contact-list.component.spec.ts
+++ b/front-end/src/app/contacts/contact-list/contact-list.component.spec.ts
@@ -167,4 +167,15 @@ describe('ContactListComponent', () => {
     component.saveContact(contact);
     expect(service.create).toHaveBeenCalledTimes(1);
   });
+
+  it('setting outer contact saves and resets to null', () => {
+    const contact = testContact();
+    contact.id = undefined;
+    spyOn(service, 'create').and.returnValue(Promise.resolve(contact));
+    spyOn(service, 'getTableData').and.returnValue(Promise.resolve(tableDataResponse));
+    component.manager().outerContact.set(contact);
+    fixture.detectChanges();
+    expect(service.create).toHaveBeenCalledTimes(1);
+    expect(component.manager().outerContact()).toBeNull();
+  });
 });

--- a/front-end/src/app/contacts/contact-list/contact-list.component.ts
+++ b/front-end/src/app/contacts/contact-list/contact-list.component.ts
@@ -76,6 +76,7 @@ export class ContactListComponent extends TableListBaseComponent<Contact> implem
 
   ngOnInit() {
     this.cmService.activeKey.set('');
+    this.manager().outerContact.set(null);
   }
 
   public override async loadTableItems(event: TableLazyLoadEvent): Promise<void> {
@@ -146,6 +147,7 @@ export class ContactListComponent extends TableListBaseComponent<Contact> implem
         });
       });
     }
+    this.manager().outerContact.set(null);
   }
 
   async restoreLoader() {


### PR DESCRIPTION
Issue [FECFILE-2458](https://fecgov.atlassian.net/browse/FECFILE-2458)

The issue was that the contact info wasn't being cleared on save. So when you left and returned it was re-saving it.