### PR TITLE
FECFILE-2803: automated cross browser e2e testing in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,10 @@ jobs:
       video:
         type: boolean
         default: false
+      browser:
+        type: enum
+        enum: [chrome, firefox, edge]
+        default: chrome
     environment:
       CYPRESS_VIDEO: << parameters.video >>
     steps:
@@ -160,29 +164,55 @@ jobs:
             docker container run --name fecfile-web-app-e2e \
               -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
               -e CYPRESS_VIDEO=${CYPRESS_VIDEO} \
+              -e CYPRESS_BROWSER=<< parameters.browser >> \
+              -e CYPRESS_SUITE=e2e-smoke \
+              -e CYPRESS_DISABLE_BROWSER_AI=true \
               -e CYPRESS_EMAIL=${CYPRESS_EMAIL} \
               -e CYPRESS_COMMITTEE_ID=${CYPRESS_COMMITTEE_ID} \
               -e CYPRESS_PASSWORD=${CYPRESS_PASSWORD} \
               -e CYPRESS_FILING_PASSWORD=${CYPRESS_FILING_PASSWORD} \
               --network container:fecfile-api-proxy \
-              cypress/browsers:latest \
-              /bin/bash -c '\
+              << pipeline.parameters.cypress-browsers-image >> \
+              /bin/bash -eo pipefail -c '\
                 cd ~; \
                 git clone https://github.com/fecgov/fecfile-web-app.git; \
                 cd fecfile-web-app/front-end; \
                 git checkout ${CIRCLE_BRANCH}; \
                 npm install; \
-                node --max_old_space_size=4000 ./node_modules/@angular/cli/bin/ng e2e --spec "cypress/e2e-smoke/**/*.cy.ts" --headless --watch=false --browser chrome;'
+                mkdir -p ci; \
+                chrome_version="$(google-chrome --version 2>/dev/null || echo unavailable)"; \
+                firefox_version="$(firefox --version 2>/dev/null || echo unavailable)"; \
+                edge_version="$(microsoft-edge --version 2>/dev/null || microsoft-edge-stable --version 2>/dev/null || echo unavailable)"; \
+                chromedriver_version="$(chromedriver --version 2>/dev/null || echo unavailable)"; \
+                geckodriver_version="$(geckodriver --version 2>/dev/null || echo unavailable)"; \
+                msedgedriver_version="$(msedgedriver --version 2>/dev/null || echo unavailable)"; \
+                cypress_version="$(npx cypress version 2>/dev/null | tr "\n" " " || echo unavailable)"; \
+                { \
+                  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+                  echo "suite=${CYPRESS_SUITE}"; \
+                  echo "requested_browser=${CYPRESS_BROWSER}"; \
+                  echo "node=$(node --version)"; \
+                  echo "npm=$(npm --version)"; \
+                  echo "cypress=${cypress_version}"; \
+                  echo "chrome=${chrome_version}"; \
+                  echo "firefox=${firefox_version}"; \
+                  echo "edge=${edge_version}"; \
+                  echo "chromedriver=${chromedriver_version}"; \
+                  echo "geckodriver=${geckodriver_version}"; \
+                  echo "msedgedriver=${msedgedriver_version}"; \
+                } | tee ci/browser-versions.txt; \
+                node --max_old_space_size=4000 ./node_modules/@angular/cli/bin/ng e2e --spec "cypress/e2e-smoke/**/*.cy.ts" --headless --watch=false --browser ${CYPRESS_BROWSER};'
       - run:
           name: stage test result artifacts
           when: always
           command: |
             rm -rf /tmp/cypress
-            mkdir -p /tmp/cypress/results /tmp/cypress/videos /tmp/cypress/screenshots
+            mkdir -p /tmp/cypress/results /tmp/cypress/videos /tmp/cypress/screenshots /tmp/cypress/ci
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/results/. /tmp/cypress/results || true
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/videos/. /tmp/cypress/videos || true
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/screenshots/. /tmp/cypress/screenshots || true
-            docker rm fecfile-web-app-e2e
+            docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/ci/. /tmp/cypress/ci || true
+            docker rm fecfile-web-app-e2e || true
       - store_artifacts:
           path: /tmp/cypress/results
           destination: cypress/results
@@ -192,6 +222,9 @@ jobs:
       - store_artifacts:
           path: /tmp/cypress/screenshots
           destination: cypress/screenshots
+      - store_artifacts:
+          path: /tmp/cypress/ci
+          destination: cypress/ci
       - store_artifacts:
           path: /tmp/cypress/results/if-5xx
           destination: cypress/results/if-5xx
@@ -204,6 +237,10 @@ jobs:
       video:
         type: boolean
         default: false
