### PR TITLE
FECFile-2757: migrate nightly workflow to schedule triggers (code/docs portion)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,16 @@ jobs:
           path: /tmp/cypress/screenshots
           destination: cypress/screenshots
 
+  update-sprint-schedule:
+    docker:
+      - image: cimg/python:3.13
+    steps:
+      - checkout
+      - run:
+          name: update nightly-latest-sprint schedule to latest release/sprint-*
+          command: |
+            python3 scripts/update_sprint_schedule_trigger.py
+
   deploy-job:
     docker:
       - image: cimg/python:3.13-node
@@ -317,6 +327,10 @@ parameters:
     type: boolean
     default: false
 
+  is-triggered-update-sprint-schedule:
+    type: boolean
+    default: false
+
 workflows:
   primary:
     when:
@@ -325,6 +339,7 @@ workflows:
         - not: << pipeline.parameters.is-triggered-e2e-extended-test >>
         - not: << pipeline.parameters.is-triggered-unit-test >>
         - not: << pipeline.parameters.is-triggered-full-nightly >>
+        - not: << pipeline.parameters.is-triggered-update-sprint-schedule >>
     jobs:
       - lint
       - test
@@ -334,7 +349,7 @@ workflows:
           filters:
             branches:
               only: /develop|release\/sprint-[\.\d]+|release\/test|main/
-      - deploy-job:  # Deploy job even when e2e tests fail
+      - deploy-job: # Deploy job even when e2e tests fail
           name: deploy-even-if-e2e-job-fails
           requires:
             - lint
@@ -375,16 +390,11 @@ workflows:
           video: true
       - test
 
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *" # 06:00 UTC
+  update-sprint-schedule:
+    when: << pipeline.parameters.is-triggered-update-sprint-schedule >>
+    jobs:
+      - update-sprint-schedule:
+          context: nightly-schedule-admin
           filters:
             branches:
-              only: /develop|release\/sprint-[\.\d]+|release\/test|main/
-    jobs:
-      - e2e-smoke:
-          video: true
-      - e2e-extended:
-          video: true
-      - test
+              only: main

