### PR TITLE
2429 - Remove defaultProject warning

### DIFF
--- a/front-end/angular.json
+++ b/front-end/angular.json
@@ -240,7 +240,6 @@
             }
         }
     },
-    "defaultProject": "fecfile-web",
     "schematics": {
         "@schematics/angular:component": {
             "style": "scss"


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2429

defaultProject has been deprecated. https://github.com/angular/angular-cli/issues/11111

Test with https://github.com/fecgov/fecfile-web-app?tab=readme-ov-file#running-the-front-end-locally
```npx -p @angular/cli ng serve```

**Before**
<img width="504" height="42" alt="Screenshot 2025-09-29 at 11 31 20 AM" src="https://github.com/user-attachments/assets/7c0afed9-4e8c-481a-b19b-c7c7b67ead0a" />

**After**
<img width="504" height="42" alt="Screenshot 2025-09-29 at 11 31 43 AM" src="https://github.com/user-attachments/assets/412ef2d8-3a6e-439e-96c1-9d216cab96a4" />