+      browser:
+        type: enum
+        enum: [chrome, firefox, edge]
+        default: chrome
     environment:
       CYPRESS_VIDEO: << parameters.video >>
     steps:
@@ -214,29 +251,55 @@ jobs:
             docker container run --name fecfile-web-app-e2e \
               -e CIRCLE_BRANCH=${CIRCLE_BRANCH} \
               -e CYPRESS_VIDEO=${CYPRESS_VIDEO} \
+              -e CYPRESS_BROWSER=<< parameters.browser >> \
+              -e CYPRESS_SUITE=e2e-extended \
+              -e CYPRESS_DISABLE_BROWSER_AI=true \
               -e CYPRESS_EMAIL=${CYPRESS_EMAIL} \
               -e CYPRESS_COMMITTEE_ID=${CYPRESS_COMMITTEE_ID} \
               -e CYPRESS_PASSWORD=${CYPRESS_PASSWORD} \
               -e CYPRESS_FILING_PASSWORD=${CYPRESS_FILING_PASSWORD} \
               --network container:fecfile-api-proxy \
-              cypress/browsers:latest \
-              /bin/bash -c '\
+              << pipeline.parameters.cypress-browsers-image >> \
+              /bin/bash -eo pipefail -c '\
                 cd ~; \
                 git clone https://github.com/fecgov/fecfile-web-app.git; \
                 cd fecfile-web-app/front-end; \
                 git checkout ${CIRCLE_BRANCH}; \
                 npm install; \
-                node --max_old_space_size=4000 ./node_modules/@angular/cli/bin/ng e2e --spec "cypress/e2e-extended/**/*.cy.ts" --headless --watch=false --browser chrome;'
+                mkdir -p ci; \
+                chrome_version="$(google-chrome --version 2>/dev/null || echo unavailable)"; \
+                firefox_version="$(firefox --version 2>/dev/null || echo unavailable)"; \
+                edge_version="$(microsoft-edge --version 2>/dev/null || microsoft-edge-stable --version 2>/dev/null || echo unavailable)"; \
+                chromedriver_version="$(chromedriver --version 2>/dev/null || echo unavailable)"; \
+                geckodriver_version="$(geckodriver --version 2>/dev/null || echo unavailable)"; \
+                msedgedriver_version="$(msedgedriver --version 2>/dev/null || echo unavailable)"; \
+                cypress_version="$(npx cypress version 2>/dev/null | tr "\n" " " || echo unavailable)"; \
+                { \
+                  echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+                  echo "suite=${CYPRESS_SUITE}"; \
+                  echo "requested_browser=${CYPRESS_BROWSER}"; \
+                  echo "node=$(node --version)"; \
+                  echo "npm=$(npm --version)"; \
+                  echo "cypress=${cypress_version}"; \
+                  echo "chrome=${chrome_version}"; \
+                  echo "firefox=${firefox_version}"; \
+                  echo "edge=${edge_version}"; \
+                  echo "chromedriver=${chromedriver_version}"; \
+                  echo "geckodriver=${geckodriver_version}"; \
+                  echo "msedgedriver=${msedgedriver_version}"; \
+                } | tee ci/browser-versions.txt; \
+                node --max_old_space_size=4000 ./node_modules/@angular/cli/bin/ng e2e --spec "cypress/e2e-extended/**/*.cy.ts" --headless --watch=false --browser ${CYPRESS_BROWSER};'
       - run:
           name: stage test result artifacts
           when: always
           command: |
             rm -rf /tmp/cypress
-            mkdir -p /tmp/cypress/results /tmp/cypress/videos /tmp/cypress/screenshots
+            mkdir -p /tmp/cypress/results /tmp/cypress/videos /tmp/cypress/screenshots /tmp/cypress/ci
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/results/. /tmp/cypress/results || true
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/videos/. /tmp/cypress/videos || true
             docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/cypress/screenshots/. /tmp/cypress/screenshots || true
-            docker rm fecfile-web-app-e2e
+            docker cp fecfile-web-app-e2e:/root/fecfile-web-app/front-end/ci/. /tmp/cypress/ci || true
+            docker rm fecfile-web-app-e2e || true
       - store_artifacts:
           path: /tmp/cypress/results
           destination: cypress/results
@@ -246,6 +309,9 @@ jobs:
       - store_artifacts:
           path: /tmp/cypress/screenshots
           destination: cypress/screenshots
+      - store_artifacts:
+          path: /tmp/cypress/ci
+          destination: cypress/ci
       - store_artifacts:
           path: /tmp/cypress/results/if-5xx
           destination: cypress/results/if-5xx
