### PR TITLE
[Sprint 79] FECFILE-2830: E2E flaky F24/reports-f24-independent-expenditures.cy.ts

### DIFF
--- a/front-end/cypress/e2e-smoke/pages/reportListPage.ts
+++ b/front-end/cypress/e2e-smoke/pages/reportListPage.ts
@@ -76,21 +76,48 @@ export class ReportListPage {
   }
 
   static goToReportList(reportId: string, includeReceipts = true, includeDisbursements = true, includeLoans = true) {
-    if (includeReceipts)
-      cy.intercept(
-        'GET',
-        `http://localhost:8080/api/v1/transactions/?page=1&ordering=line_label,created&page_size=5&report_id=${reportId}&schedules=A`,
-      ).as('GetReceipts');
-    if (includeLoans)
-      cy.intercept(
-        'GET',
-        `http://localhost:8080/api/v1/transactions/?page=1&ordering=line_label,created&page_size=5&report_id=${reportId}&schedules=C,D`,
-      ).as('GetLoans');
-    if (includeDisbursements)
-      cy.intercept(
-        'GET',
-        `http://localhost:8080/api/v1/transactions/?page=1&ordering=line_label,created&page_size=5&report_id=${reportId}&schedules=B,E,F`,
-      ).as('GetDisbursements');
+    if (includeReceipts) {
+      cy.intercept({
+        method: 'GET',
+        pathname: '/api/v1/transactions/',
+        query: {
+          report_id: reportId,
+          schedules: 'A',
+          page: '1',
+          ordering: 'line_label,created',
+          page_size: '5',
+        },
+      }).as('GetReceipts');
+    }
+
+    if (includeLoans) {
+      cy.intercept({
+        method: 'GET',
+        pathname: '/api/v1/transactions/',
+        query: {
+          report_id: reportId,
+          schedules: 'C,D',
+          page: '1',
+          ordering: 'line_label,created',
+          page_size: '5',
+        },
+      }).as('GetLoans');
+    }
+
+    if (includeDisbursements) {
+      cy.intercept({
+        method: 'GET',
+        pathname: '/api/v1/transactions/',
+        query: {
+          report_id: reportId,
+          schedules: 'B,E,F',
+          page: '1',
+          ordering: 'line_label,created',
+          page_size: '5',
+        },
+      }).as('GetDisbursements');
+    }
+
     cy.visit(`/reports/transactions/report/${reportId}/list`);
     if (includeLoans) cy.wait('@GetLoans');
     if (includeDisbursements) cy.wait('@GetDisbursements');


### PR DESCRIPTION
Ticket link: [FECFILE-2830](https://fecgov.atlassian.net/browse/FECFILE-2830)

refactored the hardcoded intercepts within goToReportList for receipts, loans, and disbursements more flexible/dynamic in reportListPage (used in F24/reports-f24-independent-expenditures.cy.ts)

