### PR TITLE
feature/2779 - Fix issue with hiding accordion icons removing checkbox icons

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.scss
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.scss
@@ -31,10 +31,6 @@
     align-items: center;
   }
 
-  .p-icon {
-    display: none;
-  }
-
   .accordion-content-wrapper {
     padding: 14px 0 14px 20px;
     border: none;

--- a/front-end/src/app/reports/transactions/transaction.scss
+++ b/front-end/src/app/reports/transactions/transaction.scss
@@ -60,10 +60,6 @@
     align-items: center;
   }
 
-  .p-icon {
-    display: none;
-  }
-
   .accordion-number-icon {
     height: 64px;
     width: 64px;

--- a/front-end/src/assets/styles/theme.css
+++ b/front-end/src/assets/styles/theme.css
@@ -6580,6 +6580,10 @@ td {
   color: var(--p-accordion-header-toggle-icon-color);
 }
 
+.p-accordionheader > .p-icon {
+    display: none;
+  }
+
 .p-radiobutton-input {
   height: 100% !important;
   padding: 0;


### PR DESCRIPTION
Issue [FECFILE-2779](https://fecgov.atlassian.net/browse/FECFILE-2779)

Hiding the accordion chevron icons accidentally hid all p-icon's on the page like the checkbox icons.