@@ -319,6 +385,14 @@ parameters:
     type: boolean
     default: false
 
+  is-triggered-cross-browser:
+    type: boolean
+    default: false
+
+  cypress-browsers-image:
+    type: string
+    default: cypress/browsers:node-24.13.0-chrome-144.0.7559.132-1-ff-147.0.3-edge-144.0.3719.104-1
+
   e2e-video:
     type: boolean
     default: false
@@ -331,6 +405,7 @@ workflows:
         - not: << pipeline.parameters.is-triggered-e2e-extended-test >>
         - not: << pipeline.parameters.is-triggered-unit-test >>
         - not: << pipeline.parameters.is-triggered-full-nightly >>
+        - not: << pipeline.parameters.is-triggered-cross-browser >>
     jobs:
       - lint
       - test
@@ -380,3 +455,19 @@ workflows:
       - e2e-extended:
           video: true
       - test
+
+  cross-browser-weekly:
+    when: << pipeline.parameters.is-triggered-cross-browser >>
+    jobs:
+      - e2e-smoke:
+          name: e2e-smoke-<< matrix.browser >>
+          video: true
+          matrix:
+            parameters:
+              browser: [chrome, firefox, edge]
+      - e2e-extended:
+          name: e2e-extended-<< matrix.browser >>
+          video: true
+          matrix:
+            parameters:
+              browser: [chrome, firefox, edge]

--- a/front-end/cypress.config.ts
+++ b/front-end/cypress.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       setupA11yNodeEvents(on);
       // @ts-ignore - cypress-mochawesome-reporter/plugin is not typed
       require('cypress-mochawesome-reporter/plugin')(on);
+      CypressConfigHelper.applyCiBrowserHardening(on);
       CypressConfigHelper.deleteVideoOnSuccess(on);
       return config;
     },

--- a/front-end/cypress/README.md
+++ b/front-end/cypress/README.md
@@ -262,9 +262,11 @@ npm run e2e:smoke:headless
 - CircleCI config lives at `fecfile-web-app/.circleci/config.yml`.
 - The `e2e-smoke` and `e2e-extended` jobs:
   - Spin up the API with docker-compose using the E2E Dockerfiles and `E2E_TEST=True`.
-  - Run `ng e2e` headless from `fecfile-web-app/front-end` inside a `cypress/browsers:latest` container with `--spec` targeting either `e2e-smoke` or `e2e-extended`, `--watch=false`, and `--browser chrome`.
+  - Run `ng e2e` headless from `fecfile-web-app/front-end` inside a pinned `cypress/browsers` image controlled by `.circleci/config.yml` pipeline parameter `cypress-browsers-image`.
+  - Default browser is `chrome` for normal runs; the `cross-browser-weekly` workflow runs a matrix for `chrome`, `firefox`, and `edge` when `is-triggered-cross-browser: true`.
+  - Print browser/tool versions to job logs and write `ci/browser-versions.txt`, which is uploaded as CircleCI artifact `cypress/ci/browser-versions.txt`.
   - Pass Cypress env vars into the container (`CYPRESS_EMAIL`, `CYPRESS_COMMITTEE_ID`, `CYPRESS_PASSWORD`, `CYPRESS_FILING_PASSWORD`) along with `CIRCLE_BRANCH`.
-  - Store test results/artifacts like videos, and/or screenshots from `cypress/results`.
+  - Store test results/artifacts from `cypress/results`, `cypress/videos`, `cypress/screenshots`, and `cypress/ci`.
 
 If you want to approximate CI locally, use the headless npm scripts above.
 

--- a/front-end/cypress/cypress.config.helpers.ts
+++ b/front-end/cypress/cypress.config.helpers.ts
@@ -29,4 +29,32 @@ export class CypressConfigHelper {
       }
     });
   }
+
+  static applyCiBrowserHardening(on: Cypress.PluginEvents) {
+    on('before:browser:launch', (browser, launchOptions) => {
+      const ciHardeningEnabled = process.env['CYPRESS_DISABLE_BROWSER_AI']?.trim().toLowerCase() === 'true';
+      if (!ciHardeningEnabled) {
+        return launchOptions;
+      }
+
+      if (browser.family === 'chromium') {
+        launchOptions.args.push(
+          '--no-first-run',
+          '--no-default-browser-check',
+          '--disable-background-networking',
+          '--disable-component-update',
+          '--disable-field-trial-config',
+          '--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction'
+        );
+      }
+
+      if (browser.family === 'firefox') {
+        launchOptions.preferences = launchOptions.preferences ?? {};
+        launchOptions.preferences['app.normandy.enabled'] = false;
+        launchOptions.preferences['app.shield.optoutstudies.enabled'] = false;
+      }
+
+      return launchOptions;
+    });
+  }
 }

