### PR TITLE
feature/2792 - Cleanup Debt Input to be Schedule D coded

### DIFF
--- a/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.html
+++ b/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.html
@@ -5,13 +5,13 @@
         <label for="balance">BEGINNING BALANCE</label>
         <app-input-number
           inputId="balance"
-          [formControlName]="templateMap['balance']"
+          formControlName="beginning_balance"
           [readonly]="true"
           inputStyleClass="readonly"
         />
         <app-error-messages
           [form]="form"
-          [fieldName]="templateMap['balance']"
+          fieldName="beginning_balance"
           [formSubmitted]="formSubmitted"
           patternErrorMessage="This field must be a number"
           maxLengthErrorMessage="The beginning balance can be 12 digits max"
@@ -21,10 +21,10 @@
     <div class="col-6">
       <div class="field">
         <label for="amount">INCURRED AMOUNT</label>
-        <app-input-number inputId="amount" [formControlName]="templateMap['amount']" />
+        <app-input-number inputId="amount" formControlName="incurred_amount" />
         <app-error-messages
           [form]="form"
-          [fieldName]="templateMap['amount']"
+          fieldName="incurred_amount"
           [formSubmitted]="formSubmitted"
           patternErrorMessage="This field must be a number"
           maxLengthErrorMessage="The incurred amount can be 12 digits max"

--- a/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.spec.ts
@@ -3,7 +3,7 @@ import { DebtInputComponent } from './debt-input.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import { testMockStore, testTemplateMap } from 'app/shared/utils/unit-test.utils';
+import { testMockStore } from 'app/shared/utils/unit-test.utils';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
 import { Transaction } from 'app/shared/models/transaction.model';
 
@@ -18,9 +18,9 @@ describe('DebtInputComponent', () => {
     });
     fixture = TestBed.createComponent(DebtInputComponent);
     component = fixture.componentInstance;
-    component.templateMap = testTemplateMap();
-    component.form.setControl('loan_balance', new SubscriptionFormControl());
-    component.form.setControl('contribution_amount', new SubscriptionFormControl());
+
+    component.form.setControl('beginning_balance', new SubscriptionFormControl());
+    component.form.setControl('incurred_amount', new SubscriptionFormControl());
     component.form.setControl('payment_amount', new SubscriptionFormControl());
     component.form.setControl('balance_at_close', new SubscriptionFormControl());
   });
