### PR TITLE
FECFILE-2875 fix(nav-control): prevent structuredClone DataCloneError in dropdown 

### DIFF
--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
@@ -4,8 +4,10 @@ import {
   NavigationAction,
   NavigationControl,
   NavigationDestination,
+  NavigationEvent,
 } from 'app/shared/models/transaction-navigation-controls.model';
 import { JOINT_FUNDRAISING_TRANSFER } from 'app/shared/models/transaction-types/JOINT_FUNDRAISING_TRANSFER.model';
+import { Transaction } from 'app/shared/models/transaction.model';
 import { TransactionTypeUtils } from 'app/shared/utils/transaction-type.utils';
 import { ButtonModule } from 'primeng/button';
 import { NavigationControlComponent } from './navigation-control.component';
@@ -78,5 +80,22 @@ describe('NavigationControlComponent', () => {
     const options = component.getOptions(TransactionTypeUtils.factory(JOINT_FUNDRAISING_TRANSFER.name));
     expect(options[0].label).toBe('Joint Fundraising Transfer Memo');
     expect(options[0].items[0].label).toBe('Individual');
+  });
+
+  it('should dispatch clone-safe dropdown option events', () => {
+    const storeSpy = spyOn(store, 'dispatch');
+    component.transaction = {
+      id: 'transaction-id',
+      parent_transaction_id: 'parent-transaction-id',
+    } as Transaction;
+    const option = component.getOptionFromConfig(JOINT_FUNDRAISING_TRANSFER.name) as { value: NavigationEvent };
+
+    expect(option.value.transaction).toEqual({
+      id: 'transaction-id',
+      parent_transaction_id: 'parent-transaction-id',
+    } as Transaction);
+    expect(() => structuredClone(option.value)).not.toThrow();
+    expect(() => component.onDropdownChange(option)).not.toThrow();
+    expect(storeSpy).toHaveBeenCalled();
   });
 });

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
@@ -108,6 +108,14 @@ export class NavigationControlComponent implements OnInit {
     }
   }
 
+  private getCloneSafeTransactionContext(): Transaction | undefined {
+    if (!this.transaction) return undefined;
+    return {
+      id: this.transaction.id,
+      parent_transaction_id: this.transaction.parent_transaction_id,
+    } as Transaction;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getOptionFromConfig = (config: SubTransactionGroup | TransactionTypes, isParentConfig = false): any => {
     /** Interpret config to return either a group of navigation options or a single navigation option
@@ -143,7 +151,7 @@ export class NavigationControlComponent implements OnInit {
         NavigationAction.SAVE,
         // If this control came from the parent, the desination is ANOTHER
         isParentConfig ? NavigationDestination.ANOTHER : NavigationDestination.CHILD,
-        this.transaction,
+        this.getCloneSafeTransactionContext(),
         typeId,
       ),
     };


### PR DESCRIPTION
fix(nav-control): prevent structuredClone DataCloneError in dropdown navigation events by sending clone-safe transaction context; restores F3X receipts memo navigation

