### PR TITLE
Feature/1933 - Update Report List to show separate tables for each form type.

### DIFF
--- a/front-end/cypress/e2e/F3X/reports-f3x.cy.ts
+++ b/front-end/cypress/e2e/F3X/reports-f3x.cy.ts
@@ -14,9 +14,10 @@ describe('Manage reports', () => {
   it('Create a Quarterly Election Year report', () => {
     ReportListPage.createF3X();
     ReportListPage.goToPage();
-    cy.get('tr').should('contain', 'Form 3X');
-    cy.get('tr').should('contain', 'GENERAL (12G)');
-    cy.get('tr').should('contain', `04/01/${currentYear} - 04/30/${currentYear}`);
+    cy.get('[data-cy="form3x-list-component').as('form3xTable');
+    cy.get('@form3xTable').get('tr').should('contain', 'In progress');
+    cy.get('@form3xTable').get('tr').should('contain', 'GENERAL (12G)');
+    cy.get('@form3xTable').get('tr').should('contain', `04/01/${currentYear} - 04/30/${currentYear}`);
   });
 
   it('Create a Monthly Election Year report', () => {
@@ -29,8 +30,8 @@ describe('Manage reports', () => {
     };
     ReportListPage.createF3X(formData);
     ReportListPage.goToPage();
-    cy.get('tr').should('contain', 'Form 3X');
-    cy.get('tr').should('contain', 'OCTOBER 20 MONTHLY REPORT (M10)');
+    cy.get('[data-cy="form3x-list-component').as('form3xTable');
+    cy.get('@form3xTable').get('tr').should('contain', 'OCTOBER 20 MONTHLY REPORT (M10)');
   });
 
   it('Create a Quarterly Non-Election Year report', () => {
@@ -43,8 +44,8 @@ describe('Manage reports', () => {
     };
     ReportListPage.createF3X(formData);
     ReportListPage.goToPage();
-    cy.get('tr').should('contain', 'Form 3X');
-    cy.get('tr').should('contain', 'RUNOFF (30R)');
+    cy.get('[data-cy="form3x-list-component').as('form3xTable');
+    cy.get('@form3xTable').get('tr').should('contain', 'RUNOFF (30R)');
   });
 
   it('Create a Monthly Non-Election Year report', () => {
@@ -58,9 +59,9 @@ describe('Manage reports', () => {
     };
     ReportListPage.createF3X(formData);
     ReportListPage.goToPage();
-    cy.get('tr').should('contain', 'Form 3X');
-    cy.get('tr').should('contain', 'JANUARY 31 YEAR-END (YE)');
-    cy.get('tr').should('contain', `04/01/${currentYear} - 04/30/${currentYear}`);
+    cy.get('[data-cy="form3x-list-component').as('form3xTable');
+    cy.get('@form3xTable').get('tr').should('contain', 'JANUARY 31 YEAR-END (YE)');
+    cy.get('@form3xTable').get('tr').should('contain', `04/01/${currentYear} - 04/30/${currentYear}`);
   });
 
   it('Create a report error for overlapping coverage dates', () => {

--- a/front-end/src/app/reports/f1m/main-form/main-form.component.ts
+++ b/front-end/src/app/reports/f1m/main-form/main-form.component.ts
@@ -4,7 +4,6 @@ import { MainFormBaseComponent } from 'app/reports/shared/main-form-base.compone
 import { TransactionContactUtils } from 'app/shared/components/transaction-type-base/transaction-contact.utils';
 import { Contact } from 'app/shared/models/contact.model';
 import { Form1M } from 'app/shared/models/form-1m.model';
-import { Report } from 'app/shared/models/report.model';
 import { TransactionTemplateMapType } from 'app/shared/models/transaction-type.model';
 import { Form1MService } from 'app/shared/services/form-1m.service';
 import { blurActiveInput, printFormErrors } from 'app/shared/utils/form.utils';
@@ -50,10 +49,10 @@ import { candidatePatternMessage, committeePatternMessage } from 'app/shared/mod
   ],
   styleUrl: './main-form.component.scss',
 })
-export class MainFormComponent extends MainFormBaseComponent implements OnInit, OnDestroy {
+export class MainFormComponent extends MainFormBaseComponent<Form1M> implements OnInit, OnDestroy {
   readonly injector = inject(Injector);
   readonly cmservice = inject(ContactManagementService);
-  protected override readonly reportService: Form1MService = inject(Form1MService);
+  protected readonly reportService: Form1MService = inject(Form1MService);
   readonly contactService = inject(ContactService);
   protected readonly confirmationService = inject(ConfirmationWrapperService);
 
@@ -242,7 +241,7 @@ export class MainFormComponent extends MainFormBaseComponent implements OnInit, 
     contacts.forEach((contact: F1MContact) => contact.disableValidation());
   }
 
-  getReportPayload(): Report {
+  getReportPayload(): Form1M {
     const formValues = Form1M.fromJSON(SchemaUtils.getFormValues(this.form, this.schema, this.formProperties));
     this.updateContactsWithForm(this.report, this.form);
     return Object.assign(this.report, formValues);

--- a/front-end/src/app/reports/f99/main-form/main-form.component.spec.ts
+++ b/front-end/src/app/reports/f99/main-form/main-form.component.spec.ts
@@ -95,12 +95,8 @@ describe('MainFormComponent', () => {
   });
 
   it('should save', fakeAsync(async () => {
-    const createSpy = spyOn(component.reportService, 'create').and.callFake(
-      async () => await Promise.resolve(Form99.fromJSON({})),
-    );
-    const updateSpy = spyOn(component.reportService, 'update').and.callFake(
-      async () => await Promise.resolve(Form99.fromJSON({})),
-    );
+    const createSpy = spyOn(component.reportService, 'create').and.resolveTo(Form99.fromJSON({}));
+    const updateSpy = spyOn(component.reportService, 'update').and.resolveTo(Form99.fromJSON({}));
     const navigateSpy = spyOn(router, 'navigateByUrl');
 
     component.form.patchValue({ ...f99 });

--- a/front-end/src/app/reports/f99/main-form/main-form.component.ts
+++ b/front-end/src/app/reports/f99/main-form/main-form.component.ts
@@ -2,7 +2,6 @@ import { Component, computed, inject, OnInit, Signal } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MainFormBaseComponent } from 'app/reports/shared/main-form-base.component';
 import { filingFrequencies, Form99, textCodes, textCodesWithFilingFrequencies } from 'app/shared/models/form-99.model';
-import { Report } from 'app/shared/models/report.model';
 import { Form99Service } from 'app/shared/services/form-99.service';
 import { SchemaUtils } from 'app/shared/utils/schema.utils';
 import { schema as f99Schema } from 'fecfile-validate/fecfile_validate_js/dist/F99';
@@ -34,8 +33,8 @@ import { Observable } from 'rxjs';
   ],
   providers: [Form99Service],
 })
-export class MainFormComponent extends MainFormBaseComponent implements OnInit {
-  override reportService = inject(Form99Service);
+export class MainFormComponent extends MainFormBaseComponent<Form99> implements OnInit {
+  readonly reportService = inject(Form99Service);
   readonly formProperties: string[] = [
     'filer_committee_id_number',
     'committee_name',
@@ -65,7 +64,7 @@ export class MainFormComponent extends MainFormBaseComponent implements OnInit {
     return this.documentType() in textCodesWithFilingFrequencies;
   });
 
-  getReportPayload(): Report {
+  getReportPayload(): Form99 {
     return Form99.fromJSON(SchemaUtils.getFormValues(this.form, this.schema, this.formProperties));
   }
 

--- a/front-end/src/app/reports/report-list/abstract-form-list.component.ts
+++ b/front-end/src/app/reports/report-list/abstract-form-list.component.ts
@@ -1,0 +1,126 @@
+import { Component, inject, viewChild } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { TableAction, TableListBaseComponent } from 'app/shared/components/table-list-base/table-list-base.component';
+import { Report, ReportStatus } from 'app/shared/models';
+import { DotFecService } from 'app/shared/services/dot-fec.service';
+import { getReportFromJSON, ReportService } from 'app/shared/services/report.service';
+import { selectCommitteeAccount } from 'app/store/committee-account.selectors';
+import { ColumnDefinition } from 'app/shared/components/table/table.component';
+import { SharedTemplatesComponent } from './shared-templates.component';
+
+@Component({ template: '' })
+export abstract class AbstractFormListComponent<T extends Report> extends TableListBaseComponent<T> {
+  protected abstract override readonly itemService: ReportService<T>;
+  protected readonly router = inject(Router);
+  readonly dotFecService = inject(DotFecService);
+  private readonly store = inject(Store);
+  private readonly committeeAccount = this.store.selectSignal(selectCommitteeAccount);
+
+  readonly sharedTemplate = viewChild.required(SharedTemplatesComponent);
+  columns: ColumnDefinition<T>[] = [];
+
+  readonly rowActions: TableAction[] = [
+    new TableAction('Edit', this.editItem.bind(this), (report: T) => report.report_status === ReportStatus.IN_PROGRESS),
+    new TableAction('Amend', this.amendReport.bind(this), (report: T) => report.canAmend),
+    new TableAction(
+      'Review',
+      this.editItem.bind(this),
+      (report: T) => report.report_status !== ReportStatus.IN_PROGRESS,
+    ),
+    new TableAction('Delete', this.confirmDelete.bind(this), (report: T) => report.can_delete),
+    new TableAction('Unamend', this.unamendReport.bind(this), (report: T) => report.can_unamend),
+    new TableAction('Download as .fec', this.download.bind(this)),
+  ];
+
+  override ngAfterViewInit(): void {
+    this.columns = [
+      { field: 'report_code_label', header: 'Type', sortable: true, cssClass: 'type-column' },
+      { field: 'report_status', header: 'Status', sortable: true, cssClass: 'status-column' },
+      { field: 'version_label', header: 'Version', sortable: true, cssClass: 'version-column' },
+      {
+        field: 'upload_submission__created',
+        header: 'Filed',
+        sortable: true,
+        cssClass: 'submission-column',
+        bodyTpl: this.sharedTemplate().submissionBodyTpl(),
+      },
+      {
+        field: 'actions',
+        header: 'Actions',
+        sortable: false,
+        cssClass: 'actions-column',
+        bodyTpl: this.sharedTemplate().actionsBodyTpl(),
+        actions: this.rowActions,
+      },
+    ];
+  }
+
+  public confirmDelete(report: T): void {
+    this.confirmationService.confirm({
+      message: 'Are you sure you want to delete this report? This action cannot be undone.',
+      header: 'Hang on...',
+      rejectLabel: 'Cancel',
+      rejectIcon: 'none',
+      rejectButtonStyleClass: 'p-button-secondary',
+      acceptLabel: 'Confirm',
+      acceptIcon: 'none',
+      accept: async () => this.delete(report),
+    });
+  }
+
+  async delete(report: T) {
+    await this.itemService.delete(report);
+    this.refreshTable();
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Successful',
+      detail: 'Report Deleted',
+      life: 3000,
+    });
+  }
+
+  override async editItem(item: T): Promise<boolean> {
+    if (item.report_status && item.report_status !== ReportStatus.IN_PROGRESS) {
+      return this.router.navigateByUrl(`/reports/${item.report_type.toLocaleLowerCase()}/submit/status/${item.id}`);
+    }
+
+    return this.router.navigateByUrl(`/reports/transactions/report/${item.id}/list`);
+  }
+
+  async download(report: T): Promise<void> {
+    const payload = getReportFromJSON<T>({
+      ...report,
+      qualified_committee: this.committeeAccount().qualified,
+    });
+
+    await this.itemService.update(payload, ['qualified_committee']);
+    const download = await this.dotFecService.generateFecFile(report);
+    return this.dotFecService.checkFecFileTask(download);
+  }
+
+  async amendReport(report: T) {
+    await this.itemService.startAmendment(report);
+    this.loadTableItems({});
+  }
+
+  async unamendReport(report: T) {
+    await this.itemService.startUnamendment(report);
+    this.loadTableItems({});
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Successful',
+      detail: 'Report Unamended',
+      life: 3000,
+    });
+  }
+
+  /**
+   * Get the display name for the contact to show in the table column.
+   * @param item
+   * @returns {string} Returns the appropriate name of the contact for display in the table.
+   */
+  displayName(item: T): string {
+    return item.form_type ?? '';
+  }
+}

--- a/front-end/src/app/reports/report-list/abstract-form-list.component.ts
+++ b/front-end/src/app/reports/report-list/abstract-form-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, viewChild } from '@angular/core';
+import { Component, inject, signal, viewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TableAction, TableListBaseComponent } from 'app/shared/components/table-list-base/table-list-base.component';
@@ -16,6 +16,8 @@ export abstract class AbstractFormListComponent<T extends Report> extends TableL
   readonly dotFecService = inject(DotFecService);
   private readonly store = inject(Store);
   private readonly committeeAccount = this.store.selectSignal(selectCommitteeAccount);
+
+  override readonly rowsPerPage = signal(5);
 
   readonly sharedTemplate = viewChild.required(SharedTemplatesComponent);
   columns: ColumnDefinition<T>[] = [];
@@ -35,7 +37,7 @@ export abstract class AbstractFormListComponent<T extends Report> extends TableL
 
   override ngAfterViewInit(): void {
     this.columns = [
-      { field: 'report_code_label', header: 'Type', sortable: true, cssClass: 'type-column' },
+      { field: 'formSubLabel', header: 'Type', sortable: true, cssClass: 'type-column' },
       { field: 'report_status', header: 'Status', sortable: true, cssClass: 'status-column' },
       { field: 'version_label', header: 'Version', sortable: true, cssClass: 'version-column' },
       {
@@ -113,14 +115,5 @@ export abstract class AbstractFormListComponent<T extends Report> extends TableL
       detail: 'Report Unamended',
       life: 3000,
     });
-  }
-
-  /**
-   * Get the display name for the contact to show in the table column.
-   * @param item
-   * @returns {string} Returns the appropriate name of the contact for display in the table.
-   */
-  displayName(item: T): string {
-    return item.form_type ?? '';
   }
 }

--- a/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.html
+++ b/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.html
@@ -1,0 +1,15 @@
+<app-shared-templates />
+<app-table
+  [(first)]="first"
+  data-cy="form1m-list-component"
+  [items]="items"
+  [(totalItems)]="totalItems"
+  [loading]="loading"
+  [(rowsPerPage)]="rowsPerPage"
+  [(selectedItems)]="selectedItems"
+  itemName="reports"
+  title="Form 1M"
+  [columns]="columns"
+  sortField="report_code_label"
+  (loadTableItems)="loadTableItems($event)"
+/>

--- a/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Form1MListComponent } from './form1m-list.component';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { ScannedActionsSubject } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
+import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
+import { ApiService } from 'app/shared/services/api.service';
+import { ReportService } from 'app/shared/services/report.service';
+import { testMockStore } from 'app/shared/utils/unit-test.utils';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { DialogModule, Dialog } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
+import { ToolbarModule } from 'primeng/toolbar';
+import { ReportListComponent } from '../report-list.component';
+import { Form1M, ReportTypes } from 'app/shared/models';
+
+describe('Form1MListComponent', () => {
+  let component: Form1MListComponent;
+  let fixture: ComponentFixture<Form1MListComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableModule, ToolbarModule, DialogModule, ReportListComponent, FormTypeDialogComponent, Dialog],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ReportService,
+        ConfirmationService,
+        MessageService,
+        ApiService,
+        ScannedActionsSubject,
+        provideMockStore(testMockStore()),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(Form1MListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('edit a F1M should go to F1M edit page', () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    const item: Form1M = Form1M.fromJSON({ id: '99', report_type: ReportTypes.F1M });
+    component.editItem(item);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/f1m/edit/99');
+  });
+});

--- a/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.ts
+++ b/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.ts
@@ -1,0 +1,26 @@
+import { Component, inject } from '@angular/core';
+import { Form1M } from 'app/shared/models';
+import { AbstractFormListComponent } from '../abstract-form-list.component';
+import { TableComponent } from 'app/shared/components/table/table.component';
+import { Form1MService } from 'app/shared/services/form-1m.service';
+import { SharedTemplatesComponent } from '../shared-templates.component';
+
+@Component({
+  selector: 'app-form1m-list',
+  imports: [TableComponent, SharedTemplatesComponent],
+  templateUrl: './form1m-list.component.html',
+})
+export class Form1MListComponent extends AbstractFormListComponent<Form1M> {
+  protected readonly itemService = inject(Form1MService);
+
+  override readonly caption =
+    'Data table of all F1M reports created by the committee broken down by report type, coverage date, status, version, Date filed, and actions.';
+
+  protected getEmptyItem(): Form1M {
+    return new Form1M();
+  }
+
+  override async editItem(item: Form1M): Promise<boolean> {
+    return this.router.navigateByUrl(`/reports/f1m/edit/${item.id}`);
+  }
+}

--- a/front-end/src/app/reports/report-list/form24-list/form24-list.component.html
+++ b/front-end/src/app/reports/report-list/form24-list/form24-list.component.html
@@ -1,0 +1,15 @@
+<app-shared-templates />
+<app-table
+  [(first)]="first"
+  data-cy="form24-list-component"
+  [items]="items"
+  [(totalItems)]="totalItems"
+  [loading]="loading"
+  [(rowsPerPage)]="rowsPerPage"
+  [(selectedItems)]="selectedItems"
+  itemName="reports"
+  title="Form 24"
+  [columns]="columns"
+  sortField="report_code_label"
+  (loadTableItems)="loadTableItems($event)"
+/>

--- a/front-end/src/app/reports/report-list/form24-list/form24-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form24-list/form24-list.component.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Form24ListComponent } from './form24-list.component';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { provideMockStore } from '@ngrx/store/testing';
+import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
+import { ApiService } from 'app/shared/services/api.service';
+import { ReportService } from 'app/shared/services/report.service';
+import { testMockStore } from 'app/shared/utils/unit-test.utils';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { DialogModule, Dialog } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
+import { ToolbarModule } from 'primeng/toolbar';
+import { ReportListComponent } from '../report-list.component';
+import { ReportTypes, Form24 } from 'app/shared/models';
+import { ScannedActionsSubject } from '@ngrx/store';
+
+describe('Form24ListComponent', () => {
+  let component: Form24ListComponent;
+  let fixture: ComponentFixture<Form24ListComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableModule, ToolbarModule, DialogModule, ReportListComponent, FormTypeDialogComponent, Dialog],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ReportService,
+        ConfirmationService,
+        MessageService,
+        ApiService,
+        ScannedActionsSubject,
+        provideMockStore(testMockStore()),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(Form24ListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('edit a F24 should go to F24 edit page', () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    const item: Form24 = Form24.fromJSON({ id: '99', report_type: ReportTypes.F24 });
+    component.editItem(item);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/99/list');
+  });
+
+  // it('edit a F1M should go to F1M edit page', () => {
+  //   const navigateSpy = spyOn(router, 'navigateByUrl');
+  //   const item: Form1M = Form1M.fromJSON({ id: '99', report_type: ReportTypes.F1M });
+  //   component.editItem(item);
+  //   expect(navigateSpy).toHaveBeenCalledWith('/reports/f1m/edit/99');
+  // });
+});

