### PR TITLE
[E2E] Feature/e2e 2775 and 2783

### DIFF
--- a/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
@@ -207,7 +207,7 @@ describe('Loans', () => {
       cy.get('.p-datatable-mask').should('not.exist');
 
       // go to create guarantor
-      cy.contains('button', 'Save & add loan guarantor').should('be.enabled').click();
+      cy.contains('button', 'Save & add loan guarantor').should('be.enabled').click({force: true});
       cy.contains('h1', 'Guarantors to loan source').should('be.visible', { timeout: 5000 });
       ContactLookup.getContact(result.individual.last_name);
       cy.get('#amount').safeType(formData['amount']);

--- a/front-end/cypress/e2e-smoke/pages/transactionDetailPage.ts
+++ b/front-end/cypress/e2e-smoke/pages/transactionDetailPage.ts
@@ -172,7 +172,7 @@ export class TransactionDetailPage {
     }
 
     if (formData.line_of_credit) {
-      cy.get(alias).find('input[name="line_of_credit"]').first().click({ force: true });
+      cy.get(alias).find('input#line_of_credit').first().click({ force: true });
     }
 
     if (formData.others_liable) {


### PR DESCRIPTION
Ticket link: 
[FECFILE-2775](https://fecgov.atlassian.net/browse/FECFILE-2775)
[FECFILE-2783](https://fecgov.atlassian.net/browse/FECFILE-2783)

- a slight change to the linked contact deletion test in contacts.delete regarding finding the report id in report_ids instead
- in loans-bank, a click on 'Save & add loan guarantor' was changed to a force click

As for the remaining test failures (in loans-bank and contacts.transactions), they're caught bugs, so no changes to tests required. Bugs are tracked in [FECFILE-2788 (transaction history table)](https://fecgov.atlassian.net/browse/FECFILE-2788) and [FECFILE-2789 (bank loans kebab options)](https://fecgov.atlassian.net/browse/FECFILE-2789)
