### PR TITLE
Feature/2547 - Update Previous endpoints to return the amount rather than the entire model

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.spec.ts
@@ -27,19 +27,12 @@ describe('FormUtils', () => {
       contribution_amount: 50,
     });
 
-    const previous_transaction = SchATransaction.fromJSON({
-      transaction_type_identifier: ScheduleATransactionTypes.TRIBAL_NATIONAL_PARTY_CONVENTION_ACCOUNT,
-      aggregation_group: AggregationGroups.NATIONAL_PARTY_CONVENTION_ACCOUNT,
-      contribution_amount: 100,
-      contribution_aggregate: 100,
-    });
-
     TransactionFormUtils.updateAggregate(
       form,
       'aggregate',
       transaction.transactionType.templateMap,
       transaction,
-      previous_transaction,
+      100,
       transaction.contribution_amount as number,
     );
 
@@ -63,19 +56,12 @@ describe('FormUtils', () => {
       expenditure_amount: 50,
     });
 
-    const previous_transaction = SchATransaction.fromJSON({
-      transaction_type_identifier: ScheduleATransactionTypes.TRIBAL_NATIONAL_PARTY_CONVENTION_ACCOUNT,
-      aggregation_group: AggregationGroups.NATIONAL_PARTY_CONVENTION_ACCOUNT,
-      contribution_amount: 100,
-      contribution_aggregate: 100,
-    });
-
     TransactionFormUtils.updateAggregate(
       form,
       'aggregate',
       transaction.transactionType.templateMap,
       transaction,
-      previous_transaction,
+      100,
       transaction.expenditure_amount as number,
     );
 
@@ -99,19 +85,12 @@ it('should add the amount for calendar YTD', () => {
     expenditure_amount: 50,
   });
 
-  const previous_transaction = SchETransaction.fromJSON({
-    transaction_type_identifier: ScheduleETransactionTypes.INDEPENDENT_EXPENDITURE,
-    aggregation_group: AggregationGroups.INDEPENDENT_EXPENDITURE,
-    expenditure_amount: 100,
-    calendar_ytd_per_election_office: 100,
-  });
-
   TransactionFormUtils.updateAggregate(
     form,
     'calendar_ytd',
     transaction.transactionType.templateMap,
     transaction,
-    previous_transaction,
+    100,
     transaction.expenditure_amount as number,
   );
 
@@ -134,19 +113,12 @@ it('should add the amount for payee candidate YTD', () => {
     expenditure_amount: 50,
   });
 
