### PR TITLE
feature/2684 - Fix issue with Committee Name Input

### DIFF
--- a/front-end/src/app/shared/components/inputs/committee-input/committee-input.component.html
+++ b/front-end/src/app/shared/components/inputs/committee-input/committee-input.component.html
@@ -6,7 +6,6 @@
         <input
           type="text"
           pInputText
-          appToUpper
           id="organization_name"
           aria-labelledby="organization_name_label"
           [formControlName]="tertiaryContact ? templateMap['committee_name'] : templateMap['organization_name']"
@@ -17,7 +16,6 @@
           [form]="form"
           [fieldName]="tertiaryContact ? templateMap['committee_name'] : templateMap['organization_name']"
           [formSubmitted]="formSubmitted"
-          [patternErrorMessage]="patternMessage"
         />
       </div>
     </div>
@@ -28,6 +26,7 @@
           <input
             type="text"
             pInputText
+            appToUpper
             id="committee_fec_id"
             aria-labelledby="committee_fec_id_label"
             [formControlName]="templateMap['committee_fec_id']"
@@ -38,6 +37,7 @@
             [form]="form"
             [fieldName]="templateMap['committee_fec_id']"
             [formSubmitted]="formSubmitted"
+            [patternErrorMessage]="patternMessage"
           />
         </div>
       </div>


### PR DESCRIPTION
Issue [FECFILE-2684](https://fecgov.atlassian.net/issues?filter=10045&selectedIssue=FECFILE-2684)

This was caused by a mistake I made when I was updating all the places we modify the Committee ID. [Here](https://github.com/fecgov/fecfile-web-app/blob/2d455682aa1455e31b0c84e455f900109482a895/front-end/src/app/shared/components/inputs/committee-input/committee-input.component.html#L9)

I had made a toUpper directive to prevent users from using lowercase "c" for a committee id. Unfortunately I accidentally placed that directive on the Committee name...not the committee ID field.