### PR TITLE
FECFILE-2857: E2E adjust selector for transaction history table (edit contact)

### DIFF
--- a/front-end/cypress/e2e-extended/contacts/contacts.a11y.cy.ts
+++ b/front-end/cypress/e2e-extended/contacts/contacts.a11y.cy.ts
@@ -22,7 +22,7 @@ const WAIVERS: Record<string, { reason: string; link: string }> = {};
   - If the Manage contacts table is no longer under a p-table with the heading, update getContactsTableContainer()
   - If dialogs change away from .p-dialog, update ContactsHelpers.DIALOG and dialog queries here
   - If the deleted contacts view changes (route/table wrapper), update getRestoreDeletedContactsDialog() usage
-  - If the transaction history table title/markup changes, update the app-table[title="Transaction history"] selector
+  - If the transaction history table markup changes, update the app-table[itemname="transactions"] selector
 */
 
 const CONTACTS_LIST_ALIAS = 'getContactsList';
@@ -160,7 +160,7 @@ describe('Contacts - axe smoke (critical)', () => {
     PageUtils.clickKababItem(displayName, 'Edit');
     cy.contains(/Edit Contact/i).should('exist');
     cy.wait('@getTransactionHistory');
-    cy.get('app-table[title="Transaction history"]', { timeout: 15000 })
+    cy.get('app-table[itemname="transactions"]', { timeout: 15000 })
       .should('exist')
       .scrollIntoView({ offset: { top: -120, left: 0 } })
       .should('be.visible')

--- a/front-end/cypress/e2e-extended/contacts/contacts.helpers.ts
+++ b/front-end/cypress/e2e-extended/contacts/contacts.helpers.ts
@@ -614,7 +614,7 @@ export class ContactsHelpers {
     };
 
     return cy
-      .get('app-table[title="Transaction history"]', { timeout: 15000 })
+      .get('app-table[itemname="transactions"]', { timeout: 15000 })
       .should('exist')
       .find('table[role="table"]', { timeout: 15000 })
       .first()


### PR DESCRIPTION
Ticket link: [FECFILE-2857](https://fecgov.atlassian.net/browse/FECFILE-2857)


updated selector for transaction history table in edit contact to 'app-table[itemname="transactions"]'
after [these changes](https://github.com/fecgov/fecfile-web-app/commit/9c5ac146ffd798f0ea0410255e1cd358f7c99146) to app-table from [FECFILE-2818](https://fecgov.atlassian.net/browse/FECFILE-2818)