### PR TITLE
FECFILE-2858: updated loans-bank and PageUtils.clickAccordion()

### DIFF
--- a/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/loans-bank.cy.ts
@@ -163,7 +163,7 @@ describe('Loans', () => {
       formData.date_received = undefined;
       TransactionDetailPage.enterLoanFormData(formData);
 
-      PageUtils.clickAccordion('STEP TWO:');
+      PageUtils.clickAccordion('STEP TWO');
       TransactionDetailPage.enterLoanFormDataStepTwo(defaultLoanFormData);
       PageUtils.clickButton('Save transactions');
       PageUtils.urlCheck('/list');

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -118,7 +118,15 @@ export class PageUtils {
 
   static clickAccordion(name: string, alias = '') {
     alias = PageUtils.getAlias(alias);
-    cy.get(alias).contains('p-accordion-header', name).click();
+    const label = name.trim();
+    const exactLabel = new RegExp(String.raw`^\s*${Cypress._.escapeRegExp(label)}\s*$`, 'i');
+
+    cy.get(alias)
+      .contains('.accordion-text strong, .header-label', exactLabel, { timeout: 5000 })
+      .first()
+      .closest('p-accordion-header, .p-accordionheader')
+      .should('be.visible')
+      .click();
   }
 
   static clickButton(name: string, alias = '', force = false) {


### PR DESCRIPTION
Ticket link: [FECFILE-2858](https://fecgov.atlassian.net/browse/FECFILE-2858)

removed a trailing colon from the 'STEP TWO' string in loans-bank, and updated PageUtils.clickAccordion() after changes made in fecfile-2779

e2e-smoke passing locally, and will run on CircleCI on feature branch and update with a comment