--- a/front-end/src/app/reports/report-list/form24-list/form24-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form24-list/form24-list.component.spec.ts
@@ -54,11 +54,4 @@ describe('Form24ListComponent', () => {
     component.editItem(item);
     expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/99/list');
   });
-
-  // it('edit a F1M should go to F1M edit page', () => {
-  //   const navigateSpy = spyOn(router, 'navigateByUrl');
-  //   const item: Form1M = Form1M.fromJSON({ id: '99', report_type: ReportTypes.F1M });
-  //   component.editItem(item);
-  //   expect(navigateSpy).toHaveBeenCalledWith('/reports/f1m/edit/99');
-  // });
 });

--- a/front-end/src/app/reports/report-list/form24-list/form24-list.component.ts
+++ b/front-end/src/app/reports/report-list/form24-list/form24-list.component.ts
@@ -1,0 +1,22 @@
+import { Component, inject } from '@angular/core';
+import { Form24 } from 'app/shared/models';
+import { AbstractFormListComponent } from '../abstract-form-list.component';
+import { TableComponent } from 'app/shared/components/table/table.component';
+import { Form24Service } from 'app/shared/services/form-24.service';
+import { SharedTemplatesComponent } from '../shared-templates.component';
+
+@Component({
+  selector: 'app-form24-list',
+  imports: [TableComponent, SharedTemplatesComponent],
+  templateUrl: './form24-list.component.html',
+})
+export class Form24ListComponent extends AbstractFormListComponent<Form24> {
+  protected readonly itemService = inject(Form24Service);
+
+  override readonly caption =
+    'Data table of all F24 reports created by the committee broken down by report type, coverage date, status, version, Date filed, and actions.';
+
+  protected getEmptyItem(): Form24 {
+    return new Form24();
+  }
+}

