### PR TITLE
feature/2695 - Update reattribute/redesignation actions to not be available for transaction types with negativeAmountValueOnly

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -170,6 +170,7 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
       this.createReattribution.bind(this),
       (transaction: Transaction) =>
         transaction.transactionType.scheduleId === ScheduleIds.A &&
+        !transaction.transactionType.negativeAmountValueOnly &&
         !transaction.parent_transaction_id &&
         !ReattRedesUtils.isReattRedes(transaction, [
           ReattRedesTypes.REATTRIBUTION_FROM,
@@ -184,6 +185,7 @@ export abstract class TransactionListTableBaseComponent extends TableListBaseCom
       (transaction: Transaction) =>
         transaction.transactionType.scheduleId === ScheduleIds.B &&
         transaction.transactionType.hasElectionInformation() &&
+        !transaction.transactionType.negativeAmountValueOnly &&
         !transaction.parent_transaction_id &&
         !ReattRedesUtils.isReattRedes(transaction, [
           ReattRedesTypes.REDESIGNATION_FROM,

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component.spec.ts
@@ -146,6 +146,14 @@ describe('TransactionReceiptsComponent', () => {
     expect(itemizeAction?.isEnabled(transaction)).toBeTrue();
     expect(unitemizeAction?.isEnabled(transaction)).toBeTrue();
     expect(reattributeAction?.isEnabled(transaction)).toBeTrue();
+
+    expect(
+      reattributeAction?.isAvailable({
+        ...transaction,
+        itemized: false,
+        transactionType: { ...transaction.transactionType, negativeAmountValueOnly: true },
+      } as SchATransaction),
+    ).toEqual(false);
   });
 
   it('test forceAggregate', async () => {


### PR DESCRIPTION
Issue [FECFILE-2695](https://fecgov.atlassian.net/browse/FECFILE-2695)