### PR TITLE
e2e-extended failing during full-nightly pipeline

### DIFF
--- a/front-end/cypress/e2e-extended/contacts/contacts.list.cy.ts
+++ b/front-end/cypress/e2e-extended/contacts/contacts.list.cy.ts
@@ -151,7 +151,7 @@ describe('Contacts List (/contacts)', () => {
     cy.get('body').click();
 
     const selectPageSize = (size: number) => {
-      cy.intercept('GET', '/api/v1/contacts/**').as(`getContactsForPageSize_${size}`);
+      cy.intercept('GET', '**/api/v1/contacts/**').as(`getContactsForPageSize_${size}`);
       ContactsHelpers.selectResultsPerPage(size);
       cy.wait(`@getContactsForPageSize_${size}`, { timeout: 15000 }).then(({ request }) => {
         const url = new URL(request.url);


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2698

contacts.list.cy.ts failed again while waiting for the pageSize intercept, so I adjusted it

