### PR TITLE
Circleci parameterized jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,10 @@ parameters:
 workflows:
   primary:
     when:
-      not: << pipeline.parameters.is-triggered-e2e-test >>
+      and:
+        - not: << pipeline.parameters.is-triggered-e2e-test >>
+        - not: << pipeline.parameters.is-nightly-e2e-test >>
+        - not: << pipeline.parameters.is-triggered-unit-test >>
     jobs:
       - lint
       - test
@@ -274,7 +277,7 @@ workflows:
           filters:
             branches:
               only: /develop|release\/sprint-[\.\d]+|release\/test|main/
-      - deploy-job: # Deploy job even when e2e tests fail
+      - deploy-job:
           name: deploy-even-if-e2e-job-fails
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ workflows:
           filters:
             branches:
               only: /develop|release\/sprint-[\.\d]+|release\/test|main/
-      - deploy-job:
+      - deploy-job:  # Deploy job even when e2e tests fail
           name: deploy-even-if-e2e-job-fails
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,11 +305,7 @@ workflows:
   triggered-unit-test:
     when: << pipeline.parameters.is-triggered-unit-test >>
     jobs:
-      - test:
-          filters:
-            branches:
-              only:
-                - develop
+      - test
 
   nightly:
     triggers:


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2689

When running the parameterized jobs e2e-nightly, e2e-test, and test, they also ran the primary workflow alongside which was unintended. The fix makes it so only those parameterized jobs are run when selected in CircleCI