--- a/front-end/cypress/docs/nightly_e2e_ci_schedule.md
+++ b/front-end/cypress/docs/nightly_e2e_ci_schedule.md
@@ -1,0 +1,215 @@
+# CI Scheduling: Nightly E2E & Latest Sprint Auto-Targeting
+
+This repo uses **CircleCI Schedule Triggers (scheduled pipelines)** (not cron triggers in `.circleci/config.yml`) to run the **full-nightly** workflow on:
+
+- `main`
+- `develop`
+- `release/test`
+- **only the latest** `release/sprint-<N>` branch (greatest integer `N`)
+
+During sprint overlap (e.g., `release/sprint-78` and `release/sprint-79` both exist), **only the latest sprint** receives scheduled nightly pipelines. Older sprint branches should **not** show scheduled nightly pipelines in CircleCI.
+
+---
+
+## Why this exists
+
+Previously, the regex-based scheduled workflow in `.circleci/config.yml` matched multiple `release/sprint-*` branches during overlaps.
+
+Now we use:
+
+1. **Pipeline-parameter gating** so the nightly workflow does **not** run on pushes
+2. **Separate CircleCI schedules** for the static branches
+3. A single schedule named **`nightly-latest-sprint`** that is automatically updated to point at the newest sprint branch via an updater job/script
+
+---
+
+## Key implementation details
+
+### Project slug
+
+CircleCI project slug (used by the updater script / API commands):
+
+- `gh/fecgov/fecfile-web-app`
+
+> Note: This is a GitHub OAuth slug, which supports schedule trigger management via the CircleCI v2 Schedule API.
+
+### Pipeline parameters (in `.circleci/config.yml`)
+
+- `is-triggered-full-nightly` (boolean, default `false`)
+  - enables the `full-nightly` workflow
+- `is-triggered-update-sprint-schedule` (boolean, default `false`)
+  - enables the updater workflow which retargets the latest-sprint schedule
+
+### Workflows
+
+- `primary`
+  - default workflow for regular pushes/PRs
+- `full-nightly`
+  - runs nightly jobs **only** when triggered by schedule or manually through the CircleCI UI
+- `update-sprint-schedule`
+  - runs the updater script to move `nightly-latest-sprint` to the newest sprint branch
+
+### Updater script
+
+Location (relative to repo root):
+
+- `scripts/update_sprint_schedule_trigger.py`
+
+What it does:
+
+1. lists remote branches matching `release/sprint-<integer>` (e.g., `release/sprint-78` & `release/sprint-79`)
+2. picks the **greatest** sprint number
+3. finds the CircleCI schedule named `nightly-latest-sprint`
+4. PATCHes that schedule so `parameters.branch = release/sprint-<latest>`
+
+**Sprint selection rules**
+- deterministic: **greatest integer sprint number wins**
+- **No multi-part versions** supported (e.g., `78.1` is ignored by design)
+
+---
+
+## Where schedules are defined
+
+Schedules are managed in CircleCI (UI):
+
+- CircleCI → Project → **Project Settings** → **Triggers / Schedules** (UI wording varies)
+
+Schedules are **not** stored in git, and **do not** require edits to `.circleci/config.yml` once set up.
+
+---
+
+## Required schedules
+
+Create these schedules in CircleCI (example time: **06:00 UTC daily**):
+
+### 1) `nightly-main`
+- Branch: `main`
+- Pipeline parameters:
+  - `is-triggered-full-nightly: true`
+
+### 2) `nightly-develop`
+- Branch: `develop`
+- Pipeline parameters:
+  - `is-triggered-full-nightly: true`
+
+### 3) `nightly-release-test`
+- Branch: `release/test`
+- Pipeline parameters:
+  - `is-triggered-full-nightly: true`
+
+### 4) `nightly-latest-sprint`
+- Branch: set once initially to the current latest sprint (example: `release/sprint-78`)
+- Pipeline parameters:
+  - `is-triggered-full-nightly: true`
+
+---
+
+## Updater schedule (recommended)
+
+To keep `nightly-latest-sprint` always targeting the newest sprint branch automatically, create:
+
+### 5) `update-nightly-latest-sprint`
+- branch: `main`
+- time: before the nightly window (example: **05:30 UTC daily**)
+- pipeline parameters:
+  - `is-triggered-update-sprint-schedule: true`
+
+**Why run updater on `main`?**
+- the updater is “control-plane” logic: it should run from a stable, protected branch
+- it avoids needing to retarget *the updater* every sprint
+- it ensures the updater always runs the latest script/config version
+
+---
+
+## Secrets and context configuration
+
+The updater needs a CircleCI API token with permission to list and patch schedules.
+
+Context name:
+
+- `nightly-schedule-admin`
+
+Environment variables (stored in the context):
+
+- `CIRCLE_TOKEN` (CircleCI personal API token)
+- `CIRCLECI_PROJECT_SLUG` = `gh/fecgov/fecfile-web-app`
+- `CIRCLECI_SPRINT_SCHEDULE_NAME` = `nightly-latest-sprint` (optional; defaults to this)
+
+> Operational note: CircleCI schedules run with an “actor”. That actor must have permission to execute workflows that use restricted contexts; otherwise jobs may fail with “Unauthorized”.
+
+---
+
+## Runbook: Sprint cutover
+
+When a new sprint branch is created (example: `release/sprint-79`):
+
+1. Wait until the branch is created in GitHub like normal
+2. Let the updater schedule run (next scheduled run), **or** trigger the updater manually:
+   - CircleCI → Run pipeline on branch `main`
+   - pipeline parameter: `is-triggered-update-sprint-schedule=true`
+3. Confirm the updater job logs:
+   - detected sprint branches
+   - picked the greatest sprint number
+   - updated `nightly-latest-sprint` schedule to the new branch
+4. Next nightly window: only the newest sprint branch receives scheduled nightly pipelines
+
+---
+
+## Verification checklist (acceptance criteria)
+
+### Branch coverage
+Confirm scheduled nightly pipelines appear daily on:
+- `main`
+- `develop`
+- `release/test`
+- latest `release/sprint-<N>`
+
+### Overlap behavior
+With two sprint branches present (e.g., `release/sprint-78` and `release/sprint-79`):
+- Only `release/sprint-79` shows scheduled nightlies
+- `release/sprint-78` shows **no new** scheduled nightly pipelines
+
+### Nightly does not run on pushes
+- push to `develop`
+- confirm `primary` runs as normal
+- confirm `full-nightly` does not run unless triggered by schedule + parameter
+
+
+---
+
+## Troubleshooting
+
+### Nightly is not running on a branch
+1. check that a schedule exists for that branch (`nightly-main`, `nightly-develop`, etc.)
+2. confirm the schedule includes:
+   - `is-triggered-full-nightly: true`
+3. confirm the pipeline did not run from a normal push:
+   - nightly should only run from scheduled pipelines (or manually triggered in CircleCI UI)
+4. confirm schedule time zone and timing (UTC)
+
+### Older sprint branch still shows nightly pipelines
+- old pipelines remain in history; what matters is **no new scheduled pipelines** appear.
+- ensure `nightly-latest-sprint` has been retargeted to the newest sprint
+
+### Updater job fails
+Common causes:
+
+- **Schedule not found**
+  - you must create the schedule named `nightly-latest-sprint` once in the CircleCI UI
+- **Unauthorized**
+  - context/actor mismatch; token missing; or actor lacks access to required context
+- **No sprint branches found**
+  - branch naming does not match `release/sprint-<integer>`
+- **Multiple schedules with the same name**
+  - ensure `nightly-latest-sprint` is unique
+
+---
+
+## API quick-reference (optional)
+
+List schedules:
+
+```bash
+curl --request GET \
+  --url "https://circleci.com/api/v2/project/gh/fecgov/fecfile-web-app/schedule" \
+  --header "Circle-Token: ${CIRCLE_TOKEN}"

--- a/scripts/update_sprint_schedule_trigger.py
+++ b/scripts/update_sprint_schedule_trigger.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+import urllib.error
+
+API_BASE = "https://circleci.com/api/v2"
+
+def eprint(*args):
+    print(*args, file=sys.stderr)
+
+def require_env(name: str) -> str:
+    v = os.getenv(name)
+    if not v:
+        raise RuntimeError(f"Missing required env var: {name}")
+    return v
+
+def run(cmd):
+    p = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if p.returncode != 0:
+        eprint("Command failed:", " ".join(cmd))
+        eprint(p.stderr.strip())
+        raise RuntimeError("Command failed")
+    return p.stdout
+
+def latest_sprint_branch(remote="origin") -> str:
+    # Only supports integer sprint numbers: release/sprint-78 (NOT 78.1)
+    out = run(["git", "ls-remote", "--heads", remote, "release/sprint-*"])
+    found = []
+    for line in out.splitlines():
+        m = re.search(r"refs/heads/(release/sprint-(\d+))$", line.strip())
+        if m:
+            found.append((int(m.group(2)), m.group(1)))
+
+    if not found:
+        raise RuntimeError("No branches matched release/sprint-<integer>")
+
+    found.sort(key=lambda t: t[0])
+    latest = found[-1][1]
+    print("Detected sprint branches:", ", ".join([b for _, b in found]))
+    print("Latest sprint branch:", latest)
+    return latest
+
+def circleci_request(token, method, url, payload=None):
+    headers = {
+        "Circle-Token": token,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, method=method, headers=headers, data=data)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read().decode("utf-8").strip()
+            return {} if not body else json.loads(body)
+    except urllib.error.HTTPError as e:
+        err = e.read().decode("utf-8", errors="replace")
+        eprint(f"CircleCI API error {e.code} on {method} {url}")
+        eprint(err)
+        raise
+
+def list_schedules(token, project_slug):
+    schedules = []
+    page_token = None
+    enc_slug = urllib.parse.quote(project_slug, safe="")
+    while True:
+        url = f"{API_BASE}/project/{enc_slug}/schedule"
+        if page_token:
+            url += f"?page-token={urllib.parse.quote(page_token, safe='')}"
+        resp = circleci_request(token, "GET", url)
+        schedules.extend(resp.get("items", []))
+        page_token = resp.get("next_page_token")
+        if not page_token:
+            break
+    return schedules
+
+def patch_schedule_branch(token, schedule_id, params, branch):
+    new_params = dict(params or {})
+    new_params["branch"] = branch
+
+    # Ensure nightly param is present (defensive)
+    if "is-triggered-full-nightly" not in new_params:
+        new_params["is-triggered-full-nightly"] = True
+
+    url = f"{API_BASE}/schedule/{schedule_id}"
+    circleci_request(token, "PATCH", url, payload={"parameters": new_params})
+    print(f"Updated schedule {schedule_id} → branch={branch}")
+
+def main():
+    token = os.getenv("CIRCLE_TOKEN") or os.getenv("CIRCLECI_TOKEN")
+    if not token:
+        raise RuntimeError("Missing CIRCLE_TOKEN (or CIRCLECI_TOKEN)")
+
+    project_slug = require_env("CIRCLECI_PROJECT_SLUG")
+    schedule_name = os.getenv("CIRCLECI_SPRINT_SCHEDULE_NAME", "nightly-latest-sprint")
+
+    latest = latest_sprint_branch()
+
+    schedules = list_schedules(token, project_slug)
+    matches = [s for s in schedules if s.get("name") == schedule_name]
+
+    if not matches:
+        raise RuntimeError(f"Schedule '{schedule_name}' not found. Create it once in the CircleCI UI.")
+    if len(matches) > 1:
+        raise RuntimeError(f"Multiple schedules named '{schedule_name}'. Make schedule names unique.")
+
+    sched = matches[0]
+    sched_id = sched.get("id")
+    params = sched.get("parameters") or {}
+    current = params.get("branch")
+
+    print(f"Schedule '{schedule_name}' currently targets:", current)
+    if current == latest:
+        print("Already up to date. No changes.")
+        return 0
+
+    patch_schedule_branch(token, sched_id, params, latest)
+    return 0
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as ex:
+        eprint("Updater failed:", ex)
+        raise SystemExit(1)


### PR DESCRIPTION
here's the code/docs portion of the ticket which removes the cron nightly workflow in config.yml, adds a script to check for sprint number updates which runs on main (stable), still need to create schedule triggers as these changes get successively merged into "higher" branches, culminating on main (where an additional schedule trigger will exist (5 total) to check daily for the latest release/sprint-* branch to update which branch `nightly`latest-sprint` is triggered on, i.e. greatest numbered sprint

Ticket link: [FECFILE-2757](https://fecgov.atlassian.net/browse/FECFILE-2757)