@@ -47,7 +47,7 @@ describe('DebtInputComponent', () => {
       // Create a mock transaction object with the required properties
       const mockTransaction: Partial<Transaction> & Record<string, unknown> = {
         id: transactionId,
-        [component.templateMap.balance]: beginningBalance,
+        beginning_balance: beginningBalance,
         payment_amount: paymentAmount,
       };
 
@@ -65,7 +65,7 @@ describe('DebtInputComponent', () => {
       // Expected: balance_at_close = 5000 + 2000 - 1000 = 6000
       setupAndInitialize(5000, 1000);
 
-      const incurredAmountControl = component.form.get(component.templateMap.amount);
+      const incurredAmountControl = component.form.get('incurred_amount');
       incurredAmountControl?.setValue(2000, { emitEvent: true });
       fixture.detectChanges();
 
@@ -79,7 +79,7 @@ describe('DebtInputComponent', () => {
       // Expected: balance_at_close = 1000 + 0 - 0 = 1000
       setupAndInitialize(1000, 0);
 
-      const incurredAmountControl = component.form.get(component.templateMap.amount);
+      const incurredAmountControl = component.form.get('incurred_amount');
       incurredAmountControl?.setValue(0, { emitEvent: true });
       fixture.detectChanges();
 
@@ -91,7 +91,7 @@ describe('DebtInputComponent', () => {
       // Setup: beginning balance = 1000, payment amount = 100
       setupAndInitialize(1000, 100);
 
-      const incurredAmountControl = component.form.get(component.templateMap.amount);
+      const incurredAmountControl = component.form.get('incurred_amount');
       const balanceAtCloseControl = component.form.get('balance_at_close');
 
       // First update: incurred_amount = 500
@@ -118,7 +118,7 @@ describe('DebtInputComponent', () => {
       // Setup: beginning balance = 0, payment amount = 0 (new transaction)
       setupAndInitialize(0, 0, undefined);
 
-      const incurredAmountControl = component.form.get(component.templateMap.amount);
+      const incurredAmountControl = component.form.get('incurred_amount');
       const balanceAtCloseControl = component.form.get('balance_at_close');
 
       // After user enters incurred amount of 10000
@@ -133,7 +133,7 @@ describe('DebtInputComponent', () => {
       // Expected: balance_at_close = 5000 + 1000 - (-500) = 6500
       setupAndInitialize(5000, -500);
 
-      const incurredAmountControl = component.form.get(component.templateMap.amount);
+      const incurredAmountControl = component.form.get('incurred_amount');
       incurredAmountControl?.setValue(1000, { emitEvent: true });
       fixture.detectChanges();
 

--- a/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.ts
@@ -4,6 +4,7 @@ import { BaseInputComponent } from '../base-input.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { InputNumberComponent } from '../input-number/input-number.component';
 import { ErrorMessagesComponent } from '../../error-messages/error-messages.component';
+import { SchDTransaction } from 'app/shared/models';
 
 @Component({
   selector: 'app-debt-input',
@@ -15,22 +16,20 @@ export class DebtInputComponent extends BaseInputComponent implements OnInit {
     // For new create transactions, the debt calculated amounts are initialized to 0
     // They a calculated fields and not saved to the database
     if (!this.transaction()?.id) {
-      this.form.get(this.templateMap.balance)?.setValue(0);
+      this.form.get('beginning_balance')?.setValue(0);
       this.form.get('payment_amount')?.setValue(0);
       this.form.get('balance_at_close')?.setValue(0);
     }
 
     // balance_at_close is a calculated field and not saved to the database
     this.form
-      .get(this.templateMap.amount)
+      .get('incurred_amount')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((amount) => {
         const amountNumber = isNaN(parseFloat(amount)) ? 0 : parseFloat(amount);
-        const tx = this.transaction();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const beginning_balance = parseFloat(String((tx as any)?.[this.templateMap.balance] ?? 0));
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const payment_amount = parseFloat(String((tx as any)?.['payment_amount'] ?? 0));
+        const tx = this.transaction() as SchDTransaction | undefined;
+        const beginning_balance = tx?.beginning_balance ?? 0;
+        const payment_amount = tx?.payment_amount ?? 0;
         const balance_at_close = beginning_balance + amountNumber - payment_amount;
 
         this.form.get('balance_at_close')?.setValue(balance_at_close);

--- a/front-end/src/app/shared/models/schd-transaction.model.ts
+++ b/front-end/src/app/shared/models/schd-transaction.model.ts
@@ -1,4 +1,4 @@
-import { plainToClass } from 'class-transformer';
+import { plainToClass, Transform } from 'class-transformer';
 import { AggregationGroups, Transaction } from './transaction.model';
 import { LabelList } from '../utils/label.utils';
 import { getFromJSON, TransactionTypeUtils } from '../utils/transaction-type.utils';
@@ -20,9 +20,13 @@ export class SchDTransaction extends Transaction {
   creditor_state: string | undefined;
   creditor_zip: string | undefined;
   purpose_of_debt_or_obligation: string | undefined;
+  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
   beginning_balance: number | undefined;
+  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
   incurred_amount: number | undefined;
+  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
   payment_amount: number | undefined;
+  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
   balance_at_close: number | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Issue [FECFILE-2792](https://fecgov.atlassian.net/browse/FECFILE-2792)

This just cleans up the DebtInput component a bit to remove unnecessary lookups because this MUST be a Schedule D transaction. I also added some Transformers to the schd-transaction.model.ts so the number properties will actually be numbers instead of strings upon conversion from json.