--- a/front-end/src/app/reports/report-list/form3-list/form3-list.component.html
+++ b/front-end/src/app/reports/report-list/form3-list/form3-list.component.html
@@ -1,0 +1,18 @@
+<ng-template #coverageBody let-item>
+  {{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}
+</ng-template>
+<app-shared-templates />
+<app-table
+  [(first)]="first"
+  data-cy="form3-list-component"
+  [items]="items"
+  [(totalItems)]="totalItems"
+  [loading]="loading"
+  [(rowsPerPage)]="rowsPerPage"
+  [(selectedItems)]="selectedItems"
+  itemName="reports"
+  title="Form 3"
+  [columns]="columns"
+  sortField="report_code_label"
+  (loadTableItems)="loadTableItems($event)"
+/>

--- a/front-end/src/app/reports/report-list/form3-list/form3-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form3-list/form3-list.component.spec.ts
@@ -1,26 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Form3ListComponent } from './form3-list.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
+import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
 import { ApiService } from 'app/shared/services/api.service';
+import { ReportService } from 'app/shared/services/report.service';
 import { testMockStore } from 'app/shared/utils/unit-test.utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
-import { Dialog, DialogModule } from 'primeng/dialog';
+import { DialogModule, Dialog } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
 import { ToolbarModule } from 'primeng/toolbar';
-import { FormTypeDialogComponent } from '../form-type-dialog/form-type-dialog.component';
-import { ReportListComponent } from './report-list.component';
+import { ReportListComponent } from '../report-list.component';
 import { ScannedActionsSubject } from '@ngrx/store';
 
