### PR TITLE
FECFILE-2826: 5xx tripwire update to fail only the 'it' block with the 5xx

### DIFF
--- a/front-end/cypress/e2e-extended/users/users.validation.cy.ts
+++ b/front-end/cypress/e2e-extended/users/users.validation.cy.ts
@@ -80,7 +80,7 @@ describe("Users: Validation and API failure states", () => {
     PageUtils.closeToast();
   });
 
-  it('should stub 500 on invite, keep submit enabled, then succeed on retry @allow-5xx', () => {
+  it('should stub 500 on invite, keep submit enabled, then succeed on retry', () => {
     const adminUser = { ...userFormData, role: Roles.COMMITTEE_ADMINISTRATOR };
     UsersHelpers.stubOnce('POST', ADD_MEMBER_POST, { statusCode: 500, body: { message: 'Server error' } }, 'invite500');
     cy.intercept('GET', LIST_MEMBERS_GET).as('GetMembers');

--- a/front-end/cypress/e2e-extended/users/users.validation.cy.ts
+++ b/front-end/cypress/e2e-extended/users/users.validation.cy.ts
@@ -80,7 +80,7 @@ describe("Users: Validation and API failure states", () => {
     PageUtils.closeToast();
   });
 
-  it('should stub 500 on invite, keep submit enabled, then succeed on retry', () => {
+  it('@allow-5xx should stub 500 on invite, keep submit enabled, then succeed on retry', () => {
     const adminUser = { ...userFormData, role: Roles.COMMITTEE_ADMINISTRATOR };
     UsersHelpers.stubOnce('POST', ADD_MEMBER_POST, { statusCode: 500, body: { message: 'Server error' } }, 'invite500');
     cy.intercept('GET', LIST_MEMBERS_GET).as('GetMembers');
@@ -101,7 +101,7 @@ describe("Users: Validation and API failure states", () => {
   });
 
 
-  it('should stub 500 on delete of user, keep row, then succeed on retry @allow-5xx', () => {
+  it('@allow-5xx should stub 500 on delete of user, keep row, then succeed on retry', () => {
     const target = userFormData.email;
     UsersPage.assertRow({ ...userFormData, email: target }, 'Pending');
     cy.intercept(


### PR DESCRIPTION
update to run next 'it' block(s) in spec if one of them fails due to a 5xx, not just terminate the whole spec

Ticket link: 
[FECFILE-2826](https://fecgov.atlassian.net/browse/FECFILE-2826)


