### PR TITLE
[BEFORE CUT] fix for 'value ? parseFloat(value) : undefined'

### DIFF
--- a/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.spec.ts
@@ -40,8 +40,8 @@ describe('DebtInputComponent', () => {
      * Helper function to set transaction data for testing and initialize component
      */
     function setupAndInitialize(
-      beginningBalance: number | undefined,
-      paymentAmount: number | undefined,
+      beginningBalance: number | null | undefined,
+      paymentAmount: number | null | undefined,
       transactionId: string | undefined = '123',
     ) {
       // Create a mock transaction object with the required properties
@@ -61,6 +61,12 @@ describe('DebtInputComponent', () => {
 
     it('should initialize nullish beginning and payment balances to 0 for existing debts', () => {
       setupAndInitialize(undefined, undefined, '123');
+      expect(component.form.get('beginning_balance')?.value).toBe(0);
+      expect(component.form.get('payment_amount')?.value).toBe(0);
+    });
+
+    it('should initialize null beginning and payment balances to 0 for existing debts', () => {
+      setupAndInitialize(null, null, '123');
       expect(component.form.get('beginning_balance')?.value).toBe(0);
       expect(component.form.get('payment_amount')?.value).toBe(0);
     });

--- a/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.spec.ts
+++ b/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.spec.ts
@@ -59,6 +59,12 @@ describe('DebtInputComponent', () => {
       fixture.detectChanges();
     }
 
+    it('should initialize nullish beginning and payment balances to 0 for existing debts', () => {
+      setupAndInitialize(undefined, undefined, '123');
+      expect(component.form.get('beginning_balance')?.value).toBe(0);
+      expect(component.form.get('payment_amount')?.value).toBe(0);
+    });
+
     it('should calculate balance_at_close when incurred_amount changes', () => {
       // Setup: beginning balance = 5000, payment amount = 1000
       // When incurred_amount = 2000

--- a/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.ts
+++ b/front-end/src/app/shared/components/inputs/debt-input/debt-input.component.ts
@@ -13,12 +13,25 @@ import { SchDTransaction } from 'app/shared/models';
 })
 export class DebtInputComponent extends BaseInputComponent implements OnInit {
   ngOnInit(): void {
-    // For new create transactions, the debt calculated amounts are initialized to 0
-    // They a calculated fields and not saved to the database
-    if (!this.transaction()?.id) {
-      this.form.get('beginning_balance')?.setValue(0);
-      this.form.get('payment_amount')?.setValue(0);
-      this.form.get('balance_at_close')?.setValue(0);
+    const beginningBalanceControl = this.form.get('beginning_balance');
+    const paymentAmountControl = this.form.get('payment_amount');
+    const balanceAtCloseControl = this.form.get('balance_at_close');
+
+    // For existing debts, nullish computed fields are normalized to 0 for deterministic display.
+    if (this.transaction()?.id) {
+      // Existing debts may come back with nullish computed fields; display deterministic 0 values.
+      if (beginningBalanceControl && (beginningBalanceControl.value == null || beginningBalanceControl.value === '')) {
+        beginningBalanceControl.setValue(0, { emitEvent: false });
+      }
+      if (paymentAmountControl && (paymentAmountControl.value == null || paymentAmountControl.value === '')) {
+        paymentAmountControl.setValue(0, { emitEvent: false });
+      }
+    } else {
+      // For new create transactions, the debt calculated amounts are initialized to 0.
+      // They are calculated fields and not saved to the database.
+      beginningBalanceControl?.setValue(0, { emitEvent: false });
+      paymentAmountControl?.setValue(0, { emitEvent: false });
+      balanceAtCloseControl?.setValue(0, { emitEvent: false });
     }
 
     // balance_at_close is a calculated field and not saved to the database
@@ -26,7 +39,8 @@ export class DebtInputComponent extends BaseInputComponent implements OnInit {
       .get('incurred_amount')
       ?.valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((amount) => {
-        const amountNumber = isNaN(parseFloat(amount)) ? 0 : parseFloat(amount);
+        const parsedAmount = Number.parseFloat(String(amount));
+        const amountNumber = Number.isNaN(parsedAmount) ? 0 : parsedAmount;
         const tx = this.transaction() as SchDTransaction | undefined;
         const beginning_balance = tx?.beginning_balance ?? 0;
         const payment_amount = tx?.payment_amount ?? 0;

--- a/front-end/src/app/shared/models/schd-transaction.model.spec.ts
+++ b/front-end/src/app/shared/models/schd-transaction.model.spec.ts
@@ -33,6 +33,21 @@ describe('SchDTransaction', () => {
     expect(transaction.balance_at_close).toBe(0);
   });
 
+  it('should map null numeric fields to undefined from JSON', () => {
+    const data = {
+      transaction_type_identifier: 'DEBT_OWED_BY_COMMITTEE',
+      beginning_balance: null,
+      incurred_amount: null,
+      payment_amount: null,
+      balance_at_close: null,
+    };
+    const transaction: SchDTransaction = SchDTransaction.fromJSON(data);
+    expect(transaction.beginning_balance).toBeUndefined();
+    expect(transaction.incurred_amount).toBeUndefined();
+    expect(transaction.payment_amount).toBeUndefined();
+    expect(transaction.balance_at_close).toBeUndefined();
+  });
+
   xit('Creates a transaction object from JSON', () => {
     const json = {
       transaction_type_identifier: 'DEBT_OWED_BY_COMMITTEE',

--- a/front-end/src/app/shared/models/schd-transaction.model.spec.ts
+++ b/front-end/src/app/shared/models/schd-transaction.model.spec.ts
@@ -18,6 +18,21 @@ describe('SchDTransaction', () => {
     expect(transaction.creditor_organization_name).toBe('foo');
   });
 
+  it('should preserve zero-valued numeric fields from JSON', () => {
+    const data = {
+      transaction_type_identifier: 'DEBT_OWED_BY_COMMITTEE',
+      beginning_balance: 0,
+      incurred_amount: '0',
+      payment_amount: 0,
+      balance_at_close: '0',
+    };
+    const transaction: SchDTransaction = SchDTransaction.fromJSON(data);
+    expect(transaction.beginning_balance).toBe(0);
+    expect(transaction.incurred_amount).toBe(0);
+    expect(transaction.payment_amount).toBe(0);
+    expect(transaction.balance_at_close).toBe(0);
+  });
+
   xit('Creates a transaction object from JSON', () => {
     const json = {
       transaction_type_identifier: 'DEBT_OWED_BY_COMMITTEE',

--- a/front-end/src/app/shared/models/schd-transaction.model.spec.ts
+++ b/front-end/src/app/shared/models/schd-transaction.model.spec.ts
@@ -48,6 +48,21 @@ describe('SchDTransaction', () => {
     expect(transaction.balance_at_close).toBeUndefined();
   });
 
+  it('should map non-primitive numeric fields to undefined from JSON', () => {
+    const data = {
+      transaction_type_identifier: 'DEBT_OWED_BY_COMMITTEE',
+      beginning_balance: {},
+      incurred_amount: [],
+      payment_amount: { value: '1' },
+      balance_at_close: true,
+    };
+    const transaction: SchDTransaction = SchDTransaction.fromJSON(data);
+    expect(transaction.beginning_balance).toBeUndefined();
+    expect(transaction.incurred_amount).toBeUndefined();
+    expect(transaction.payment_amount).toBeUndefined();
+    expect(transaction.balance_at_close).toBeUndefined();
+  });
+
   xit('Creates a transaction object from JSON', () => {
     const json = {
       transaction_type_identifier: 'DEBT_OWED_BY_COMMITTEE',

--- a/front-end/src/app/shared/models/schd-transaction.model.ts
+++ b/front-end/src/app/shared/models/schd-transaction.model.ts
@@ -3,6 +3,12 @@ import { AggregationGroups, Transaction } from './transaction.model';
 import { LabelList } from '../utils/label.utils';
 import { getFromJSON, TransactionTypeUtils } from '../utils/transaction-type.utils';
 
+function parseOptionalNumber(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  const parsedValue = parseFloat(String(value));
+  return Number.isNaN(parsedValue) ? undefined : parsedValue;
+}
+
 export class SchDTransaction extends Transaction {
   entity_type: string | undefined;
   receipt_line_number: string | undefined;
@@ -20,13 +26,13 @@ export class SchDTransaction extends Transaction {
   creditor_state: string | undefined;
   creditor_zip: string | undefined;
   purpose_of_debt_or_obligation: string | undefined;
-  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
+  @Transform(({ value }) => parseOptionalNumber(value))
   beginning_balance: number | undefined;
-  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
+  @Transform(({ value }) => parseOptionalNumber(value))
   incurred_amount: number | undefined;
-  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
+  @Transform(({ value }) => parseOptionalNumber(value))
   payment_amount: number | undefined;
-  @Transform(({ value }) => (value ? parseFloat(value) : undefined))
+  @Transform(({ value }) => parseOptionalNumber(value))
   balance_at_close: number | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/front-end/src/app/shared/models/schd-transaction.model.ts
+++ b/front-end/src/app/shared/models/schd-transaction.model.ts
@@ -5,8 +5,17 @@ import { getFromJSON, TransactionTypeUtils } from '../utils/transaction-type.uti
 
 function parseOptionalNumber(value: unknown): number | undefined {
   if (value === null || value === undefined || value === '') return undefined;
-  const parsedValue = parseFloat(String(value));
-  return Number.isNaN(parsedValue) ? undefined : parsedValue;
+
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? undefined : value;
+  }
+
+  if (typeof value === 'string') {
+    const parsedValue = Number.parseFloat(value);
+    return Number.isNaN(parsedValue) ? undefined : parsedValue;
+  }
+
+  return undefined;
 }
 
 export class SchDTransaction extends Transaction {


### PR DESCRIPTION
primary bug: Schedule D transforms convert numeric 0 to undefined because of truthy checks in `schd-transaction.model.ts`
value ? parseFloat(value) : undefined

secondary behavior: debt form only initializes zero defaults for create mode (!id) in `debt-input.component.ts`. On edit mode, null/undefined values stay empty

rendering behavior confirms symptom: input-number shows empty when value is null/undefined with default allowEmpty=true in `input-number.component.ts`