### PR TITLE
FECFile-2775: flaky loans-bank 'add Guarantor' test

### DIFF
--- a/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
@@ -199,7 +199,10 @@ describe('Loans', () => {
   it('should test: Loan Received from Bank - add Guarantor', () => {
     setupLoanFromBank({ individual: true, organization: true }).then((result: any) => {
       ReportListPage.goToReportList(result.report);
-      cy.intercept('GET', '**/api/v1/transactions/?*parent=**&*schedules=C2*').as('GetC2List');
+      cy.intercept(
+        'GET',
+        /\/api\/v1\/transactions\/\?(?=.*parent=)(?=.*schedules=C2).*/
+      ).as('GetC2List');
       clickLoan('Edit');
     
       // wait for form to be done (load c2 table)
@@ -210,7 +213,7 @@ describe('Loans', () => {
       cy.intercept('PUT', '**/api/v1/transactions/**').as('saveAddGuarantor')
       cy.contains('button', 'Save & add loan guarantor').should('be.enabled').click();
       cy.wait('@saveAddGuarantor', {timeout: 15000});
-      cy.contains('h1', 'Guarantors to loan source').should('be.visible', { timeout: 15000 });
+      cy.contains('h1', 'Guarantors to loan source', { timeout: 15000 }).should('be.visible');
       ContactLookup.getContact(result.individual.last_name);
       cy.get('#amount').safeType(formData['amount']);
       TransactionDetailPage.clickSave(result.report);

--- a/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
@@ -46,8 +46,8 @@ function setupLoanFromBank(setup: Setup) {
 
     const loanInfo: LoanInfo = {
       loan_amount: 60000,
-      loan_incurred_date: '2025-04-27',
-      loan_due_date: '2025-04-27',
+      loan_incurred_date: `${currentYear}-04-27`,
+      loan_due_date: `${currentYear}-04-27`,
       loan_interest_rate: '2.3%',
       secured: false,
       loan_restructured: false,
@@ -60,7 +60,7 @@ function setupLoanFromBank(setup: Setup) {
         middle_name: null,
         prefix: null,
         suffix: null,
-        date_signed: '2025-04-27',
+        date_signed: `${currentYear}-04-27`,
       },
       {
         last_name: 'Leannon',
@@ -199,16 +199,18 @@ describe('Loans', () => {
   it('should test: Loan Received from Bank - add Guarantor', () => {
     setupLoanFromBank({ individual: true, organization: true }).then((result: any) => {
       ReportListPage.goToReportList(result.report);
-      clickLoan('Edit');
-
-      // wait for form to be done (load c2 table)
       cy.intercept('GET', '**/api/v1/transactions/?*parent=**&*schedules=C2*').as('GetC2List');
-      cy.wait('@GetC2List');
+      clickLoan('Edit');
+    
+      // wait for form to be done (load c2 table)
+      cy.wait('@GetC2List', {timeout: 15000});
       cy.get('.p-datatable-mask').should('not.exist');
-
+    
       // go to create guarantor
-      cy.contains('button', 'Save & add loan guarantor').should('be.enabled').click({force: true});
-      cy.contains('h1', 'Guarantors to loan source').should('be.visible', { timeout: 5000 });
+      cy.intercept('PUT', '**/api/v1/transactions/**').as('saveAddGuarantor')
+      cy.contains('button', 'Save & add loan guarantor').should('be.enabled').click();
+      cy.wait('@saveAddGuarantor', {timeout: 15000});
+      cy.contains('h1', 'Guarantors to loan source').should('be.visible', { timeout: 15000 });
       ContactLookup.getContact(result.individual.last_name);
       cy.get('#amount').safeType(formData['amount']);
       TransactionDetailPage.clickSave(result.report);


### PR DESCRIPTION
Ticket link: 
[FECFILE-2775](https://fecgov.atlassian.net/browse/FECFILE-2775)

cleaned up order of original intercept for GetC2List, and added another when loan is saved (before asserting the 'h1' header containing 'Guarantors to loan source' is visible on the ensuing page), and fixed another issue i found regarding a hardcoded year in the bank loan setup helper so i set it to currentYear