### PR TITLE
fix save & add memo drop down by creating NavigationEvent clone function

### DIFF
--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.spec.ts
@@ -10,10 +10,13 @@ import { TransactionTypeUtils } from 'app/shared/utils/transaction-type.utils';
 import { ButtonModule } from 'primeng/button';
 import { NavigationControlComponent } from './navigation-control.component';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
-import { testMockStore } from '../../utils/unit-test.utils';
+import { getTestTransactionByType, testMockStore } from '../../utils/unit-test.utils';
 import { provideMockStore } from '@ngrx/store/testing';
 import { Store } from '@ngrx/store';
 import { SelectModule } from 'primeng/select';
+import { ScheduleATransactionTypes } from 'app/shared/models/scha-transaction.model';
+import { navigationEventSetAction } from 'app/store/navigation-event.actions';
+import { cloneInstance, Transaction } from 'app/shared/models';
 
 describe('NavigationControlComponent', () => {
   let component: NavigationControlComponent;
@@ -54,6 +57,7 @@ describe('NavigationControlComponent', () => {
     beforeEach(async () => {
       fixture = TestBed.createComponent(NavigationControlComponent);
       component = fixture.componentInstance;
+      component.transaction = getTestTransactionByType(ScheduleATransactionTypes.PARTNERSHIP_RECEIPT);
       component.navigationControl = new NavigationControl(
         NavigationAction.SAVE,
         NavigationDestination.ANOTHER,
@@ -71,6 +75,24 @@ describe('NavigationControlComponent', () => {
       const nativeElement = fixture.nativeElement;
       const button = nativeElement.querySelector('.dd-button');
       expect(button).toBeTruthy();
+    });
+
+    it('should dispatch a navigationEvent with a transaction', () => {
+      // spy on event emitter
+      const storeSpy = spyOn(store, 'dispatch');
+
+      console.log(component.dropdownOptions);
+      component.onDropdownChange(component.dropdownOptions[0]); // simulate selecting the first dropdown option
+
+      fixture.detectChanges();
+      expect(storeSpy).toHaveBeenCalledWith(
+        navigationEventSetAction({
+          action: NavigationAction.SAVE,
+          destination: NavigationDestination.CHILD,
+          transaction: cloneInstance(component.transaction as Transaction),
+          destinationTransactionType: ScheduleATransactionTypes.PARTNERSHIP_ATTRIBUTION,
+        }),
+      );
     });
   });
 

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, Input, OnInit } from '@angular/core';
 import { cloneInstance, Transaction, TransactionTypes } from 'app/shared/models/transaction.model';
 import {
+  cloneNavigationEvent,
   ControlType,
   NavigationAction,
   NavigationControl,
@@ -103,7 +104,7 @@ export class NavigationControlComponent implements OnInit {
   onDropdownChange(event: { value: NavigationEvent }): void {
     // Handle click event for dropdown version of control
     if (event.value.action) {
-      const navigationEvent = structuredClone(event.value);
+      const navigationEvent = cloneNavigationEvent(event.value);
       this.store.dispatch(navigationEventSetAction(navigationEvent));
     }
   }

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -26,6 +26,7 @@ import {
   NavigationAction,
   NavigationDestination,
   NavigationEvent,
+  cloneNavigationEvent,
 } from 'app/shared/models';
 import { singleClickEnableAction } from 'app/store/single-click.actions';
 import { ConfirmationWrapperService } from 'app/shared/services/confirmation-wrapper.service';
@@ -81,7 +82,7 @@ export abstract class TransactionTypeBaseComponent extends FormComponent impleme
     effect(() => {
       const navEvent = this.navigationEvent();
       if (navEvent) {
-        const navigationEvent = { ...navEvent };
+        const navigationEvent = cloneNavigationEvent(navEvent);
         this.handleNavigate(navigationEvent);
         this.store.dispatch(navigationEventClearAction());
       }

--- a/front-end/src/app/shared/models/transaction-navigation-controls.model.ts
+++ b/front-end/src/app/shared/models/transaction-navigation-controls.model.ts
@@ -1,4 +1,4 @@
-import { hasNoContact, Transaction } from './transaction.model';
+import { hasNoContact, Transaction, cloneInstance } from './transaction.model';
 import { TransactionTypes } from 'app/shared/models/transaction.model';
 
 export enum NavigationAction {
@@ -36,6 +36,15 @@ export class NavigationEvent {
     this.destinationTransactionType = destinationTransactionType;
   }
 }
+
+export const cloneNavigationEvent = (event: NavigationEvent): NavigationEvent => {
+  return new NavigationEvent(
+    event.action,
+    event.destination,
+    cloneInstance(event.transaction),
+    event.destinationTransactionType,
+  );
+};
 
 export class NavigationControl {
   navigationAction: NavigationAction = NavigationAction.CANCEL;

--- a/front-end/src/app/shared/models/transaction.model.ts
+++ b/front-end/src/app/shared/models/transaction.model.ts
@@ -43,19 +43,15 @@ export abstract class Transaction extends BaseModel {
   itemized: boolean | undefined;
   force_itemized: boolean | undefined;
 
-  @Exclude({ toPlainOnly: true })
   parent_transaction: Transaction | undefined;
   parent_transaction_id: string | undefined; // Foreign key to the parent transaction db record
 
-  @Exclude({ toPlainOnly: true })
   debt: Transaction | undefined;
   debt_id: string | undefined; // Foreign key to debt which this transaction repays
 
-  @Exclude({ toPlainOnly: true })
   loan: Transaction | undefined;
   loan_id: string | undefined; // Foreign key to loan which this transaction repays
 
-  @Exclude({ toPlainOnly: true })
   reatt_redes: Transaction | undefined;
   reatt_redes_id: string | undefined; // Foreign key to original reattribution/redesignation transaction
 
@@ -63,7 +59,6 @@ export abstract class Transaction extends BaseModel {
   updated: string | undefined;
   deleted: string | undefined;
 
-  @Exclude({ toPlainOnly: true })
   reports: Report[] | undefined;
   report_ids: string[] | undefined;
 

--- a/front-end/src/app/shared/models/transaction.model.ts
+++ b/front-end/src/app/shared/models/transaction.model.ts
@@ -43,15 +43,19 @@ export abstract class Transaction extends BaseModel {
   itemized: boolean | undefined;
   force_itemized: boolean | undefined;
 
+  @Exclude({ toPlainOnly: true })
   parent_transaction: Transaction | undefined;
   parent_transaction_id: string | undefined; // Foreign key to the parent transaction db record
 
+  @Exclude({ toPlainOnly: true })
   debt: Transaction | undefined;
   debt_id: string | undefined; // Foreign key to debt which this transaction repays
 
+  @Exclude({ toPlainOnly: true })
   loan: Transaction | undefined;
   loan_id: string | undefined; // Foreign key to loan which this transaction repays
 
+  @Exclude({ toPlainOnly: true })
   reatt_redes: Transaction | undefined;
   reatt_redes_id: string | undefined; // Foreign key to original reattribution/redesignation transaction
 
@@ -59,6 +63,7 @@ export abstract class Transaction extends BaseModel {
   updated: string | undefined;
   deleted: string | undefined;
 
+  @Exclude({ toPlainOnly: true })
   reports: Report[] | undefined;
   report_ids: string[] | undefined;
 


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2875

Creates CloneNavigationEvent function to use instead of structuredClone().  For cloning the transaction, it uses the new cloneInstance method.

Removed `Exclude`s in transaction type model so that those fields are available down stream when the transaction is used in places like the transaction base component
