### PR TITLE
feature/2666 - Add 300ms more delay before searching contact lookup

### DIFF
--- a/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.html
+++ b/front-end/src/app/shared/components/contact-lookup/contact-lookup.component.html
@@ -32,6 +32,7 @@
         [forceSelection]="true"
         (completeMethod)="onDropdownSearch($event)"
         (onSelect)="onContactLookupSelect($event.value)"
+        [delay]="600"
         scrollHeight="30vh"
         appendTo="body"
       >


### PR DESCRIPTION
Issue [FECFILE-2666](https://fecgov.atlassian.net/browse/FECFILE-2666)

There is a built in delay field for the PrimeNG Autocomplete. The default is 300ms so we already had that 300ms delay. So I simply increased it by another 300ms for a total of 600ms.