-  const previous_transaction = SchFTransaction.fromJSON({
-    transaction_type_identifier: ScheduleFTransactionTypes.COORDINATED_PARTY_EXPENDITURE,
-    aggregation_group: AggregationGroups.COORDINATED_PARTY_EXPENDITURES,
-    expenditure_amount: 100,
-    aggregate_general_elec_expended: 100,
-  });
-
   TransactionFormUtils.updateAggregate(
     form,
     'aggregate_general_elec_expended',
     transaction.transactionType.templateMap,
     transaction,
-    previous_transaction,
+    100,
     transaction.expenditure_amount as number,
   );
 

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
@@ -162,7 +162,7 @@ export class TransactionFormUtils {
     templateMap: TransactionTemplateMapType,
   ) {
     if (!transaction.transactionType.inheritCalendarYTD) {
-      const previous_election$: Observable<Transaction | undefined> =
+      const previous_election$: Observable<number | null> =
         merge(
           (form.get(templateMap.date) as SubscriptionFormControl).valueChanges,
           (form.get(templateMap.date2) as SubscriptionFormControl).valueChanges,
@@ -206,7 +206,7 @@ export class TransactionFormUtils {
       const parent = await component.transactionService.get(transaction.parent_transaction?.id ?? '');
       const inheritedElectionAggregate = (parent as SchETransaction).calendar_ytd_per_election_office;
       if (inheritedElectionAggregate) {
-        this.updateAggregate(form, 'calendar_ytd', templateMap, transaction, undefined, inheritedElectionAggregate);
+        this.updateAggregate(form, 'calendar_ytd', templateMap, transaction, null, inheritedElectionAggregate);
       }
     }
   }
@@ -222,7 +222,7 @@ export class TransactionFormUtils {
     templateMap: TransactionTemplateMapType,
   ) {
     const contactId$ = contactIdMap['contact_2'].asObservable();
-    const previous_expenditure$: Observable<Transaction | undefined> =
+    const previous_expenditure$: Observable<number | null> =
       merge(
         (form.get(templateMap.date) as SubscriptionFormControl).valueChanges,
         (form.get(templateMap.general_election_year) as SubscriptionFormControl).valueChanges,
@@ -267,11 +267,10 @@ export class TransactionFormUtils {
     field: TemplateMapKeyType,
     templateMap: TransactionTemplateMapType,
     transaction: Transaction,
-    previousTransaction: Transaction | undefined,
+    previousTransaction: number | null,
     amount: number,
   ) {
-    const key = previousTransaction?.transactionType?.templateMap[field] as keyof ScheduleTransaction;
-    const previousAggregate = previousTransaction ? +((previousTransaction as ScheduleTransaction)[key] || 0) : 0;
+    const previousAggregate = previousTransaction ?? 0;
     if (transaction.force_unaggregated) {
       form.get(templateMap[field])?.setValue(previousAggregate);
     } else if (transaction.transactionType?.isRefund) {

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
@@ -180,7 +180,7 @@ export class TransactionFormUtils {
             const candidate_district = form.get(templateMap.candidate_district)?.value;
 
             return from(
-              component.transactionService.getPreviousTransactionForCalendarYTD(
+              component.transactionService.getPreviousElectionAggregate(
                 transaction,
                 disbursement_date,
                 dissemination_date,
@@ -199,8 +199,8 @@ export class TransactionFormUtils {
           combineLatestWith(previous_election$, of(transaction)),
           takeUntil(component.destroy$),
         )
-        .subscribe(([amount, previous_election, transaction]) => {
-          this.updateAggregate(form, 'calendar_ytd', templateMap, transaction, previous_election, amount);
+        .subscribe(([amount, previousAggregate, transaction]) => {
+          this.updateAggregate(form, 'calendar_ytd', templateMap, transaction, previousAggregate, amount);
         });
     } else {
       const parent = await component.transactionService.get(transaction.parent_transaction?.id ?? '');
@@ -234,7 +234,7 @@ export class TransactionFormUtils {
           const contact2Id = transaction.contact_2?.id;
 
           return from(
-            component.transactionService.getPreviousTransactionForPayeeCandidate(
+            component.transactionService.getPreviousPayeeCandidateAggregate(
               transaction,
               contact2Id,
               expenditure_date,
@@ -250,13 +250,13 @@ export class TransactionFormUtils {
         combineLatestWith(previous_expenditure$, of(transaction)),
         takeUntil(component.destroy$),
       )
-      .subscribe(([amount, previous_election, transaction]) => {
+      .subscribe(([amount, previousAggregate, transaction]) => {
         this.updateAggregate(
           form,
           'aggregate_general_elec_expended',
           templateMap,
           transaction,
-          previous_election,
+          previousAggregate,
           amount,
         );
       });
@@ -267,10 +267,10 @@ export class TransactionFormUtils {
     field: TemplateMapKeyType,
     templateMap: TransactionTemplateMapType,
     transaction: Transaction,
-    previousTransaction: number | null,
+    previousAggregate: number | null,
     amount: number,
   ) {
-    const previousAggregate = previousTransaction ?? 0;
+    previousAggregate = previousAggregate ?? 0;
     if (transaction.force_unaggregated) {
       form.get(templateMap[field])?.setValue(previousAggregate);
     } else if (transaction.transactionType?.isRefund) {
@@ -436,12 +436,12 @@ export class TransactionFormUtils {
     firstValueFrom(contactId$).then((contactIdStart) => {
       (form.get(templateMap.date) as SubscriptionFormControl).addSubscription(
         async ([contribution_date, amount, contactId]) => {
-          const previous_transaction = await component.transactionService.getPreviousTransactionForAggregate(
+          const previousAggregate = await component.transactionService.getPreviousEntityAggregate(
             transaction,
             contactId,
             contribution_date,
           );
-          this.updateAggregate(form, 'aggregate', templateMap, transaction, previous_transaction, amount);
+          this.updateAggregate(form, 'aggregate', templateMap, transaction, previousAggregate, amount);
         },
         component.destroy$,
         [

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
@@ -89,7 +89,7 @@ describe('TransactionTypeBaseComponent', () => {
           useValue: jasmine.createSpyObj('TransactionService', {
             update: of(undefined),
             create: of(undefined),
-            getPreviousTransactionForAggregate: Promise.resolve(undefined),
+            getPreviousEntityAggregate: Promise.resolve(undefined),
           }),
         },
         ConfirmationService,
@@ -621,11 +621,11 @@ describe('TransactionTypeBaseComponent', () => {
 
       form.get('expenditure_amount')?.setValue(25);
       form.get('expenditure_date')?.setValue(new Date('1-1-2013'));
-      expect(transactionServiceSpy.getPreviousTransactionForAggregate).not.toHaveBeenCalled();
+      expect(transactionServiceSpy.getPreviousEntityAggregate).not.toHaveBeenCalled();
 
       contactId$.next('1234-abcd-1234-abcd');
       tick();
-      expect(transactionServiceSpy.getPreviousTransactionForAggregate).toHaveBeenCalled();
+      expect(transactionServiceSpy.getPreviousEntityAggregate).toHaveBeenCalled();
     }));
   });
 });

--- a/front-end/src/app/shared/services/api.service.ts
+++ b/front-end/src/app/shared/services/api.service.ts
@@ -1,7 +1,7 @@
-import { HttpClient, HttpContext, HttpParams, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpErrorResponse, HttpParams, HttpResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
-import { firstValueFrom } from 'rxjs';
+import { catchError, firstValueFrom, of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ALLOW_ERROR_CODES } from '../interceptors/http-error.interceptor';
 
@@ -47,16 +47,26 @@ export class ApiService {
     const headers = this.getHeaders();
     if (allowedErrorCodes) {
       return firstValueFrom(
-        this.http.get<T>(`${environment.apiUrl}${endpoint}`, {
-          headers,
-          params,
-          withCredentials: true,
-          observe: 'response',
-          responseType: 'json',
-          context: new HttpContext().set(ALLOW_ERROR_CODES, allowedErrorCodes),
-        }),
+        this.http
+          .get<T>(`${environment.apiUrl}${endpoint}`, {
+            headers,
+            params,
+            withCredentials: true,
+            observe: 'response',
+            responseType: 'json',
+            context: new HttpContext().set(ALLOW_ERROR_CODES, allowedErrorCodes),
+          })
+          .pipe(
+            catchError((error: HttpErrorResponse) => {
+              if (allowedErrorCodes.includes(error.status)) {
+                return of(error as unknown as HttpResponse<T>);
+              }
+              throw error;
+            }),
+          ),
       );
     }
+
     return firstValueFrom(
       this.http.get<T>(`${environment.apiUrl}${endpoint}`, {
         headers,

--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -11,7 +11,7 @@ import { TransactionTypeUtils } from '../utils/transaction-type.utils';
 import { HTTP_INTERCEPTORS, HttpStatusCode, provideHttpClient } from '@angular/common/http';
 import { HttpErrorInterceptor } from '../interceptors/http-error.interceptor';
 import { ScheduleETransactionTypes } from '../models/sche-transaction.model';
-import { ScheduleFTransactionTypes, SchFTransaction } from '../models/schf-transaction.model';
+import { ScheduleFTransactionTypes } from '../models/schf-transaction.model';
 
 describe('TransactionService', () => {
   let service: TransactionService;
@@ -56,17 +56,17 @@ describe('TransactionService', () => {
 
   describe('getPreviousTransactionForAggregate', () => {
     it('should GET previous transaction', () => {
-      const mockResponse: SchATransaction = SchATransaction.fromJSON({
-        id: 1,
-        transaction_type_identifier: ScheduleATransactionTypes.OFFSET_TO_OPERATING_EXPENDITURES,
-        aggregation_group: AggregationGroups.GENERAL,
-      });
+      const mockResponse = {
+        aggregate: 1,
+        calendar_ytd_per_election_office: 2,
+        aggregate_general_elec_expended: 3,
+      };
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
       service.getPreviousTransactionForAggregate(mockTransaction, '1', new Date()).then((response) => {
-        expect(response?.id).toEqual(mockResponse.id);
+        expect(response).toEqual(mockResponse.aggregate);
       });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
@@ -83,7 +83,7 @@ describe('TransactionService', () => {
       ).getNewTransaction();
       mockTransaction.id = 'abc';
       service.getPreviousTransactionForAggregate(mockTransaction, '1', new Date()).then((response) => {
-        expect(response).toEqual(undefined);
+        expect(response).toEqual(0);
       });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
@@ -97,17 +97,17 @@ describe('TransactionService', () => {
 
   describe('getPreviousTransactionForPayeeCandidate', () => {
     it('should GET previous transaction', () => {
-      const mockResponse: SchFTransaction = SchFTransaction.fromJSON({
-        id: 1,
-        transaction_type_identifier: ScheduleFTransactionTypes.COORDINATED_PARTY_EXPENDITURE,
-        aggregation_group: AggregationGroups.COORDINATED_PARTY_EXPENDITURES,
-      });
+      const mockResponse = {
+        aggregate: 1,
+        calendar_ytd_per_election_office: 2,
+        aggregate_general_elec_expended: 3,
+      };
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleFTransactionTypes.COORDINATED_PARTY_EXPENDITURE,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
       service.getPreviousTransactionForPayeeCandidate(mockTransaction, '1', new Date(), '2024').then((response) => {
-        expect(response?.id).toEqual(mockResponse.id);
+        expect(response).toEqual(mockResponse.aggregate_general_elec_expended);
       });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
@@ -124,14 +124,21 @@ describe('TransactionService', () => {
       ).getNewTransaction();
       mockTransaction.id = 'abc';
       service.getPreviousTransactionForPayeeCandidate(mockTransaction, '1', new Date(), '2024').then((response) => {
-        expect(response).toEqual(undefined);
+        expect(response).toEqual(0);
       });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
         `${environment.apiUrl}/transactions/previous/payee-candidate/?transaction_id=abc&contact_2_id=1&date=${formattedDate}&aggregation_group=${AggregationGroups.COORDINATED_PARTY_EXPENDITURES}&general_election_year=2024`,
       );
       expect(req.request.method).toEqual('GET');
-      req.flush({}, { status: HttpStatusCode.NotFound, statusText: 'not found' });
+      req.flush(
+        {
+          aggregate: 0,
+          calendar_ytd_per_election_office: 0,
+          aggregate_general_elec_expended: 0,
+        },
+        { status: HttpStatusCode.NotFound, statusText: 'not found' },
+      );
       httpTestingController.verify();
     });
   });
@@ -145,14 +152,21 @@ describe('TransactionService', () => {
       service
         .getPreviousTransactionForCalendarYTD(mockTransaction, new Date(), new Date(), '1', 'A', 'A', 'A')
         .then((response) => {
-          expect(response).toEqual(undefined);
+          expect(response).toEqual(0);
         });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
         `${environment.apiUrl}/transactions/previous/election/?transaction_id=abc&date=${formattedDate}&aggregation_group=${AggregationGroups.INDEPENDENT_EXPENDITURE}&election_code=1&candidate_office=A&candidate_state=A&candidate_district=A`,
       );
       expect(req.request.method).toEqual('GET');
-      req.flush({}, { status: HttpStatusCode.NotFound, statusText: 'not found' });
+      req.flush(
+        {
+          aggregate: 0,
+          calendar_ytd_per_election_office: 0,
+          aggregate_general_elec_expended: 0,
+        },
+        { status: HttpStatusCode.NotFound, statusText: 'not found' },
+      );
       httpTestingController.verify();
     });
   });

--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -77,7 +77,7 @@ describe('TransactionService', () => {
       httpTestingController.verify();
     });
 
-    it('should return undefined', () => {
+    it('should return 0', () => {
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
       ).getNewTransaction();
@@ -118,7 +118,7 @@ describe('TransactionService', () => {
       httpTestingController.verify();
     });
 
-    it('should return undefined', () => {
+    it('should return 0', () => {
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleFTransactionTypes.COORDINATED_PARTY_EXPENDITURE,
       ).getNewTransaction();
@@ -144,7 +144,7 @@ describe('TransactionService', () => {
   });
 
   describe('getPreviousTransactionForCalendarYTD', () => {
-    it('should return undefined', () => {
+    it('should return 0', () => {
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleETransactionTypes.INDEPENDENT_EXPENDITURE,
       ).getNewTransaction();

--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -54,7 +54,7 @@ describe('TransactionService', () => {
     });
   });
 
-  describe('getPreviousTransactionForAggregate', () => {
+  describe('getPreviousEntityAggregate', () => {
     it('should GET previous transaction', () => {
       const mockResponse = {
         aggregate: 1,
@@ -65,38 +65,38 @@ describe('TransactionService', () => {
         ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
-      service.getPreviousTransactionForAggregate(mockTransaction, '1', new Date()).then((response) => {
+      service.getPreviousEntityAggregate(mockTransaction, '1', new Date()).then((response) => {
         expect(response).toEqual(mockResponse.aggregate);
       });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
-        `${environment.apiUrl}/transactions/previous/entity/?transaction_id=abc&contact_1_id=1&date=${formattedDate}&aggregation_group=${AggregationGroups.GENERAL}`,
+        `${environment.apiUrl}/transactions/previous/entity/?transaction_id=abc&aggregation_group=${AggregationGroups.GENERAL}&contact_1_id=1&date=${formattedDate}`,
       );
       expect(req.request.method).toEqual('GET');
       req.flush(mockResponse);
       httpTestingController.verify();
     });
 
-    it('should return 0', () => {
+    it('should return null', async () => {
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
-      service.getPreviousTransactionForAggregate(mockTransaction, '1', new Date()).then((response) => {
-        expect(response).toEqual(0);
-      });
+      const promise = service.getPreviousEntityAggregate(mockTransaction, '1', new Date());
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
-        `${environment.apiUrl}/transactions/previous/entity/?transaction_id=abc&contact_1_id=1&date=${formattedDate}&aggregation_group=${AggregationGroups.GENERAL}`,
+        `${environment.apiUrl}/transactions/previous/entity/?transaction_id=abc&aggregation_group=${AggregationGroups.GENERAL}&contact_1_id=1&date=${formattedDate}`,
       );
       expect(req.request.method).toEqual('GET');
       req.flush({}, { status: HttpStatusCode.NotFound, statusText: 'not found' });
+      const response = await promise;
+      expect(response).toBeNull();
       httpTestingController.verify();
     });
   });
 
-  describe('getPreviousTransactionForPayeeCandidate', () => {
-    it('should GET previous transaction', () => {
+  describe('getPreviousPayeeCandidateAggregate', () => {
+    it('should GET previous transaction', async () => {
       const mockResponse = {
         aggregate: 1,
         calendar_ytd_per_election_office: 2,
@@ -106,29 +106,28 @@ describe('TransactionService', () => {
         ScheduleFTransactionTypes.COORDINATED_PARTY_EXPENDITURE,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
-      service.getPreviousTransactionForPayeeCandidate(mockTransaction, '1', new Date(), '2024').then((response) => {
+      service.getPreviousPayeeCandidateAggregate(mockTransaction, '1', new Date(), '2024').then((response) => {
         expect(response).toEqual(mockResponse.aggregate_general_elec_expended);
       });
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
-        `${environment.apiUrl}/transactions/previous/payee-candidate/?transaction_id=abc&contact_2_id=1&date=${formattedDate}&aggregation_group=${AggregationGroups.COORDINATED_PARTY_EXPENDITURES}&general_election_year=2024`,
+        `${environment.apiUrl}/transactions/previous/payee-candidate/?transaction_id=abc&aggregation_group=${AggregationGroups.COORDINATED_PARTY_EXPENDITURES}&contact_2_id=1&date=${formattedDate}&general_election_year=2024`,
       );
       expect(req.request.method).toEqual('GET');
       req.flush(mockResponse);
       httpTestingController.verify();
     });
 
-    it('should return 0', () => {
+    it('should return null', async () => {
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleFTransactionTypes.COORDINATED_PARTY_EXPENDITURE,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
-      service.getPreviousTransactionForPayeeCandidate(mockTransaction, '1', new Date(), '2024').then((response) => {
-        expect(response).toEqual(0);
-      });
+      const promise = service.getPreviousPayeeCandidateAggregate(mockTransaction, '1', new Date(), '2024');
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
+
       const req = httpTestingController.expectOne(
-        `${environment.apiUrl}/transactions/previous/payee-candidate/?transaction_id=abc&contact_2_id=1&date=${formattedDate}&aggregation_group=${AggregationGroups.COORDINATED_PARTY_EXPENDITURES}&general_election_year=2024`,
+        `${environment.apiUrl}/transactions/previous/payee-candidate/?transaction_id=abc&aggregation_group=${AggregationGroups.COORDINATED_PARTY_EXPENDITURES}&contact_2_id=1&date=${formattedDate}&general_election_year=2024`,
       );
       expect(req.request.method).toEqual('GET');
       req.flush(
@@ -139,24 +138,23 @@ describe('TransactionService', () => {
         },
         { status: HttpStatusCode.NotFound, statusText: 'not found' },
       );
+      const response = await promise;
+      expect(response).toBeNull();
       httpTestingController.verify();
     });
   });
 
-  describe('getPreviousTransactionForCalendarYTD', () => {
-    it('should return 0', () => {
+  describe('getPreviousElectionAggregate', () => {
+    it('should return null', async () => {
       const mockTransaction: Transaction = TransactionTypeUtils.factory(
         ScheduleETransactionTypes.INDEPENDENT_EXPENDITURE,
       ).getNewTransaction();
       mockTransaction.id = 'abc';
-      service
-        .getPreviousTransactionForCalendarYTD(mockTransaction, new Date(), new Date(), '1', 'A', 'A', 'A')
-        .then((response) => {
-          expect(response).toEqual(0);
-        });
+      const promise = service.getPreviousElectionAggregate(mockTransaction, new Date(), new Date(), '1', 'A', 'A', 'A');
+
       const formattedDate = formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
       const req = httpTestingController.expectOne(
-        `${environment.apiUrl}/transactions/previous/election/?transaction_id=abc&date=${formattedDate}&aggregation_group=${AggregationGroups.INDEPENDENT_EXPENDITURE}&election_code=1&candidate_office=A&candidate_state=A&candidate_district=A`,
+        `${environment.apiUrl}/transactions/previous/election/?transaction_id=abc&aggregation_group=${AggregationGroups.INDEPENDENT_EXPENDITURE}&date=${formattedDate}&election_code=1&candidate_office=A&candidate_state=A&candidate_district=A`,
       );
       expect(req.request.method).toEqual('GET');
       req.flush(
@@ -167,6 +165,8 @@ describe('TransactionService', () => {
         },
         { status: HttpStatusCode.NotFound, statusText: 'not found' },
       );
+      const response = await promise;
+      expect(response).toBeNull();
       httpTestingController.verify();
     });
   });

--- a/front-end/src/app/shared/services/transaction.service.ts
+++ b/front-end/src/app/shared/services/transaction.service.ts
@@ -23,14 +23,14 @@ export class TransactionService {
     transaction: Transaction | undefined,
     contact_1_id: string,
     action_date: Date | string,
-  ): Promise<Transaction | undefined> {
+  ): Promise<number> {
     const actionDateString: string = action_date === '' ? '' : formatDate(action_date, 'yyyy-MM-dd', 'en-US') || '';
     const transaction_id: string = transaction?.id ?? '';
     const aggregation_group: AggregationGroups | undefined =
       (transaction as ScheduleTransaction)?.aggregation_group ?? AggregationGroups.GENERAL;
 
     if (transaction && action_date && contact_1_id && aggregation_group) {
-      const response = await this.apiService.get<HttpResponse<Transaction>>(
+      const response = await this.apiService.get<HttpResponse<{ value: number }>>(
         '/transactions/previous/entity/',
         {
           transaction_id,
@@ -41,11 +41,11 @@ export class TransactionService {
         [HttpStatusCode.NotFound],
       );
       if (response.status === HttpStatusCode.NotFound) {
-        return undefined;
+        return 0;
       }
-      return getFromJSON(response.body);
+      return response.body?.value ?? 0;
     }
-    return undefined;
+    return 0;
   }
 
   public async getPreviousTransactionForCalendarYTD(
@@ -56,7 +56,7 @@ export class TransactionService {
     candidate_office: string | undefined,
     candidate_state: string | undefined,
     candidate_district: string | undefined,
-  ): Promise<Transaction | undefined> {
+  ): Promise<number> {
     const actionDateString = this.getActionDateString(disbursement_date, dissemination_date);
 
     const transaction_id: string = transaction?.id ?? '';
@@ -86,17 +86,17 @@ export class TransactionService {
         params['candidate_district'] = candidate_district;
       }
 
-      const response = await this.apiService.get<HttpResponse<Transaction>>(
+      const response = await this.apiService.get<HttpResponse<{ value: number }>>(
         '/transactions/previous/election/',
         params,
         [HttpStatusCode.NotFound],
       );
       if (response.status === HttpStatusCode.NotFound) {
-        return undefined;
+        return 0;
       }
-      return getFromJSON(response.body);
+      return response.body?.value ?? 0;
     }
-    return undefined;
+    return 0;
   }
 
   public async getPreviousTransactionForPayeeCandidate(
@@ -104,7 +104,7 @@ export class TransactionService {
     contact2Id: string | undefined,
     expenditure_date: Date | string,
     general_election_year: string | undefined,
-  ): Promise<Transaction | undefined> {
+  ): Promise<number | null> {
     const actionDateString: string =
       expenditure_date === '' ? '' : formatDate(expenditure_date, 'yyyy-MM-dd', 'en-US') || '';
 
@@ -122,17 +122,17 @@ export class TransactionService {
         general_election_year,
       };
 
-      const response = await this.apiService.get<HttpResponse<Transaction>>(
+      const response = await this.apiService.get<HttpResponse<{ value: number }>>(
         '/transactions/previous/payee-candidate/',
         params,
         [HttpStatusCode.NotFound],
       );
       if (response.status === HttpStatusCode.NotFound) {
-        return undefined;
+        return 0;
       }
-      return getFromJSON(response.body);
+      return response.body?.value ?? 0;
     }
-    return undefined;
+    return 0;
   }
 
   public async create(transaction: Transaction): Promise<Transaction> {

--- a/front-end/src/app/shared/services/transaction.service.ts
+++ b/front-end/src/app/shared/services/transaction.service.ts
@@ -7,6 +7,12 @@ import { AggregationGroups, ScheduleTransaction, Transaction } from '../models/t
 import { getFromJSON } from '../utils/transaction-type.utils';
 import { ApiService } from './api.service';
 
+interface PreviousTransaction {
+  aggregate: number;
+  calendar_ytd_per_election_office: number;
+  aggregate_general_elec_expended: number;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -30,7 +36,7 @@ export class TransactionService {
       (transaction as ScheduleTransaction)?.aggregation_group ?? AggregationGroups.GENERAL;
 
     if (transaction && action_date && contact_1_id && aggregation_group) {
-      const response = await this.apiService.get<HttpResponse<{ value: number }>>(
+      const response = await this.apiService.get<HttpResponse<PreviousTransaction>>(
         '/transactions/previous/entity/',
         {
           transaction_id,
@@ -40,10 +46,8 @@ export class TransactionService {
         },
         [HttpStatusCode.NotFound],
       );
-      if (response.status === HttpStatusCode.NotFound) {
-        return 0;
-      }
-      return response.body?.value ?? 0;
+
+      return response.body?.aggregate ?? 0;
     }
     return 0;
   }
@@ -86,15 +90,12 @@ export class TransactionService {
         params['candidate_district'] = candidate_district;
       }
 
-      const response = await this.apiService.get<HttpResponse<{ value: number }>>(
+      const response = await this.apiService.get<HttpResponse<PreviousTransaction>>(
         '/transactions/previous/election/',
         params,
         [HttpStatusCode.NotFound],
       );
-      if (response.status === HttpStatusCode.NotFound) {
-        return 0;
-      }
-      return response.body?.value ?? 0;
+      return response.body?.calendar_ytd_per_election_office ?? 0;
     }
     return 0;
   }
@@ -122,15 +123,12 @@ export class TransactionService {
         general_election_year,
       };
 
-      const response = await this.apiService.get<HttpResponse<{ value: number }>>(
+      const response = await this.apiService.get<HttpResponse<PreviousTransaction>>(
         '/transactions/previous/payee-candidate/',
         params,
         [HttpStatusCode.NotFound],
       );
-      if (response.status === HttpStatusCode.NotFound) {
-        return 0;
-      }
-      return response.body?.value ?? 0;
+      return response.body?.aggregate_general_elec_expended ?? 0;
     }
     return 0;
   }

--- a/front-end/src/app/shared/services/transaction.service.ts
+++ b/front-end/src/app/shared/services/transaction.service.ts
@@ -7,11 +7,16 @@ import { AggregationGroups, ScheduleTransaction, Transaction } from '../models/t
 import { getFromJSON } from '../utils/transaction-type.utils';
 import { ApiService } from './api.service';
 
-interface PreviousTransaction {
+interface PreviousAggregate {
   aggregate: number;
   calendar_ytd_per_election_office: number;
   aggregate_general_elec_expended: number;
 }
+
+type PreviousAggregateField = keyof Pick<
+  PreviousAggregate,
+  'aggregate' | 'calendar_ytd_per_election_office' | 'aggregate_general_elec_expended'
+>;
 
 @Injectable({
   providedIn: 'root',
@@ -25,34 +30,23 @@ export class TransactionService {
     return getFromJSON(response);
   };
 
-  public async getPreviousTransactionForAggregate(
-    transaction: Transaction | undefined,
+  public async getPreviousEntityAggregate(
+    transaction: Transaction,
     contact_1_id: string,
     action_date: Date | string,
-  ): Promise<number> {
-    const actionDateString: string = action_date === '' ? '' : formatDate(action_date, 'yyyy-MM-dd', 'en-US') || '';
-    const transaction_id: string = transaction?.id ?? '';
-    const aggregation_group: AggregationGroups | undefined =
-      (transaction as ScheduleTransaction)?.aggregation_group ?? AggregationGroups.GENERAL;
+  ): Promise<number | null> {
+    const date = action_date ? formatDate(action_date, 'yyyy-MM-dd', 'en-US') : '';
 
-    if (transaction && action_date && contact_1_id && aggregation_group) {
-      const response = await this.apiService.get<HttpResponse<PreviousTransaction>>(
-        '/transactions/previous/entity/',
-        {
-          transaction_id,
-          contact_1_id,
-          date: actionDateString,
-          aggregation_group,
-        },
-        [HttpStatusCode.NotFound],
-      );
-
-      return response.body?.aggregate ?? 0;
-    }
-    return 0;
+    return this.fetchPreviousAggregate(
+      transaction,
+      '/transactions/previous/entity/',
+      { contact_1_id, date },
+      'aggregate',
+      !!contact_1_id,
+    );
   }
 
-  public async getPreviousTransactionForCalendarYTD(
+  public async getPreviousElectionAggregate(
     transaction: Transaction | undefined,
     disbursement_date: DateType,
     dissemination_date: DateType,
@@ -60,77 +54,37 @@ export class TransactionService {
     candidate_office: string | undefined,
     candidate_state: string | undefined,
     candidate_district: string | undefined,
-  ): Promise<number> {
-    const actionDateString = this.getActionDateString(disbursement_date, dissemination_date);
+  ): Promise<number | null> {
+    const date = this.getActionDateString(disbursement_date, dissemination_date);
+    const hasRequiredState = !!(candidate_state || candidate_office === CandidateOfficeTypes.PRESIDENTIAL);
+    const hasRequiredDistrict = !!(candidate_district || candidate_office !== CandidateOfficeTypes.HOUSE);
+    const isValid = !!(candidate_office && election_code && hasRequiredState && hasRequiredDistrict);
 
-    const transaction_id: string = transaction?.id ?? '';
-    const aggregation_group: AggregationGroups | undefined =
-      (transaction as ScheduleTransaction)?.aggregation_group ?? AggregationGroups.GENERAL;
-
-    if (
-      transaction &&
-      actionDateString &&
-      candidate_office &&
-      aggregation_group &&
-      election_code &&
-      (candidate_state || candidate_office === CandidateOfficeTypes.PRESIDENTIAL) &&
-      (candidate_district || candidate_office !== CandidateOfficeTypes.HOUSE)
-    ) {
-      const params: { [key: string]: string } = {
-        transaction_id,
-        date: actionDateString,
-        aggregation_group,
-        election_code,
-        candidate_office,
-      };
-      if (candidate_state) {
-        params['candidate_state'] = candidate_state;
-      }
-      if (candidate_district) {
-        params['candidate_district'] = candidate_district;
-      }
-
-      const response = await this.apiService.get<HttpResponse<PreviousTransaction>>(
-        '/transactions/previous/election/',
-        params,
-        [HttpStatusCode.NotFound],
-      );
-      return response.body?.calendar_ytd_per_election_office ?? 0;
-    }
-    return 0;
+    return this.fetchPreviousAggregate(
+      transaction,
+      '/transactions/previous/election/',
+      { date, election_code, candidate_office, candidate_state, candidate_district },
+      'calendar_ytd_per_election_office',
+      isValid,
+    );
   }
 
-  public async getPreviousTransactionForPayeeCandidate(
+  public async getPreviousPayeeCandidateAggregate(
     transaction: Transaction | undefined,
     contact2Id: string | undefined,
     expenditure_date: Date | string,
     general_election_year: string | undefined,
   ): Promise<number | null> {
-    const actionDateString: string =
-      expenditure_date === '' ? '' : formatDate(expenditure_date, 'yyyy-MM-dd', 'en-US') || '';
+    const date = expenditure_date ? formatDate(expenditure_date, 'yyyy-MM-dd', 'en-US') : '';
+    const contact_2_id = contact2Id ?? '';
 
-    const transaction_id: string = transaction?.id ?? '';
-    const contact_2_id: string = contact2Id ?? '';
-    const aggregation_group: AggregationGroups | undefined =
-      (transaction as ScheduleTransaction)?.aggregation_group ?? AggregationGroups.GENERAL;
-
-    if (transaction && actionDateString && contact_2_id && aggregation_group && general_election_year) {
-      const params: { [key: string]: string } = {
-        transaction_id,
-        contact_2_id,
-        date: actionDateString,
-        aggregation_group,
-        general_election_year,
-      };
-
-      const response = await this.apiService.get<HttpResponse<PreviousTransaction>>(
-        '/transactions/previous/payee-candidate/',
-        params,
-        [HttpStatusCode.NotFound],
-      );
-      return response.body?.aggregate_general_elec_expended ?? 0;
-    }
-    return 0;
+    return this.fetchPreviousAggregate(
+      transaction,
+      '/transactions/previous/payee-candidate/',
+      { contact_2_id, date, general_election_year },
+      'aggregate_general_elec_expended',
+      !!(contact_2_id && general_election_year),
+    );
   }
 
   public async create(transaction: Transaction): Promise<Transaction> {
@@ -210,5 +164,28 @@ export class TransactionService {
       actionDateString = dissemination_date ? formatDate(dissemination_date, 'yyyy-MM-dd', 'en-US') : '';
     }
     return actionDateString;
+  }
+
+  private async fetchPreviousAggregate(
+    transaction: Transaction | undefined,
+    endpoint: string,
+    params: Record<string, string | undefined>,
+    resultField: PreviousAggregateField,
+    validationCondition: boolean,
+  ): Promise<number | null> {
+    const transaction_id = transaction?.id ?? '';
+    const aggregation_group = (transaction as ScheduleTransaction)?.aggregation_group ?? AggregationGroups.GENERAL;
+
+    if (!transaction || !aggregation_group || !params['date'] || !validationCondition) {
+      return null;
+    }
+
+    const response = await this.apiService.get<HttpResponse<PreviousAggregate>>(
+      endpoint,
+      { transaction_id, aggregation_group, ...params },
+      [HttpStatusCode.NotFound],
+    );
+
+    return response.body?.[resultField] ?? null;
   }
 }

--- a/front-end/src/app/tools/cash-on-hand-override/cash-on-hand-override.component.scss
+++ b/front-end/src/app/tools/cash-on-hand-override/cash-on-hand-override.component.scss
@@ -31,9 +31,9 @@
   }
 
   .form-content {
-    @include standard-container();
     gap: 20px;
     display: grid;
+    @include standard-container();
   }
 
   .right-grid {


### PR DESCRIPTION
Issue [FECFILE-2547](https://fecgov.atlassian.net/browse/FECFILE-2547)

API [PR1874](https://github.com/fecgov/fecfile-web-api/pull/1874)

List of changes

- Update /previous/ endpoints to return the three aggregate amounts, so APP endpoints update to work with those values directly
- Updated tests appropriately
- Also noticed a deprecation warning. Simple css ordering fix.