### PR TITLE
[FECFILE-2714] updated e2e tests due to PR which refactored dialogs/confirmations

### DIFF
--- a/front-end/cypress/e2e-extended/users/users.validation.cy.ts
+++ b/front-end/cypress/e2e-extended/users/users.validation.cy.ts
@@ -18,15 +18,17 @@ describe("Users: Validation and API failure states", () => {
   it('shows required inline validation when email is empty', () => {
     UsersPage.goToPage();
     PageUtils.clickButton('Add user');
-    cy.get('#email').clear({ force: true }).should('have.value', '');
-    cy.get('[data-cy="membership-submit"]').click();
-    cy.get('[data-cy="membership-submit"]').should('be.visible');
+    cy.get(DIALOG).filter(':visible').first().as('dialog');
+    UsersHelpers.emailInput().clear({ force: true }).should('have.value', '');
+    UsersHelpers.submitBtn().click();
+    UsersHelpers.submitBtn().should('be.visible');
     cy.get('body')
-      .find(".p-error")
+      .find('.p-error')
       .first()
       .should('be.visible')
       .and('contain.text', 'This is a required field.');
   });
+
 
   it('shows inline validation message for invalid emails (multiple cases)', () => {
     const invalidEmails = [
@@ -48,29 +50,32 @@ describe("Users: Validation and API failure states", () => {
 
     UsersPage.goToPage();
     PageUtils.clickButton('Add user');
+    cy.get(DIALOG).filter(':visible').first().as('dialog');
+
     for (const badEmail of invalidEmails) {
-      cy.get('#email').clear({ force: true }).type(badEmail, { delay: 0 });
-      cy.get('[data-cy="membership-submit"]').click();
-      cy.get('[data-cy="membership-submit"]').should('be.visible');
+      UsersHelpers.emailInput().clear({ force: true }).type(badEmail, { delay: 0 });
+      UsersHelpers.submitBtn().click();
+      UsersHelpers.submitBtn().should('be.visible');
       findEmailError()
         .should('be.visible')
         .and('contain.text', 'This email is invalid');
-      cy.get('#email').clear({ force: true });
+
+      UsersHelpers.emailInput().clear({ force: true });
     }
-    cy.get('#email').should('have.value', '');
+    UsersHelpers.emailInput().should('have.value', '');
   });
 
   it('should verify results per page dropdown', () => {
     UsersPage.goToPage();
-    cy.get('#pn_id_8 > div').as('resultsPerPageDropdown');
-    cy.get('@resultsPerPageDropdown').click();
-    cy.get('#pn_id_8_0').should('be.visible').and('have.text', '5').click();
-    cy.get('@resultsPerPageDropdown').click();
-    cy.get('#pn_id_8_1').should('be.visible').and('have.text', '10').click();
-    cy.get('@resultsPerPageDropdown').click();
-    cy.get('#pn_id_8_2').should('be.visible').and('have.text', '15').click();
-    cy.get('@resultsPerPageDropdown').click();
-    cy.get('#pn_id_8_3').should('be.visible').and('have.text', '20').click();
+    //cy.get('.p-select-dropdown').as('resultsPerPageDropdown');
+    cy.get('.p-select-dropdown').first().click();
+    cy.contains('.p-select-option', '5').click();
+    cy.get('.p-select-dropdown').first().click();
+    cy.contains('.p-select-option', '10').click();
+    cy.get('.p-select-dropdown').first().click();
+    cy.contains('.p-select-option', '15').click();
+    cy.get('.p-select-dropdown').first().click();
+    cy.contains('.p-select-option', '20').click();
   });
 
   it('should verify that toast messages close correctly on all actions', () => {

--- a/front-end/cypress/e2e-smoke/F3X/aggregate-calculation.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/aggregate-calculation.cy.ts
@@ -63,7 +63,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
       // Move the date back
       TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(currentYear, 3, 30), '');
-      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField();
       cy.get('[id=aggregate]').should('have.value', '$225.01');
 
       // Change the contact
@@ -76,7 +76,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
       // Change the amount
       cy.get('[id="amount"]').clear().safeType('40');
-      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField();
       cy.get('[id=aggregate]').should('have.value', '$240.01');
       PageUtils.clickButton('Save');
 
@@ -97,7 +97,7 @@ describe('Tests transaction form aggregate calculation', () => {
       cy.get('[data-cy="searchBox"]').type('A');
       cy.contains('Ant').should('exist');
       cy.contains('Ant').click({ force: true });
-      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField();
 
       cy.get('[id=aggregate]').should('have.value', '$225.01');
       PageUtils.clickButton('Save');
@@ -117,7 +117,7 @@ describe('Tests transaction form aggregate calculation', () => {
       // Tests changing the amount
       cy.get('[id=aggregate]').should('have.value', '$225.01');
       cy.get('[id="amount"]').clear().safeType('40');
-      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField();
 
       cy.get('[id=aggregate]').should('have.value', '$240.01');
       PageUtils.clickButton('Save');
@@ -136,7 +136,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
       // Tests moving the first transaction's date to be later than the second
       TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(currentYear, 3, 30), '');
-      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField();
 
       cy.get('[id=aggregate]').should('have.value', '$225.01');
       PageUtils.clickButton('Save');
@@ -165,7 +165,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
         // Tests moving the first transaction's date to be later than the second
         TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(currentYear, 3, 29), '');
-        PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
+        PageUtils.blurActiveField();
 
         cy.get('[id=aggregate]').should('have.value', '$200.01');
         PageUtils.clickButton('Save');

--- a/front-end/cypress/e2e-smoke/F3X/aggregate-calculation.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/aggregate-calculation.cy.ts
@@ -45,19 +45,25 @@ describe('Tests transaction form aggregate calculation', () => {
     setupTransactions(true).then((result: any) => {
       ReportListPage.goToReportList(result.report);
 
-      cy.get(':nth-child(2) > :nth-child(2) > a').click();
+      cy.get('.p-datatable-tbody > tr')
+        .eq(1) // 0-based, so 2nd row
+        .find('td')
+        .eq(1) // 2nd cell
+        .find('a')
+        .first()
+        .click();
       cy.contains('Create a new contact').should('exist');
 
       cy.get('[id=aggregate]').should('have.value', '$225.01');
 
       // Tests moving the date to be earlier
       TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(2025, 3, 10), '');
-      cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
       cy.get('[id=aggregate]').should('have.value', '$25.00');
 
       // Move the date back
       TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(currentYear, 3, 30), '');
-      cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
       cy.get('[id=aggregate]').should('have.value', '$225.01');
 
       // Change the contact
@@ -70,7 +76,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
       // Change the amount
       cy.get('[id="amount"]').clear().safeType('40');
-      cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
       cy.get('[id=aggregate]').should('have.value', '$240.01');
       PageUtils.clickButton('Save');
 
@@ -91,7 +97,7 @@ describe('Tests transaction form aggregate calculation', () => {
       cy.get('[data-cy="searchBox"]').type('A');
       cy.contains('Ant').should('exist');
       cy.contains('Ant').click({ force: true });
-      cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
 
       cy.get('[id=aggregate]').should('have.value', '$225.01');
       PageUtils.clickButton('Save');
@@ -111,7 +117,7 @@ describe('Tests transaction form aggregate calculation', () => {
       // Tests changing the amount
       cy.get('[id=aggregate]').should('have.value', '$225.01');
       cy.get('[id="amount"]').clear().safeType('40');
-      cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
 
       cy.get('[id=aggregate]').should('have.value', '$240.01');
       PageUtils.clickButton('Save');
@@ -130,7 +136,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
       // Tests moving the first transaction's date to be later than the second
       TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(currentYear, 3, 30), '');
-      cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+      PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
 
       cy.get('[id=aggregate]').should('have.value', '$225.01');
       PageUtils.clickButton('Save');
@@ -159,7 +165,7 @@ describe('Tests transaction form aggregate calculation', () => {
 
         // Tests moving the first transaction's date to be later than the second
         TransactionDetailPage.enterDate('[data-cy="contribution_date"]', new Date(currentYear, 3, 29), '');
-        cy.get('h1').click(); // clicking outside of fields to ensure that the amount field loses focus and updates
+        PageUtils.blurActiveField(); // clicking outside of fields to ensure that the amount field loses focus and updates
 
         cy.get('[id=aggregate]').should('have.value', '$200.01');
         PageUtils.clickButton('Save');
@@ -198,7 +204,7 @@ describe('Tests transaction form aggregate calculation', () => {
         'date_signed',
       );
 
-      cy.get('h1').click();
+      PageUtils.blurActiveField();
       cy.get('#calendar_ytd').should('have.value', '$100.00');
       PageUtils.clickButton('Save');
       cy.contains('Transactions in this report').should('exist');
@@ -225,7 +231,7 @@ describe('Tests transaction form aggregate calculation', () => {
         'date_signed',
       );
 
-      cy.get('h1').click();
+      PageUtils.blurActiveField();
       cy.get('#calendar_ytd').should('have.value', '$150.00');
       PageUtils.clickButton('Save');
       cy.contains('Transactions in this report').should('exist');
@@ -252,7 +258,7 @@ describe('Tests transaction form aggregate calculation', () => {
         'date_signed',
       );
 
-      cy.get('h1').click();
+      PageUtils.blurActiveField();
       cy.get('#calendar_ytd').should('have.value', '$175.00');
       PageUtils.clickButton('Save');
       cy.contains('Transactions in this report').should('exist');
@@ -261,7 +267,7 @@ describe('Tests transaction form aggregate calculation', () => {
       cy.get('.p-datatable-tbody > :nth-child(1) > :nth-child(2) > a').click();
       cy.contains('Payee').should('exist');
       TransactionDetailPage.enterDate('[data-cy="disbursement_date"]', new Date(currentYear, 4 - 1, 20), '');
-      cy.get('h1').click();
+      PageUtils.blurActiveField();
       cy.get('#calendar_ytd').should('have.value', '$150.00');
       PageUtils.clickButton('Save');
       cy.contains('Transactions in this report').should('exist');

--- a/front-end/cypress/e2e-smoke/F3X/loans-committee.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-committee.cy.ts
@@ -84,9 +84,7 @@ describe('Loans', () => {
       cy.contains('Loan By Committee').click();
       cy.wait('@GuarantorList');
       PageUtils.clickKababItem(result.individual.last_name, 'Delete');
-      const alias = PageUtils.getAlias('');
-      cy.get(alias).find('.p-confirmdialog-accept-button').click();
-
+      PageUtils.clickButton('Confirm');
       cy.contains(result.individual.last_name).should('not.exist');
     });
   });

--- a/front-end/cypress/e2e-smoke/F3X/loans-individual.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-individual.cy.ts
@@ -70,10 +70,7 @@ describe('Loans', () => {
       cy.get(alias).contains('Loan Received from Individual').click();
       cy.wait('@GuarantorList');
       PageUtils.clickKababItem(result.individual2.last_name, 'Delete');
-
-      alias = PageUtils.getAlias('');
-      cy.get(alias).find('.p-confirmdialog-accept-button').click();
-
+      PageUtils.clickButton('Confirm');
       cy.contains(result.individual.last_name).should('not.exist');
     });
   });

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -123,7 +123,10 @@ export class PageUtils {
 
   static clickButton(name: string, alias = '', force = false) {
     alias = PageUtils.getAlias(alias);
-    cy.get(alias).contains('button', name).as('btn');
+    cy.get(alias)
+      .contains('button', name)
+      .first()
+      .as('btn');
     cy.get('@btn').click({ force });
   }
 
@@ -224,13 +227,16 @@ export class PageUtils {
     PageUtils.urlCheck('/submit');
     PageUtils.enterValue('#treasurer_last_name', 'TEST');
     PageUtils.enterValue('#treasurer_first_name', 'TEST');
-    PageUtils.enterValue('#filingPassword', Cypress.env('FILING_PASSWORD')); // Insert password from env variable
+    PageUtils.enterValue('#filingPassword', Cypress.env('FILING_PASSWORD'));
     cy.get(alias).find('[data-cy="userCertified"]').first().click();
     PageUtils.clickButton('Submit');
     PageUtils.findOnPage('div', 'Are you sure?');
-
-    PageUtils.clickButton('Yes');
-
+    PageUtils.clickButton('Confirm');
     cy.wait('@SubmitReport');
   }
+
+  static blurActiveField = () => {
+    cy.get('body').click(0, 0);
+  };
+
 }

--- a/front-end/cypress/e2e-smoke/pages/usersPage.ts
+++ b/front-end/cypress/e2e-smoke/pages/usersPage.ts
@@ -28,22 +28,37 @@ export class UsersPage {
   static create(fd: UserFormData) {
     UsersPage.goToPage();
     PageUtils.clickButton('Add user');
-    cy.wait(150);
-    UsersPage.enterFormData(fd);
-    cy.get('[data-cy="membership-submit"]').click();
+    cy.get('#content-offset app-committee-member-dialog')
+      .filter(':visible')
+      .first()
+      .as('dialog');
+
+    UsersPage.enterFormData(fd, false, '@dialog');
+    cy.get('@dialog').find('[data-cy="membership-submit"]').click();
   }
+
 
   static editRole(fd: UserFormData, alias = '') {
     UsersPage.goToPage();
     PageUtils.clickKababItem(fd.email, 'Edit Role');
-    PageUtils.dropdownSetValue("app-select[inputid='role']", fd['role'], alias);
-    cy.get('[data-cy="membership-submit"]').click();
+    cy.get('#content-offset app-committee-member-dialog')
+      .filter(':visible')
+      .first()
+      .as('dialog');
+
+    PageUtils.dropdownSetValue(
+      "app-select[inputid='role']",
+      fd['role'],
+      '@dialog'
+    );
+    cy.get('@dialog').find('[data-cy="membership-submit"]').click();
   }
 
   static delete(email: string) {
-    const alias = PageUtils.getAlias('');
     UsersPage.goToPage();
     PageUtils.clickKababItem(email, 'Delete');
-    cy.get(alias).find('.p-confirmdialog-accept-button').click();
+    cy.get('app-confirm-dialog')
+      .contains('button', 'Confirm')
+      .click();
   }
 }


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2714



e2e-smoke began failing at this merge [1b85ace Merge pull request #3307 from fecgov/feature/2648](https://github.com/fecgov/fecfile-web-app/commit/1b85acedbd806b88a32310eb92366d68bf72349b)

the following tests failed
[users.cy](http://users.cy/).ts, F1M/f1m-affiliation.cy.ts, F3X/aggregate-calculation.cy.ts, F3X/amendments.cy.ts, F3X/loans-committee.cy.ts, F3X/loans-individual.cy.ts
the next merge [8232a18 Merge pull request #3311 from fecgov/feature/2654](https://github.com/fecgov/fecfile-web-app/commit/8232a18b05bf5aef9ba0884a92121cb829b28ed0) also had e2e-smoke fail in an identical way

this led to to e2e-smoke failing in the nightly workflow as well

two new failures for e2e-extended arose during the nightly workflow, specifically the users/users.manage.cy.ts & users/users.validation.cy.ts