-describe('ReportListComponent', () => {
-  let component: ReportListComponent;
-  let fixture: ComponentFixture<ReportListComponent>;
+describe('Form3ListComponent', () => {
+  let component: Form3ListComponent;
+  let fixture: ComponentFixture<Form3ListComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ToolbarModule, DialogModule, ReportListComponent, FormTypeDialogComponent, Dialog],
+      imports: [TableModule, ToolbarModule, DialogModule, ReportListComponent, FormTypeDialogComponent, Dialog],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
+        ReportService,
         ConfirmationService,
         MessageService,
         ApiService,
@@ -31,7 +35,7 @@ describe('ReportListComponent', () => {
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(ReportListComponent);
+    fixture = TestBed.createComponent(Form3ListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/front-end/src/app/reports/report-list/form3-list/form3-list.component.ts
+++ b/front-end/src/app/reports/report-list/form3-list/form3-list.component.ts
@@ -1,0 +1,34 @@
+import { Component, inject, TemplateRef, viewChild } from '@angular/core';
+import { Form3 } from 'app/shared/models';
+import { AbstractFormListComponent } from '../abstract-form-list.component';
+import { Form3Service } from 'app/shared/services/form-3.service';
+import { TableBodyContext, TableComponent } from 'app/shared/components/table/table.component';
+import { FecDatePipe } from '../../../shared/pipes/fec-date.pipe';
+import { SharedTemplatesComponent } from '../shared-templates.component';
+
+@Component({
+  selector: 'app-form3-list',
+  imports: [TableComponent, FecDatePipe, SharedTemplatesComponent],
+  templateUrl: './form3-list.component.html',
+})
+export class Form3ListComponent extends AbstractFormListComponent<Form3> {
+  readonly itemService = inject(Form3Service);
+  readonly coverageBodyTpl = viewChild.required<TemplateRef<TableBodyContext<Form3>>>('coverageBody');
+  override readonly caption =
+    'Data table of all F3X reports created by the committee broken down by report type, coverage date, status, version, Date filed, and actions.';
+
+  override ngAfterViewInit(): void {
+    super.ngAfterViewInit();
+    this.columns.splice(1, 0, {
+      field: 'coverage_through_date',
+      header: 'Coverage',
+      sortable: true,
+      cssClass: 'coverage-column',
+      bodyTpl: this.coverageBodyTpl(),
+    });
+  }
+
+  protected getEmptyItem(): Form3 {
+    return new Form3();
+  }
+}

--- a/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.html
+++ b/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.html
@@ -1,0 +1,18 @@
+<ng-template #coverageBody let-item>
+  {{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}
+</ng-template>
+<app-shared-templates />
+<app-table
+  [(first)]="first"
+  data-cy="form3x-list-component"
+  [items]="items"
+  [(totalItems)]="totalItems"
+  [loading]="loading"
+  [(rowsPerPage)]="rowsPerPage"
+  [(selectedItems)]="selectedItems"
+  itemName="reports"
+  title="Form 3X"
+  [columns]="columns"
+  sortField="report_code_label"
+  (loadTableItems)="loadTableItems($event)"
+/>

--- a/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.spec.ts
@@ -1,0 +1,212 @@
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { Form3XListComponent } from './form3x-list.component';
+import { Form3XService } from 'app/shared/services/form-3x.service';
+import { of, Subject } from 'rxjs';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Actions } from '@ngrx/effects';
+import { provideMockStore } from '@ngrx/store/testing';
+import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
+import { ReportTypes, ReportStatus, Form3X, F3xFormTypes } from 'app/shared/models';
+import { ApiService } from 'app/shared/services/api.service';
+import { ReportService } from 'app/shared/services/report.service';
+import { testMockStore, testActiveReport } from 'app/shared/utils/unit-test.utils';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { DialogModule, Dialog } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
+import { ToolbarModule } from 'primeng/toolbar';
+import { ReportListComponent } from '../report-list.component';
+
+describe('Form3XListComponent', () => {
+  let component: Form3XListComponent;
+  let fixture: ComponentFixture<Form3XListComponent>;
+  let router: Router;
+  let reportService: Form3XService;
+  const actions$ = new Subject<{ type: string }>();
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableModule, ToolbarModule, DialogModule, ReportListComponent, FormTypeDialogComponent, Dialog],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ReportService,
+        ConfirmationService,
+        MessageService,
+        ApiService,
+        provideMockStore(testMockStore()),
+        { provide: Actions, useValue: actions$ },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({}),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    router = TestBed.inject(Router);
+    reportService = TestBed.inject(Form3XService);
+    fixture = TestBed.createComponent(Form3XListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('rowActions', () => {
+    it('should have "Unamend" if report can_unamend', () => {
+      const report = testActiveReport();
+      report.can_unamend = false;
+      const action = component.rowActions.find((action) => action.label === 'Unamend');
+      if (action) {
+        expect(action.isAvailable(report)).toBeFalse();
+        report.can_unamend = true;
+        expect(action.isAvailable(report)).toBeTrue();
+      }
+    });
+  });
+
+  it('#getEmptyItem should return a new Report instance', () => {
+    const item = component['getEmptyItem']();
+    expect(item.id).toBe(undefined);
+  });
+
+  it('#editItem should route properly for report_status undefined', async () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+    component.editItem({
+      id: '777',
+      report_type: ReportTypes.F3X,
+      report_status: undefined,
+    } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/777/list');
+  });
+
+  it('#editItem should route properly for in-progress report', async () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+    component.editItem({
+      id: '777',
+      report_type: ReportTypes.F3X,
+      report_status: ReportStatus.IN_PROGRESS,
+    } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/777/list');
+  });
+
+  it('#editItem should route properly for report with submission pending', async () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+    component.editItem({
+      id: '777',
+      report_type: ReportTypes.F3X,
+      report_status: ReportStatus.SUBMIT_PENDING,
+    } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/submit/status/777');
+  });
+
+  it('#editItem should route properly for report with submission success', async () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+    component.editItem({
+      id: '777',
+      report_type: ReportTypes.F3X,
+      report_status: ReportStatus.SUBMIT_SUCCESS,
+    } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/submit/status/777');
+  });
+
+  it('#editItem should route properly for report with submission failure', async () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+    component.editItem({
+      id: '777',
+      report_type: ReportTypes.F3X,
+      report_status: ReportStatus.SUBMIT_FAILURE,
+    } as Form3X);
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/submit/status/777');
+  });
+
+  it('#amend should hit service', fakeAsync(async () => {
+    const amendSpy = spyOn(reportService, 'startAmendment').and.returnValue(Promise.resolve(''));
+    await component.amendReport({ id: '999' } as Form3X);
+    expect(amendSpy).toHaveBeenCalled();
+  }));
+
+  describe('unamend', () => {
+    it('should hit service', fakeAsync(async () => {
+      const unamendSpy = spyOn(reportService, 'startUnamendment').and.returnValue(Promise.resolve(''));
+      await component.unamendReport({ id: '999' } as Form3X);
+      expect(unamendSpy).toHaveBeenCalled();
+    }));
+  });
+  it('#onActionClick should route properly', async () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+    await component.editItem({
+      id: '888',
+      report_type: ReportTypes.F3X,
+    } as Form3X);
+
+    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+  });
+
+  it('#onDownload should open download panel properly', async () => {
+    const generateSpy = spyOn(component.dotFecService, 'generateFecFile');
+    const report = { id: '888', report_type: ReportTypes.F3X } as Form3X;
+    spyOn(component.itemService, 'update').and.resolveTo(report);
+    await component.download(report);
+    expect(generateSpy).toHaveBeenCalledWith(report);
+  });
+
+  it('#displayName should display the item form_type code', () => {
+    const item: Form3X = Form3X.fromJSON({ form_type: F3xFormTypes.F3XT });
+    const name: string = component.displayName(item);
+    expect(name).toBe(F3xFormTypes.F3XT);
+  });
+
+  // it('edit a F24 should go to F24 edit page', () => {
+  //   const navigateSpy = spyOn(router, 'navigateByUrl');
+  //   const item: Form24 = Form24.fromJSON({ id: '99', report_type: ReportTypes.F24 });
+  //   component.editItem(item);
+  //   expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/99/list');
+  // });
+
+  // it('edit a F1M should go to F1M edit page', () => {
+  //   const navigateSpy = spyOn(router, 'navigateByUrl');
+  //   const item: Form1M = Form1M.fromJSON({ id: '99', report_type: ReportTypes.F1M });
+  //   component.editItem(item);
+  //   expect(navigateSpy).toHaveBeenCalledWith('/reports/f1m/edit/99');
+  // });
+
+  describe('deleteReport', () => {
+    it('should call confirm', () => {
+      const confirmSpy = spyOn(component.confirmationService, 'confirm');
+      component.confirmDelete(testActiveReport());
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should delete', fakeAsync(async () => {
+      const report = testActiveReport();
+      const deleteSpy = spyOn(reportService, 'delete').and.returnValue(Promise.resolve(null));
+      const messageServiceSpy = spyOn(component.messageService, 'add');
+      await component.delete(report);
+      expect(deleteSpy).toHaveBeenCalledOnceWith(report);
+      expect(messageServiceSpy).toHaveBeenCalledOnceWith({
+        severity: 'success',
+        summary: 'Successful',
+        detail: 'Report Deleted',
+        life: 3000,
+      });
+    }));
+  });
+});

--- a/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.spec.ts
@@ -8,7 +8,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { Actions } from '@ngrx/effects';
 import { provideMockStore } from '@ngrx/store/testing';
 import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
-import { ReportTypes, ReportStatus, Form3X, F3xFormTypes } from 'app/shared/models';
+import { ReportTypes, ReportStatus, Form3X } from 'app/shared/models';
 import { ApiService } from 'app/shared/services/api.service';
 import { ReportService } from 'app/shared/services/report.service';
 import { testMockStore, testActiveReport } from 'app/shared/utils/unit-test.utils';
@@ -167,26 +167,6 @@ describe('Form3XListComponent', () => {
     await component.download(report);
     expect(generateSpy).toHaveBeenCalledWith(report);
   });
-
-  it('#displayName should display the item form_type code', () => {
-    const item: Form3X = Form3X.fromJSON({ form_type: F3xFormTypes.F3XT });
-    const name: string = component.displayName(item);
-    expect(name).toBe(F3xFormTypes.F3XT);
-  });
-
-  // it('edit a F24 should go to F24 edit page', () => {
-  //   const navigateSpy = spyOn(router, 'navigateByUrl');
-  //   const item: Form24 = Form24.fromJSON({ id: '99', report_type: ReportTypes.F24 });
-  //   component.editItem(item);
-  //   expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/99/list');
-  // });
-
-  // it('edit a F1M should go to F1M edit page', () => {
-  //   const navigateSpy = spyOn(router, 'navigateByUrl');
-  //   const item: Form1M = Form1M.fromJSON({ id: '99', report_type: ReportTypes.F1M });
-  //   component.editItem(item);
-  //   expect(navigateSpy).toHaveBeenCalledWith('/reports/f1m/edit/99');
-  // });
 
   describe('deleteReport', () => {
     it('should call confirm', () => {

--- a/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.ts
+++ b/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.ts
@@ -1,0 +1,34 @@
+import { AfterViewInit, Component, inject, TemplateRef, viewChild } from '@angular/core';
+import { Form3X } from 'app/shared/models';
+import { AbstractFormListComponent } from '../abstract-form-list.component';
+import { Form3XService } from 'app/shared/services/form-3x.service';
+import { TableBodyContext, TableComponent } from 'app/shared/components/table/table.component';
+import { FecDatePipe } from '../../../shared/pipes/fec-date.pipe';
+import { SharedTemplatesComponent } from '../shared-templates.component';
+
+@Component({
+  selector: 'app-form3x-list',
+  imports: [TableComponent, FecDatePipe, SharedTemplatesComponent],
+  templateUrl: './form3x-list.component.html',
+})
+export class Form3XListComponent extends AbstractFormListComponent<Form3X> implements AfterViewInit {
+  readonly itemService = inject(Form3XService);
+  readonly coverageBodyTpl = viewChild.required<TemplateRef<TableBodyContext<Form3X>>>('coverageBody');
+  override readonly caption =
+    'Data table of all F3X reports created by the committee broken down by report type, coverage date, status, version, Date filed, and actions.';
+
+  protected getEmptyItem(): Form3X {
+    return new Form3X();
+  }
+
+  override ngAfterViewInit(): void {
+    super.ngAfterViewInit();
+    this.columns.splice(1, 0, {
+      field: 'coverage_through_date',
+      header: 'Coverage',
+      sortable: true,
+      cssClass: 'coverage-column',
+      bodyTpl: this.coverageBodyTpl(),
+    });
+  }
+}

--- a/front-end/src/app/reports/report-list/form99-list/form99-list.component.html
+++ b/front-end/src/app/reports/report-list/form99-list/form99-list.component.html
@@ -1,0 +1,15 @@
+<app-shared-templates />
+<app-table
+  [(first)]="first"
+  data-cy="form99-list-component"
+  [items]="items"
+  [(totalItems)]="totalItems"
+  [loading]="loading"
+  [(rowsPerPage)]="rowsPerPage"
+  [(selectedItems)]="selectedItems"
+  itemName="reports"
+  title="Form 99"
+  [columns]="columns"
+  sortField="report_code_label"
+  (loadTableItems)="loadTableItems($event)"
+/>

--- a/front-end/src/app/reports/report-list/form99-list/form99-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form99-list/form99-list.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Form99ListComponent } from './form99-list.component';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+import { ScannedActionsSubject } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
+import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
+import { ApiService } from 'app/shared/services/api.service';
+import { ReportService } from 'app/shared/services/report.service';
+import { testMockStore } from 'app/shared/utils/unit-test.utils';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { DialogModule, Dialog } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
+import { ToolbarModule } from 'primeng/toolbar';
+import { of } from 'rxjs';
+import { ReportListComponent } from '../report-list.component';
+
+describe('Form99List', () => {
+  let component: Form99ListComponent;
+  let fixture: ComponentFixture<Form99ListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableModule, ToolbarModule, DialogModule, ReportListComponent, FormTypeDialogComponent, Dialog],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ReportService,
+        ConfirmationService,
+        MessageService,
+        ApiService,
+        ScannedActionsSubject,
+        provideMockStore(testMockStore()),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({}),
+          },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(Form99ListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/reports/report-list/form99-list/form99-list.component.ts
+++ b/front-end/src/app/reports/report-list/form99-list/form99-list.component.ts
@@ -1,0 +1,26 @@
+import { Component, inject } from '@angular/core';
+import { Form99 } from 'app/shared/models';
+import { AbstractFormListComponent } from '../abstract-form-list.component';
+import { TableComponent } from 'app/shared/components/table/table.component';
+import { Form99Service } from 'app/shared/services/form-99.service';
+import { SharedTemplatesComponent } from '../shared-templates.component';
+
+@Component({
+  selector: 'app-form99-list',
+  imports: [TableComponent, SharedTemplatesComponent],
+  templateUrl: './form99-list.component.html',
+})
+export class Form99ListComponent extends AbstractFormListComponent<Form99> {
+  protected readonly itemService = inject(Form99Service);
+
+  override readonly caption =
+    'Data table of all F99 reports created by the committee broken down by report type, coverage date, status, version, Date filed, and actions.';
+
+  protected getEmptyItem(): Form99 {
+    return new Form99();
+  }
+
+  override async editItem(item: Form99): Promise<boolean> {
+    return this.router.navigateByUrl(`/reports/f99/edit/${item.id}`);
+  }
+}

--- a/front-end/src/app/reports/report-list/report-list.component.html
+++ b/front-end/src/app/reports/report-list/report-list.component.html
@@ -1,18 +1,8 @@
-<app-table
-  [(first)]="first"
-  data-cy="report-list-component"
-  [items]="items"
-  title="Manage reports"
-  [(totalItems)]="totalItems"
-  [loading]="loading"
-  [(rowsPerPage)]="rowsPerPage"
-  [(selectedItems)]="selectedItems"
-  itemName="reports"
-  [sortableHeaders]="sortableHeaders"
-  sortField="form_type"
-  (loadTableItems)="loadTableItems($event)"
->
-  <ng-template #caption>
+<p-toolbar>
+  <ng-template #start>
+    <h1 class="m-0">Manage reports</h1>
+  </ng-template>
+  <ng-template #end>
     <button
       pButton
       pRipple
@@ -20,37 +10,17 @@
       data-cy="create-report"
       icon="pi pi-plus"
       class="add-button"
-      (click)="showDialog()"
+      (click)="dialogVisible.set(true)"
     ></button>
   </ng-template>
-  <ng-template #header>
-    <th id="actions" role="columnheader">Actions</th>
-  </ng-template>
-  <ng-template #body let-item>
-    <td>{{ item.formLabel }}</td>
-    <td>
-      {{ item.formSubLabel }}
-    </td>
-    <td>
-      @if (item.coverage_from_date || item.coverage_through_date) {
-        {{ item.coverage_from_date | fecDate }} - {{ item.coverage_through_date | fecDate }}
-      } @else {
-        N/A
-      }
-    </td>
-    <td>{{ item.report_status }}</td>
-    <td>{{ item.version_label }}</td>
-    <td>{{ item.upload_submission?.created | fecDate }}</td>
-    <td>
-      <app-table-actions-button
-        [tableActions]="rowActions"
-        [actionItem]="item"
-        (tableActionClick)="onRowActionClick($event.action, $event.actionItem)"
-        buttonIcon="pi pi-ellipsis-v"
-        buttonStyleClass="flex justify-content-center p-button-rounded p-button-primary  p-button-text mr-2"
-        [buttonAriaLabel]="'edit ' + displayName(item)"
-      />
-    </td>
-  </ng-template>
-</app-table>
+</p-toolbar>
+
+<app-form3x-list />
+@if (showForm3) {
+  <app-form3-list />
+}
+<app-form24-list />
+<app-form1m-list />
+<app-form99-list />
+
 <app-form-type-dialog [(dialogVisible)]="dialogVisible" />

--- a/front-end/src/app/reports/report-list/report-list.component.scss
+++ b/front-end/src/app/reports/report-list/report-list.component.scss
@@ -1,0 +1,5 @@
+:host ::ng-deep {
+  .p-datatable-header {
+    padding-top: 48px;
+  }
+}

--- a/front-end/src/app/reports/report-list/report-list.component.ts
+++ b/front-end/src/app/reports/report-list/report-list.component.ts
@@ -1,146 +1,33 @@
-import { Component, inject, signal } from '@angular/core';
-import { Router } from '@angular/router';
-import { Store } from '@ngrx/store';
-import { DotFecService } from 'app/shared/services/dot-fec.service';
-import { Form3XService } from 'app/shared/services/form-3x.service';
-import { selectCommitteeAccount } from 'app/store/committee-account.selectors';
-import { ButtonDirective } from 'primeng/button';
+import { Component, signal } from '@angular/core';
+import { Toolbar } from 'primeng/toolbar';
+import { ButtonModule } from 'primeng/button';
 import { Ripple } from 'primeng/ripple';
 import { FormTypeDialogComponent } from '../form-type-dialog/form-type-dialog.component';
-import { FecDatePipe } from '../../shared/pipes/fec-date.pipe';
-import { TableActionsButtonComponent } from 'app/shared/components/table-actions-button/table-actions-button.component';
-import { TableListBaseComponent, TableAction } from 'app/shared/components/table-list-base/table-list-base.component';
-import { TableComponent } from 'app/shared/components/table/table.component';
-import { ReportStatus, Form3X, Report, ReportTypes } from 'app/shared/models';
-import { ReportService } from 'app/shared/services/report.service';
+import { Report } from 'app/shared/models';
+import { Form3XListComponent } from './form3x-list/form3x-list.component';
+import { Form99ListComponent } from './form99-list/form99-list.component';
+import { Form1MListComponent } from './form1m-list/form1m-list.component';
+import { Form24ListComponent } from './form24-list/form24-list.component';
+import { environment } from 'environments/environment';
+import { Form3ListComponent } from './form3-list/form3-list.component';
 
 @Component({
   selector: 'app-report-list',
   templateUrl: './report-list.component.html',
   styleUrls: ['./report-list.component.scss'],
-  imports: [TableComponent, ButtonDirective, Ripple, TableActionsButtonComponent, FormTypeDialogComponent, FecDatePipe],
+  imports: [
+    FormTypeDialogComponent,
+    Toolbar,
+    ButtonModule,
+    Ripple,
+    Form3XListComponent,
+    Form99ListComponent,
+    Form1MListComponent,
+    Form24ListComponent,
+    Form3ListComponent,
+  ],
 })
-export class ReportListComponent extends TableListBaseComponent<Report> {
-  public readonly router = inject(Router);
-  protected readonly itemService = inject(ReportService);
-  private readonly store = inject(Store);
-  private readonly form3XService = inject(Form3XService);
-  public readonly dotFecService = inject(DotFecService);
-
+export class ReportListComponent {
   readonly dialogVisible = signal(false);
-  readonly committeeAccount = this.store.selectSignal(selectCommitteeAccount);
-  public rowActions: TableAction[] = [
-    new TableAction(
-      'Edit',
-      this.editItem.bind(this),
-      (report: Report) => report.report_status === ReportStatus.IN_PROGRESS,
-    ),
-    new TableAction('Amend', this.amendReport.bind(this), (report: Report) => report.canAmend),
-    new TableAction(
-      'Review',
-      this.editItem.bind(this),
-      (report: Report) => report.report_status !== ReportStatus.IN_PROGRESS,
-    ),
-    new TableAction('Delete', this.confirmDelete.bind(this), (report: Report) => report.can_delete),
-    new TableAction('Unamend', this.unamendReport.bind(this), (report: Report) => report.can_unamend),
-    new TableAction('Download as .fec', this.download.bind(this)),
-  ];
-
-  readonly sortableHeaders: { field: string; label: string }[] = [
-    { field: 'form_type', label: 'Form' },
-    { field: 'report_code_label', label: 'Name' },
-    { field: 'coverage_through_date', label: 'Coverage' },
-    { field: 'report_status', label: 'Status' },
-    { field: 'version_label', label: 'Version' },
-    { field: 'upload_submission__created', label: 'Filed' },
-  ];
-
-  override readonly caption =
-    'Data table of all reports created by the committee broken down by form type, report type, coverage date, status, version, Date filed, and actions.';
-
-  protected getEmptyItem(): Report {
-    return new Form3X();
-  }
-
-  public override async editItem(item: Report): Promise<boolean> {
-    if (item.report_status && item.report_status !== ReportStatus.IN_PROGRESS) {
-      return this.router.navigateByUrl(`/reports/${item.report_type.toLocaleLowerCase()}/submit/status/${item.id}`);
-    }
-
-    switch (item.report_type) {
-      case ReportTypes.F3:
-      case ReportTypes.F3X:
-      case ReportTypes.F24:
-        return this.router.navigateByUrl(`/reports/transactions/report/${item.id}/list`);
-      case ReportTypes.F99:
-        return this.router.navigateByUrl(`/reports/f99/edit/${item.id}`);
-      case ReportTypes.F1M:
-        return this.router.navigateByUrl(`/reports/f1m/edit/${item.id}`);
-    }
-  }
-
-  async amendReport(report: Report) {
-    await this.itemService.startAmendment(report);
-    this.loadTableItems({});
-  }
-
-  async unamendReport(report: Report) {
-    await this.itemService.startUnamendment(report);
-    this.loadTableItems({});
-    this.messageService.add({
-      severity: 'success',
-      summary: 'Successful',
-      detail: 'Report Unamended',
-      life: 3000,
-    });
-  }
-
-  public confirmDelete(report: Report): void {
-    this.confirmationService.confirm({
-      message: 'Are you sure you want to delete this report? This action cannot be undone.',
-      header: 'Hang on...',
-      rejectLabel: 'Cancel',
-      rejectIcon: 'none',
-      rejectButtonStyleClass: 'p-button-secondary',
-      acceptLabel: 'Confirm',
-      acceptIcon: 'none',
-      accept: async () => this.delete(report),
-    });
-  }
-
-  async delete(report: Report) {
-    await this.itemService.delete(report);
-    this.refreshTable();
-    this.messageService.add({
-      severity: 'success',
-      summary: 'Successful',
-      detail: 'Report Deleted',
-      life: 3000,
-    });
-  }
-
-  public async download(report: Report): Promise<void> {
-    if (report instanceof Form3X) {
-      const payload: Form3X = Form3X.fromJSON({
-        ...report,
-        qualified_committee: this.committeeAccount().qualified,
-      });
-      await this.form3XService.update(payload, ['qualified_committee']);
-    }
-    const download = await this.dotFecService.generateFecFile(report);
-    this.dotFecService.checkFecFileTask(download);
-  }
-
-  /**
-   * Get the display name for the contact to show in the table column.
-   * @param item
-   * @returns {string} Returns the appropriate name of the contact for display in the table.
-   */
-  public displayName(item: Report): string {
-    return item.form_type ?? '';
-  }
-
-  public showDialog(): void {
-    this.dialogVisible.set(true);
-  }
+  readonly showForm3 = environment.showForm3;
 }

--- a/front-end/src/app/reports/report-list/report-list.component.ts
+++ b/front-end/src/app/reports/report-list/report-list.component.ts
@@ -3,7 +3,6 @@ import { Toolbar } from 'primeng/toolbar';
 import { ButtonModule } from 'primeng/button';
 import { Ripple } from 'primeng/ripple';
 import { FormTypeDialogComponent } from '../form-type-dialog/form-type-dialog.component';
-import { Report } from 'app/shared/models';
 import { Form3XListComponent } from './form3x-list/form3x-list.component';
 import { Form99ListComponent } from './form99-list/form99-list.component';
 import { Form1MListComponent } from './form1m-list/form1m-list.component';

--- a/front-end/src/app/reports/report-list/shared-templates.component.ts
+++ b/front-end/src/app/reports/report-list/shared-templates.component.ts
@@ -1,0 +1,28 @@
+import { Component, TemplateRef, viewChild } from '@angular/core';
+import { TableActionsButtonComponent } from 'app/shared/components/table-actions-button/table-actions-button.component';
+import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
+import { TableBodyContext } from 'app/shared/components/table/table.component';
+import { Report } from 'app/shared/models';
+
+@Component({
+  selector: 'app-shared-templates',
+  template: `
+    <ng-template #actionsBody let-item let-actions="rowActions">
+      <app-table-actions-button
+        (tableActionClick)="$event.action.action($event.actionItem)"
+        [actionItem]="item"
+        [tableActions]="actions"
+        buttonIcon="pi pi-ellipsis-v"
+        buttonStyleClass="flex justify-content-center p-button-rounded p-button-primary p-button-text mr-2"
+      />
+    </ng-template>
+    <ng-template #submissionBody let-item>
+      {{ item.upload_submission?.created | fecDate }}
+    </ng-template>
+  `,
+  imports: [TableActionsButtonComponent, FecDatePipe],
+})
+export class SharedTemplatesComponent<T extends Report> {
+  readonly actionsBodyTpl = viewChild.required<TemplateRef<TableBodyContext<T>>>('actionsBody');
+  readonly submissionBodyTpl = viewChild.required<TemplateRef<TableBodyContext<T>>>('submissionBody');
+}

--- a/front-end/src/app/reports/shared/main-form-base.component.ts
+++ b/front-end/src/app/reports/shared/main-form-base.component.ts
@@ -13,14 +13,14 @@ import { firstValueFrom } from 'rxjs';
 @Component({
   template: '',
 })
-export abstract class MainFormBaseComponent extends FormComponent implements OnInit {
-  protected abstract reportService: ReportService;
+export abstract class MainFormBaseComponent<T extends Report> extends FormComponent implements OnInit {
+  protected abstract reportService: ReportService<T>;
   protected readonly messageService = inject(MessageService);
   protected readonly router = inject(Router);
   protected readonly activatedRoute = inject(ActivatedRoute);
   abstract readonly formProperties: string[];
   abstract readonly schema: JsonSchema;
-  abstract getReportPayload(): Report;
+  abstract getReportPayload(): T;
   abstract webprintURL: string;
 
   reportId?: string;
@@ -73,8 +73,8 @@ export abstract class MainFormBaseComponent extends FormComponent implements OnI
       return;
     }
 
-    const payload: Report = this.getReportPayload();
-    let report: Report;
+    const payload: T = this.getReportPayload();
+    let report: T;
     if (this.reportId) {
       payload.id = this.reportId;
       report = await this.reportService.update(payload, this.formProperties);

--- a/front-end/src/app/reports/shared/print-preview/print-preview.component.spec.ts
+++ b/front-end/src/app/reports/shared/print-preview/print-preview.component.spec.ts
@@ -14,8 +14,8 @@ import { provideRouter } from '@angular/router';
 describe('PrintPreviewComponent', () => {
   let component: PrintPreviewComponent;
   let fixture: ComponentFixture<PrintPreviewComponent>;
-  let reportService: ReportService;
-  let webPrintService: WebPrintService;
+  let reportService: ReportService<Form3X>;
+  let webPrintService: WebPrintService<Form3X>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -28,11 +28,11 @@ describe('PrintPreviewComponent', () => {
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(PrintPreviewComponent);
-    reportService = TestBed.inject(ReportService);
-    webPrintService = TestBed.inject(WebPrintService);
+    reportService = TestBed.inject(ReportService<Form3X>);
+    webPrintService = TestBed.inject(WebPrintService<Form3X>);
     component = fixture.componentInstance;
-    spyOn(reportService, 'get').and.returnValue(Promise.resolve(Form3X.fromJSON({})));
-    spyOn(reportService, 'update').and.returnValue(Promise.resolve(Form3X.fromJSON({})));
+    spyOn(reportService, 'get').and.resolveTo(Form3X.fromJSON({}));
+    spyOn(reportService, 'update').and.resolveTo(Form3X.fromJSON({}));
     fixture.detectChanges();
   });
 
@@ -100,9 +100,9 @@ describe('PrintPreviewComponent', () => {
   it('#submitPrintJob() calls the service', fakeAsync(() => {
     component.report = Form3X.fromJSON({ id: '123' });
     component.pollingTime = 0;
-    const submit = spyOn(webPrintService, 'submitPrintJob').and.callFake(() => Promise.resolve({}));
+    const submit = spyOn(webPrintService, 'submitPrintJob').and.resolveTo({});
     const poll = spyOn(component, 'pollPrintStatus');
-    const update = spyOn(reportService, 'fecUpdate').and.callFake(() => Promise.resolve(component.report));
+    const update = spyOn(reportService, 'fecUpdate').and.resolveTo(component.report as Form3X);
     component.submitPrintJob();
 
     tick(100);
@@ -128,7 +128,7 @@ describe('PrintPreviewComponent', () => {
     component.pollingTime = 0;
     spyOn(webPrintService, 'submitPrintJob').and.returnValue(Promise.reject('failed'));
     const poll = spyOn(component, 'pollPrintStatus');
-    spyOn(reportService, 'fecUpdate').and.returnValue(Promise.resolve(component.report));
+    spyOn(reportService, 'fecUpdate').and.resolveTo(component.report as Form3X);
     component.submitPrintJob();
 
     tick(100);

--- a/front-end/src/app/reports/shared/print-preview/print-preview.component.ts
+++ b/front-end/src/app/reports/shared/print-preview/print-preview.component.ts
@@ -126,17 +126,15 @@ export class PrintPreviewComponent extends DestroyerComponent implements OnInit 
       /** Update the report with the committee information
        * this is a must because the .fec requires this information */
       await this.reportService.fecUpdate(this.report, this.committeeAccount);
-      return this.webPrintService.submitPrintJob(this.report.id).then(
-        () => {
-          // Start polling for a completed status
-          this.pollPrintStatus();
-        },
-        () => {
-          // Handles any failure when submitting the print request
-          this.webPrintStage = 'failure';
-          this.printError = 'Failed to compile PDF';
-        },
-      );
+      try {
+        await this.webPrintService.submitPrintJob(this.report.id);
+        // Start polling for a completed status
+        return this.pollPrintStatus();
+      } catch {
+        // Handles any failure when submitting the print request
+        this.webPrintStage = 'failure';
+        this.printError = 'Failed to compile PDF';
+      }
     }
   }
 

--- a/front-end/src/app/reports/transactions/secondary-report-selection-dialog/secondary-report-selection-dialog.component.spec.ts
+++ b/front-end/src/app/reports/transactions/secondary-report-selection-dialog/secondary-report-selection-dialog.component.spec.ts
@@ -5,7 +5,6 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { testMockStore, testScheduleATransaction } from 'app/shared/utils/unit-test.utils';
 import { Report, ReportStatus, ReportTypes } from 'app/shared/models/report.model';
 import { SecondaryReportSelectionDialogComponent } from './secondary-report-selection-dialog.component';
-import { ReportService } from 'app/shared/services/report.service';
 import { TransactionService } from 'app/shared/services/transaction.service';
 import { DatePipe } from '@angular/common';
 import { LabelPipe } from 'app/shared/pipes/label.pipe';
@@ -13,8 +12,9 @@ import { MessageService, ToastMessageOptions } from 'primeng/api';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component, signal, viewChild } from '@angular/core';
-import { F24FormTypes, Form24, Form3X, Transaction } from 'app/shared/models';
+import { F24FormTypes, Form24, Transaction } from 'app/shared/models';
 import { of } from 'rxjs';
+import { Form24Service } from 'app/shared/services/form-24.service';
 
 const mockReports = [
   Form24.fromJSON({ id: '1', name: 'test1', created: '2022-12-01', report_status: ReportStatus.IN_PROGRESS }),
@@ -26,7 +26,6 @@ const mockReports = [
     form_type: F24FormTypes.F24A,
     report_status: ReportStatus.IN_PROGRESS,
   }),
-  Form3X.fromJSON({ id: '2', created: '2022-12-31', report_status: ReportStatus.IN_PROGRESS }),
 ];
 
 @Component({
@@ -56,12 +55,12 @@ describe('SecondaryReportSelectionDialogComponent', () => {
   let messageService: MessageService;
   let transactionService: TransactionService;
   let addSpy: jasmine.Spy<(transaction: Transaction, report: Report) => Promise<HttpResponse<string>>>;
-  let reportServiceMock: jasmine.SpyObj<ReportService>;
+  let reportServiceMock: jasmine.SpyObj<Form24Service>;
   let messageSpy: jasmine.Spy<(message: ToastMessageOptions) => void>;
 
   beforeEach(async () => {
-    reportServiceMock = jasmine.createSpyObj('ReportService', ['getAllReports']);
-    reportServiceMock.getAllReports.and.returnValue(Promise.resolve(mockReports));
+    reportServiceMock = jasmine.createSpyObj('Form24Service', ['getAllReports']);
+    reportServiceMock.getAllReports.and.resolveTo(mockReports);
 
     await TestBed.configureTestingModule({
       imports: [DialogModule, Dialog, SecondaryReportSelectionDialogComponent, LabelPipe],
@@ -74,7 +73,7 @@ describe('SecondaryReportSelectionDialogComponent', () => {
             redirectTo: '',
           },
         ]),
-        { provide: ReportService, useValue: reportServiceMock },
+        { provide: Form24Service, useValue: reportServiceMock },
         TransactionService,
         MessageService,
         DatePipe,

--- a/front-end/src/app/reports/transactions/secondary-report-selection-dialog/secondary-report-selection-dialog.component.ts
+++ b/front-end/src/app/reports/transactions/secondary-report-selection-dialog/secondary-report-selection-dialog.component.ts
@@ -4,7 +4,9 @@ import { Router } from '@angular/router';
 import { Report, ReportStatus, ReportTypes, reportLabelList } from 'app/shared/models/report.model';
 import { Transaction } from 'app/shared/models/transaction.model';
 import { LabelPipe } from 'app/shared/pipes/label.pipe';
-import { ReportService } from 'app/shared/services/report.service';
+import { Form24Service } from 'app/shared/services/form-24.service';
+import { Form3XService } from 'app/shared/services/form-3x.service';
+import { Form24, Form3X } from 'app/shared/models';
 import { TransactionService } from 'app/shared/services/transaction.service';
 import { LabelList } from 'app/shared/utils/label.utils';
 import { MessageService } from 'primeng/api';
@@ -23,7 +25,9 @@ import { derivedAsync } from 'ngxtension/derived-async';
 })
 export class SecondaryReportSelectionDialogComponent {
   public readonly router = inject(Router);
-  readonly reportService = inject(ReportService);
+  private readonly f24Service = inject(Form24Service);
+  private readonly f3xService = inject(Form3XService);
+  readonly reportService = computed(() => (this.isForm24() ? this.f24Service : this.f3xService));
   private readonly transactionService = inject(TransactionService);
   private readonly messageService = inject(MessageService);
 
@@ -34,7 +38,7 @@ export class SecondaryReportSelectionDialogComponent {
   readonly transaction = input<Transaction>();
   readonly dialogVisible = model.required<boolean>();
 
-  readonly selectedReport = model<Report | undefined>();
+  readonly selectedReport = model<Form3X | Form24 | undefined>();
   readonly reloadTables = output<void>();
   readonly create = output<void>();
   readonly dropDownFieldText = computed(() => {
@@ -49,9 +53,9 @@ export class SecondaryReportSelectionDialogComponent {
     async () => {
       const type = this.reportType();
       if (!type) return [];
-      const reports = await this.reportService.getAllReports();
+      const reports = await this.reportService().getAllReports();
       return reports.filter((report) => {
-        return report.report_type === type && report.report_status === ReportStatus.IN_PROGRESS;
+        return report.report_status === ReportStatus.IN_PROGRESS;
       });
     },
     { initialValue: [] },

--- a/front-end/src/app/reports/transactions/secondary-report-selection-dialog/secondary-report-selection-dialog.component.ts
+++ b/front-end/src/app/reports/transactions/secondary-report-selection-dialog/secondary-report-selection-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, inject, input, model, output, Signal, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { Report, ReportStatus, ReportTypes, reportLabelList } from 'app/shared/models/report.model';
+import { ReportStatus, ReportTypes, reportLabelList } from 'app/shared/models/report.model';
 import { Transaction } from 'app/shared/models/transaction.model';
 import { LabelPipe } from 'app/shared/pipes/label.pipe';
 import { Form24Service } from 'app/shared/services/form-24.service';

--- a/front-end/src/app/reports/transactions/transaction-detail/transaction-detail.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-detail/transaction-detail.component.spec.ts
@@ -11,7 +11,6 @@ import {
   NavigationEvent,
 } from 'app/shared/models/transaction-navigation-controls.model';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
-import { ReportService } from 'app/shared/services/report.service';
 import { getTestTransactionByType, testMockStore, testTemplateMap } from 'app/shared/utils/unit-test.utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -27,11 +26,12 @@ import { TransactionDetailComponent } from './transaction-detail.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
+import { Form3XService } from 'app/shared/services/form-3x.service';
 
 describe('TransactionDetailComponent', () => {
   let component: TransactionDetailComponent;
   let fixture: ComponentFixture<TransactionDetailComponent>;
-  let reportService: ReportService;
+  let reportService: Form3XService;
   const transaction = getTestTransactionByType(ScheduleATransactionTypes.TRIBAL_RECEIPT);
 
   beforeAll(async () => {
@@ -65,13 +65,13 @@ describe('TransactionDetailComponent', () => {
         FormBuilder,
         provideMockStore(testMockStore()),
         FecDatePipe,
-        ReportService,
+        Form3XService,
       ],
     }).compileComponents();
   });
 
   beforeEach(() => {
-    reportService = TestBed.inject(ReportService);
+    reportService = TestBed.inject(Form3XService);
     spyOn(reportService, 'isEditable').and.returnValue(true);
     fixture = TestBed.createComponent(TransactionDetailComponent);
     component = fixture.componentInstance;

--- a/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.spec.ts
@@ -3,15 +3,16 @@ import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { provideMockStore } from '@ngrx/store/testing';
 import { LinkedReportInputComponent } from './linked-report-input.component';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
-import { ReportService } from 'app/shared/services/report.service';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
 import { testMockStore, testScheduleATransaction, testTemplateMap } from 'app/shared/utils/unit-test.utils';
 import { InputTextModule } from 'primeng/inputtext';
 import { ErrorMessagesComponent } from '../../error-messages/error-messages.component';
-import { Transaction, Form3X, Report, UploadSubmission } from 'app/shared/models';
+import { Transaction, Form3X, UploadSubmission } from 'app/shared/models';
 import { Component, viewChild } from '@angular/core';
+import { Form3XService } from 'app/shared/services/form-3x.service';
+import { provideHttpClient } from '@angular/common/http';
 
-const mockReports: Report[] = [
+const mockReports: Form3X[] = [
   Form3X.fromJSON({
     id: '1',
     coverage_from_date: '2024-01-01',
@@ -87,10 +88,10 @@ describe('LinkedReportInputComponent', () => {
   let host: TestHostComponent;
   let component: LinkedReportInputComponent;
   let fixture: ComponentFixture<TestHostComponent>;
-  let reportServiceMock: jasmine.SpyObj<ReportService>;
+  let reportServiceMock: jasmine.SpyObj<Form3XService>;
 
   beforeEach(async () => {
-    reportServiceMock = jasmine.createSpyObj('ReportService', ['getAllReports', 'get']);
+    reportServiceMock = jasmine.createSpyObj('Form3XService', ['getAllReports', 'get']);
     reportServiceMock.getAllReports.and.returnValue(Promise.resolve(mockReports));
     reportServiceMock.get.and.callFake((id: string) => Promise.resolve(mockReports.find((r) => r.id === id)!));
 
@@ -98,8 +99,9 @@ describe('LinkedReportInputComponent', () => {
       imports: [ReactiveFormsModule, LinkedReportInputComponent, InputTextModule, ErrorMessagesComponent],
       providers: [
         provideMockStore(testMockStore()),
+        provideHttpClient(),
         FecDatePipe,
-        { provide: ReportService, useValue: reportServiceMock },
+        { provide: Form3XService, useValue: reportServiceMock },
       ],
     }).compileComponents();
 

--- a/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.spec.ts
@@ -118,7 +118,7 @@ describe('LinkedReportInputComponent', () => {
 
   it('should load F3X reports on init', async () => {
     expect(reportServiceMock.getAllReports).toHaveBeenCalled();
-    expect(component.committeeF3xReports()).toEqual(mockReports as Form3X[]);
+    expect(component.committeeF3xReports()).toEqual(mockReports);
   });
 
   it('should set associated F3X based on disbursement date', async () => {

--- a/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/linked-report-input/linked-report-input.component.ts
@@ -1,8 +1,6 @@
 import { Component, computed, effect, inject, OnInit, signal } from '@angular/core';
 import { BaseInputComponent } from '../base-input.component';
 import { ReportTypes } from 'app/shared/models/report.model';
-import { ReportService } from 'app/shared/services/report.service';
-import { Form3X } from 'app/shared/models/form-3x.model';
 import { FecDatePipe } from 'app/shared/pipes/fec-date.pipe';
 import { derivedAsync } from 'ngxtension/derived-async';
 import { buildCorrespondingForm3XValidator } from 'app/shared/utils/validators.utils';
@@ -11,6 +9,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { Tooltip } from 'primeng/tooltip';
 import { InputText } from 'primeng/inputtext';
 import { ErrorMessagesComponent } from '../../error-messages/error-messages.component';
+import { Form3XService } from 'app/shared/services/form-3x.service';
 
 @Component({
   selector: 'app-linked-report-input',
@@ -19,7 +18,7 @@ import { ErrorMessagesComponent } from '../../error-messages/error-messages.comp
   imports: [ReactiveFormsModule, Tooltip, InputText, ErrorMessagesComponent],
 })
 export class LinkedReportInputComponent extends BaseInputComponent implements OnInit {
-  private readonly reportService = inject(ReportService);
+  private readonly form3XService = inject(Form3XService);
   private readonly datePipe = inject(FecDatePipe);
 
   readonly tooltipText =
@@ -32,15 +31,7 @@ export class LinkedReportInputComponent extends BaseInputComponent implements On
   readonly disseminationDate = signal<Date | undefined>(undefined);
   readonly userTouchedValues = signal(false);
 
-  readonly committeeF3xReports = derivedAsync(
-    () =>
-      this.reportService.getAllReports().then((reports) => {
-        return reports.filter((report) => {
-          return report.report_type === ReportTypes.F3X;
-        }) as Form3X[];
-      }),
-    { initialValue: [] },
-  );
+  readonly committeeF3xReports = derivedAsync(() => this.form3XService.getAllReports(), { initialValue: [] });
 
   // the form3X that is associated with the transaction on load
   private readonly initialForm3X = derivedAsync(async () => {
@@ -48,7 +39,7 @@ export class LinkedReportInputComponent extends BaseInputComponent implements On
     if (!reports) return undefined;
     const report = reports.find((report) => report.report_type === ReportTypes.F3X);
     if (!report?.id) return undefined;
-    return (await this.reportService.get(report.id)) as Form3X;
+    return await this.form3XService.get(report.id);
   });
 
   // the form3X that is associated with the transaction based on

--- a/front-end/src/app/shared/components/table/table.component.html
+++ b/front-end/src/app/shared/components/table/table.component.html
@@ -85,7 +85,7 @@
       @for (col of columns(); track col) {
         <td [ngClass]="col.cssClass">
           @if (col.bodyTpl) {
-            <ng-container *ngTemplateOutlet="col.bodyTpl; context: { $implicit: item }" />
+            <ng-container *ngTemplateOutlet="col.bodyTpl; context: { $implicit: item, rowActions: col.actions }" />
           } @else {
             <span>{{ item[col.field] }}</span>
           }

--- a/front-end/src/app/shared/components/table/table.component.ts
+++ b/front-end/src/app/shared/components/table/table.component.ts
@@ -7,6 +7,7 @@ import { Select } from 'primeng/select';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { TableSortIconComponent } from '../table-sort-icon/table-sort-icon.component';
 import { Toolbar } from 'primeng/toolbar';
+import { TableAction } from '../table-list-base/table-list-base.component';
 
 export interface ColumnDefinition<T> {
   field: string;
@@ -14,10 +15,12 @@ export interface ColumnDefinition<T> {
   cssClass?: string;
   sortable?: boolean;
   bodyTpl?: TemplateRef<TableBodyContext<T>>;
+  actions?: TableAction[];
 }
 
 export interface TableBodyContext<T> {
   $implicit: T;
+  rowActions?: TableAction[];
 }
 
 @Component({

--- a/front-end/src/app/shared/components/transaction-type-base/double-transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/double-transaction-type-base.component.spec.ts
@@ -24,7 +24,7 @@ import { TransactionContactUtils } from './transaction-contact.utils';
 import { ConfirmationWrapperService } from 'app/shared/services/confirmation-wrapper.service';
 import { DoubleTransactionDetailComponent } from 'app/reports/transactions/double-transaction-detail/double-transaction-detail.component';
 import { Component, viewChild } from '@angular/core';
-import { Transaction } from 'app/shared/models';
+import { Form3X, Transaction } from 'app/shared/models';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 @Component({
@@ -43,7 +43,7 @@ describe('DoubleTransactionTypeBaseComponent', () => {
   let host: TestHostComponent;
   let testConfirmationService: ConfirmationService;
   let transactionService: TransactionService;
-  let reportService: ReportService;
+  let reportService: ReportService<Form3X>;
   let testRouter: Router;
   let testTransaction: Transaction;
 
@@ -90,7 +90,7 @@ describe('DoubleTransactionTypeBaseComponent', () => {
 
     testRouter = TestBed.inject(Router);
     transactionService = TestBed.inject(TransactionService);
-    reportService = TestBed.inject(ReportService);
+    reportService = TestBed.inject(ReportService<Form3X>);
     spyOn(reportService, 'isEditable').and.returnValue(true);
     testConfirmationService = TestBed.inject(ConfirmationService);
     spyOn(testConfirmationService, 'confirm').and.callFake((confirmation: Confirmation) => {

--- a/front-end/src/app/shared/components/transaction-type-base/reatt-redes-transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/reatt-redes-transaction-type-base.component.spec.ts
@@ -24,6 +24,7 @@ import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-cont
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { Form3X } from 'app/shared/models';
 
 describe('ReattTransactionTypeBaseComponent', () => {
   let component: ReattRedesTransactionTypeDetailComponent;
@@ -31,7 +32,7 @@ describe('ReattTransactionTypeBaseComponent', () => {
   let testTransaction: SchATransaction;
   let testConfirmationService: ConfirmationService;
   let transactionService: TransactionService;
-  let reportService: ReportService;
+  let reportService: ReportService<Form3X>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -62,7 +63,7 @@ describe('ReattTransactionTypeBaseComponent', () => {
       getTestTransactionByType(ScheduleATransactionTypes.PAC_EARMARK_MEMO) as SchATransaction,
     ];
 
-    reportService = TestBed.inject(ReportService);
+    reportService = TestBed.inject(ReportService<Form3X>);
     spyOn(reportService, 'isEditable').and.returnValue(true);
     testConfirmationService = TestBed.inject(ConfirmationService);
     spyOn(testConfirmationService, 'confirm').and.callFake((confirmation: Confirmation) => {

--- a/front-end/src/app/shared/services/form-1m.service.ts
+++ b/front-end/src/app/shared/services/form-1m.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { ReportService } from './report.service';
+import { Form1M } from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Form1MService extends ReportService {
+export class Form1MService extends ReportService<Form1M> {
   override apiEndpoint = '/reports/form-1m';
 }

--- a/front-end/src/app/shared/services/form-24.service.ts
+++ b/front-end/src/app/shared/services/form-24.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { ReportService } from './report.service';
+import { Form24 } from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Form24Service extends ReportService {
+export class Form24Service extends ReportService<Form24> {
   override apiEndpoint = '/reports/form-24';
 }

--- a/front-end/src/app/shared/services/form-3.service.ts
+++ b/front-end/src/app/shared/services/form-3.service.ts
@@ -2,14 +2,13 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { CommitteeAccount } from '../models/committee-account.model';
 import { F3CoverageDates, Form3 } from '../models/form-3.model';
-import { Report } from '../models/report.model';
 import { ReportCodes } from '../utils/report-code.utils';
 import { ReportService } from './report.service';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Form3Service extends ReportService {
+export class Form3Service extends ReportService<Form3> {
   override apiEndpoint = '/reports/form-3';
 
   f3ReportCodeLabelMap$ = new BehaviorSubject<{ [key in ReportCodes]: string } | undefined>(undefined);
@@ -43,7 +42,7 @@ export class Form3Service extends ReportService {
     return this.apiService.get<Form3 | undefined>(`${this.apiEndpoint}/final/?year=${year}`);
   }
 
-  public override fecUpdate(report: Form3, committeeAccount?: CommitteeAccount): Promise<Report> {
+  public override fecUpdate(report: Form3, committeeAccount?: CommitteeAccount): Promise<Form3> {
     const payload: Form3 = Form3.fromJSON({
       ...report,
       qualified_committee: committeeAccount?.qualified,

--- a/front-end/src/app/shared/services/form-3x.service.ts
+++ b/front-end/src/app/shared/services/form-3x.service.ts
@@ -2,14 +2,13 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { CommitteeAccount } from '../models/committee-account.model';
 import { Form3X, CoverageDates } from '../models';
-import { Report } from '../models/report.model';
 import { ReportCodes } from '../utils/report-code.utils';
 import { ReportService } from './report.service';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Form3XService extends ReportService {
+export class Form3XService extends ReportService<Form3X> {
   override apiEndpoint = '/reports/form-3x';
 
   f3xReportCodeLabelMap$ = new BehaviorSubject<{ [key in ReportCodes]: string } | undefined>(undefined);
@@ -43,7 +42,7 @@ export class Form3XService extends ReportService {
     return this.apiService.get<Form3X | undefined>(`${this.apiEndpoint}/final/?year=${year}`);
   }
 
-  public override fecUpdate(report: Form3X, committeeAccount?: CommitteeAccount): Promise<Report> {
+  public override fecUpdate(report: Form3X, committeeAccount?: CommitteeAccount): Promise<Form3X> {
     const payload: Form3X = Form3X.fromJSON({
       ...report,
       qualified_committee: committeeAccount?.qualified,

--- a/front-end/src/app/shared/services/form-99.service.ts
+++ b/front-end/src/app/shared/services/form-99.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { ReportService } from './report.service';
+import { Form99 } from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Form99Service extends ReportService {
+export class Form99Service extends ReportService<Form99> {
   override apiEndpoint = '/reports/form-99';
 }

--- a/front-end/src/app/shared/services/report.service.spec.ts
+++ b/front-end/src/app/shared/services/report.service.spec.ts
@@ -9,7 +9,7 @@ import { testMockStore } from '../utils/unit-test.utils';
 import { ReportService } from './report.service';
 
 describe('ReportService', () => {
-  let service: ReportService;
+  let service: ReportService<Form3X>;
   let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe('ReportService', () => {
       providers: [provideHttpClient(), provideHttpClientTesting(), ReportService, provideMockStore(testMockStore())],
     });
     httpTestingController = TestBed.inject(HttpTestingController);
-    service = TestBed.inject(ReportService);
+    service = TestBed.inject(ReportService<Form3X>);
   });
 
   it('should be created', () => {

--- a/front-end/src/app/shared/services/web-print.service.spec.ts
+++ b/front-end/src/app/shared/services/web-print.service.spec.ts
@@ -9,9 +9,9 @@ import { WebPrintService } from './web-print.service';
 import { provideHttpClient } from '@angular/common/http';
 
 describe('WebPrintService', () => {
-  let service: WebPrintService;
+  let service: WebPrintService<Form3X>;
   let apiService: ApiService;
-  let reportService: ReportService;
+  let reportService: ReportService<Form3X>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -19,9 +19,9 @@ describe('WebPrintService', () => {
     }).compileComponents();
 
     TestBed.inject(HttpTestingController);
-    service = TestBed.inject(WebPrintService);
+    service = TestBed.inject(WebPrintService<Form3X>);
     apiService = TestBed.inject(ApiService);
-    reportService = TestBed.inject(ReportService);
+    reportService = TestBed.inject(ReportService<Form3X>);
   });
 
   it('should be created', () => {
@@ -36,9 +36,9 @@ describe('WebPrintService', () => {
     });
   });
 
-  it('should get new reports', () => {
-    const reportRequest = spyOn(reportService, 'setActiveReportById').and.returnValue(Promise.resolve(new Form3X()));
-    service.getStatus('1');
+  it('should get new reports', async () => {
+    const reportRequest = spyOn(reportService, 'setActiveReportById').and.resolveTo(new Form3X());
+    await service.getStatus('1');
     expect(reportRequest).toHaveBeenCalledWith('1');
   });
 });

--- a/front-end/src/app/shared/services/web-print.service.ts
+++ b/front-end/src/app/shared/services/web-print.service.ts
@@ -1,13 +1,14 @@
 import { inject, Injectable } from '@angular/core';
 import { ApiService } from './api.service';
 import { ReportService } from './report.service';
+import { Report } from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class WebPrintService {
+export class WebPrintService<T extends Report> {
   private readonly apiService = inject(ApiService);
-  private readonly reportService = inject(ReportService);
+  private readonly reportService = inject(ReportService<T>);
 
   /**
    * Gets the print-status of a report.

--- a/front-end/src/app/shared/services/web-print.service.ts
+++ b/front-end/src/app/shared/services/web-print.service.ts
@@ -15,8 +15,8 @@ export class WebPrintService<T extends Report> {
    *
    * @return     {Promise}  The WebPrint status.
    */
-  public getStatus(reportId: string): void {
-    this.reportService.setActiveReportById(reportId);
+  public getStatus(reportId: string): Promise<void> {
+    return this.reportService.setActiveReportById(reportId);
   }
 
   public submitPrintJob(reportId: string): Promise<object> {


### PR DESCRIPTION
Issue [FECFILE-1933](https://fecgov.atlassian.net/browse/FECFILE-1933)

One of the things I changed to accomplish this was by adding a generic type to the ReportService since it would apply to something extending Report.  However this meant there were a few more points that needed to be updated to make use of the Genericized version of ReportService.

I also included the updates from the ColumnDefinition version of the Table Component from [FECFILE-2042](https://github.com/fecgov/fecfile-web-app/pull/3140) 