--- a/front-end/cypress/docs/cross_browser_e2e_ci_schedule.md
+++ b/front-end/cypress/docs/cross_browser_e2e_ci_schedule.md
@@ -1,0 +1,125 @@
+# CI Scheduling: Weekly Cross-Browser E2E (Main Branch)
+
+This repo uses **CircleCI Schedule Triggers (scheduled pipelines)** (not cron triggers in `.circleci/config.yml`) to run cross-browser E2E jobs on `main`.
+
+---
+
+## Why this exists
+
+Cross-browser runs are scheduled/opt-in because they are heavier than default push/PR CI.
+
+Now we use:
+
+1. **Pipeline-parameter gating** so cross-browser workflow does **not** run on pushes
+2. **A dedicated CircleCI schedule** for `main`
+3. A browser matrix (Chrome/Firefox/Edge) for both smoke and extended suites
+
+---
+
+## Key implementation details
+
+### Project slug
+
+CircleCI project slug:
+
+- `gh/fecgov/fecfile-web-app`
+
+### Pipeline parameters (in `.circleci/config.yml`)
+
+- `is-triggered-cross-browser` (boolean, default `false`)
+  - enables the `cross-browser-weekly` workflow
+- `cypress-browsers-image` (string)
+  - pinned Cypress browsers image tag used by E2E jobs
+
+### Workflows
+
+- `primary`
+  - default workflow for regular pushes/PRs
+  - explicitly guarded to **not** run cross-browser workflow jobs
+- `cross-browser-weekly`
+  - runs E2E smoke + extended as a matrix:
+    - `chrome`
+    - `firefox`
+    - `edge`
+  - runs only when `is-triggered-cross-browser: true`
+
+---
+
+## Where schedules are defined
+
+Schedules are managed in CircleCI (UI):
+
+- CircleCI -> Project -> **Project Settings** -> **Triggers / Schedules** (UI wording varies)
+
+Schedules are **not** stored in git.
+
+---
+
+## Required schedule (current scope)
+
+Create this schedule in CircleCI (example time: weekly at **06:00 UTC**):
+
+### 1) `cross-browser-main`
+- Branch: `main`
+- Pipeline parameters:
+  - `is-triggered-cross-browser: true`
+
+---
+
+## Version traceability (logs + artifacts)
+
+Each E2E matrix job captures browser/tool versions inline in the existing test command:
+
+- Printed to job logs
+- Written to `ci/browser-versions.txt` inside the test container
+- Exported as CircleCI artifact at `cypress/ci/browser-versions.txt`
+
+This avoids repo scripts while still preserving downloadable run metadata.
+
+---
+
+## Verification checklist (acceptance criteria)
+
+1. **Scheduled pipeline appears on `main`**
+   - verify `cross-browser-main` runs on cadence
+2. **Cross-browser does not run on normal pushes**
+   - push to `main`
+   - confirm `primary` runs as normal
+   - confirm `cross-browser-weekly` does not run unless triggered by parameter
+3. **Matrix coverage**
+   - verify smoke + extended both run for:
+     - `chrome`
+     - `firefox`
+     - `edge`
+4. **Version traceability present**
+   - confirm job logs include browser/tool version output
+   - confirm artifact `cypress/ci/browser-versions.txt` exists per matrix job
+
+---
+
+## Troubleshooting
+
+### Cross-browser workflow did not run
+1. confirm the schedule exists and targets branch `main`
+2. confirm schedule parameter includes:
+   - `is-triggered-cross-browser: true`
+3. confirm the pipeline was schedule-triggered (or manually run with parameter), not a normal push
+
+### Missing version artifact
+1. confirm the job reached artifact staging step (`when: always`)
+2. confirm `docker cp` captured `/root/fecfile-web-app/front-end/ci/`
+3. check job logs for version block output (helps distinguish generation vs copy issue)
+
+### Browser version drift
+1. confirm `.circleci/config.yml` still uses pinned `cypress-browsers-image`
+2. avoid switching back to mutable tags such as `latest`
+
+---
+
+## Future expansion
+
+If branch coverage expands later, create additional schedules in CircleCI UI with the same parameter:
+
+- `is-triggered-cross-browser: true`
+
+No code changes are needed for branch expansion.


### PR DESCRIPTION
Ticket link: [FECFILE-2803](https://fecgov.atlassian.net/browse/FECFILE-2803)

jobs run as intended, failures in e2e-smoke are not from this, however the e2e-extended-firefox did pick up a seemingly firefox-specific failure which is good!