### PR TITLE
FECFILE-2820: flaky F3X/loans-individual.cy.ts ('should test: Loan By Committee - delete Guarantor')

### DIFF
--- a/front-end/cypress/e2e-smoke/F3X/loans-individual.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-individual.cy.ts
@@ -50,11 +50,11 @@ describe('Loans', () => {
     Initialize();
   });
 
-  xit('should test: Loan Received From Individual', () => {
+  it('should test: Loan Received From Individual', () => {
     setupLoanReceivedFromIndividual().then(verifyLoanReceivedFromIndividualNoDeleteButton);
   });
 
-  xit('should test: Loan Guarantors', () => {
+  it('should test: Loan Guarantors', () => {
     setupLoanReceivedFromIndividual().then((result: any) => {
       TransactionDetailPage.addGuarantor(result.individual2.last_name, formData['amount'], result.report);
       cy.contains('Transactions in this report').should('exist');

--- a/front-end/cypress/e2e-smoke/F3X/loans-individual.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-individual.cy.ts
@@ -50,11 +50,11 @@ describe('Loans', () => {
     Initialize();
   });
 
-  it('should test: Loan Received From Individual', () => {
+  xit('should test: Loan Received From Individual', () => {
     setupLoanReceivedFromIndividual().then(verifyLoanReceivedFromIndividualNoDeleteButton);
   });
 
-  it('should test: Loan Guarantors', () => {
+  xit('should test: Loan Guarantors', () => {
     setupLoanReceivedFromIndividual().then((result: any) => {
       TransactionDetailPage.addGuarantor(result.individual2.last_name, formData['amount'], result.report);
       cy.contains('Transactions in this report').should('exist');
@@ -63,11 +63,14 @@ describe('Loans', () => {
 
   it('should test: Loan By Committee - delete Guarantor', () => {
     setupLoanReceivedFromIndividual().then((result: any) => {
+      // put intercept here so it registers before the addGuarantor call
+      // also changed the endpoint to use a regex to match the schedules parameter order-agnostic
+      cy.intercept('GET', /\/api\/v1\/transactions\/\?(?=.*schedules=C2).*/).as('GuarantorList');
       TransactionDetailPage.addGuarantor(result.individual2.last_name, formData['amount'], result.report);
 
-      cy.intercept('GET', 'http://localhost:8080/api/v1/transactions/**&schedules=C2').as('GuarantorList');
       let alias = PageUtils.getAlias('app-transaction-receipts');
       cy.get(alias).contains('Loan Received from Individual').click();
+      // there're also `**/transaction/previous/entity/**` calls before this wait that might need to be intercepted/handled
       cy.wait('@GuarantorList');
       PageUtils.clickKababItem(result.individual2.last_name, 'Delete');
       PageUtils.clickButton('Confirm');


### PR DESCRIPTION
put GuarantorList intercept alias before TransactionDetailPage.addGuarantor(), changed the intercept to regex, added a few comments regarding '/previous/entity/' calls

Ticket link: [FECFILE-2820](https://fecgov.atlassian.net/browse/FECFILE-2820)

