### PR TITLE
2936 - Update package-lock to address vulnerabilities

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -487,13 +487,13 @@
             }
         },
         "node_modules/@angular-devkit/schematics": {
-            "version": "20.3.19",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.19.tgz",
-            "integrity": "sha512-7ZwThNeCcdKNuFpmrpQvm049v2Y+7CCCoFOzGg0UnH7F+wmaTSwEwLr+NmGJO0shYCUGl1Q/pcF9y58xs2njiQ==",
+            "version": "20.3.20",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.20.tgz",
+            "integrity": "sha512-+NNHQhQHcgQWZopStZ6os30YuP99lRzNS4wOnkJmoROy40SZct8lPnl2QW50a9Vc0AtaHx1a1NUZ+ohbf6fXqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/core": "20.3.19",
+                "@angular-devkit/core": "20.3.20",
                 "jsonc-parser": "3.3.1",
                 "magic-string": "0.30.17",
                 "ora": "8.2.0",
@@ -503,6 +503,34 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
                 "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
                 "yarn": ">= 1.13.0"
+            }
+        },
+        "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
+            "version": "20.3.20",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.20.tgz",
+            "integrity": "sha512-Iobw7He3yJVR2aQ6JN9Kq/2ldD8+uHzJZwd41SQ91A+TzPrBRSV0t80WHHrANZ7xnAjtHDc7zSSGp/i7DzUc9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "8.18.0",
+                "ajv-formats": "3.0.1",
+                "jsonc-parser": "3.3.1",
+                "picomatch": "4.0.3",
+                "rxjs": "7.8.2",
+                "source-map": "0.7.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+                "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+                "yarn": ">= 1.13.0"
+            },
+            "peerDependencies": {
+                "chokidar": "^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "chokidar": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@angular-eslint/builder": {
@@ -779,6 +807,25 @@
             },
             "bin": {
                 "ng": "bin/ng.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+                "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+                "yarn": ">= 1.13.0"
+            }
+        },
+        "node_modules/@angular/cli/node_modules/@angular-devkit/schematics": {
+            "version": "20.3.19",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.19.tgz",
+            "integrity": "sha512-7ZwThNeCcdKNuFpmrpQvm049v2Y+7CCCoFOzGg0UnH7F+wmaTSwEwLr+NmGJO0shYCUGl1Q/pcF9y58xs2njiQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@angular-devkit/core": "20.3.19",
+                "jsonc-parser": "3.3.1",
+                "magic-string": "0.30.17",
+                "ora": "8.2.0",
+                "rxjs": "7.8.2"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -1129,9 +1176,9 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-            "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.7.tgz",
+            "integrity": "sha512-6Fqi8MtQ/PweQ9xvux65emkLQ83uB+qAVtfHkC9UodyHMIZdxNI01HjLCLUtybElp2KY2XNE0nOgyP1E1vXw9w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3135,15 +3182,15 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.2"
+                "minimatch": "^3.1.5"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3301,9 +3348,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.10",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
-            "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
+            "version": "1.19.11",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5839,6 +5886,25 @@
                 "yarn": ">= 1.13.0"
             }
         },
+        "node_modules/@schematics/angular/node_modules/@angular-devkit/schematics": {
+            "version": "20.3.19",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.19.tgz",
+            "integrity": "sha512-7ZwThNeCcdKNuFpmrpQvm049v2Y+7CCCoFOzGg0UnH7F+wmaTSwEwLr+NmGJO0shYCUGl1Q/pcF9y58xs2njiQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@angular-devkit/core": "20.3.19",
+                "jsonc-parser": "3.3.1",
+                "magic-string": "0.30.17",
+                "ora": "8.2.0",
+                "rxjs": "7.8.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+                "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+                "yarn": ">= 1.13.0"
+            }
+        },
         "node_modules/@sigstore/bundle": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -6164,9 +6230,9 @@
             }
         },
         "node_modules/@types/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
             "dev": true,
             "license": "MIT"
         },
@@ -6262,7 +6328,7 @@
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
             "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -6520,9 +6586,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-            "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+            "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6632,17 +6698,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-            "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+            "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1"
+                "@typescript-eslint/scope-manager": "8.57.0",
+                "@typescript-eslint/types": "8.57.0",
+                "@typescript-eslint/typescript-estree": "8.57.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6657,15 +6723,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-            "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+            "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.56.1",
-                "@typescript-eslint/types": "^8.56.1",
+                "@typescript-eslint/tsconfig-utils": "^8.57.0",
+                "@typescript-eslint/types": "^8.57.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -6680,15 +6746,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-            "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+            "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1"
+                "@typescript-eslint/types": "8.57.0",
+                "@typescript-eslint/visitor-keys": "8.57.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6699,9 +6765,9 @@
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-            "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+            "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -6717,17 +6783,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-            "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+            "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/project-service": "8.56.1",
-                "@typescript-eslint/tsconfig-utils": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/project-service": "8.57.0",
+                "@typescript-eslint/tsconfig-utils": "8.57.0",
+                "@typescript-eslint/types": "8.57.0",
+                "@typescript-eslint/visitor-keys": "8.57.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -6746,14 +6812,14 @@
             }
         },
         "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-            "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+            "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/types": "8.57.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -7576,14 +7642,14 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.15",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-            "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.16.tgz",
+            "integrity": "sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.7",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -7615,13 +7681,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-            "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.7.tgz",
+            "integrity": "sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.6"
+                "@babel/helper-define-polyfill-provider": "^0.6.7"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -8080,9 +8146,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001776",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
-            "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+            "version": "1.0.30001777",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
+            "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9589,14 +9655,15 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.6.5",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
-            "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+            "version": "6.6.6",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+            "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/cors": "^2.8.12",
                 "@types/node": ">=10.0.0",
+                "@types/ws": "^8.5.12",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
                 "cookie": "~0.7.2",
@@ -9732,7 +9799,6 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
             "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -10258,13 +10324,13 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-            "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+            "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "10.0.1"
+                "ip-address": "10.1.0"
             },
             "engines": {
                 "node": ">= 16"
@@ -10460,7 +10526,7 @@
         "node_modules/fecfile-validate": {
             "version": "0.0.1",
             "resolved": "git+ssh://git@github.com/fecgov/fecfile-validate.git#0cf017439a59a08a7bed02e2069045708887209c",
-            "integrity": "sha512-QybmLFQHELGhveD10kF0C0snq2Iy+KEaj0RwEk+hVV+1LgIvvqCt//5xCEpWmZTob1Ai82XAIGZ0QIFWA8roHg==",
+            "integrity": "sha512-6R3Gpx9yRZSYXNysfs3hdcFiu6ftfhlq6Ps1Z5SbJGCWKJYWNQnQIHoOqdEh+dOAizU9i2EuMvu3hIXxtyxZhA==",
             "hasInstallScript": true,
             "license": "CC0-1.0",
             "dependencies": {
@@ -10584,9 +10650,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+            "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
             "devOptional": true,
             "license": "ISC"
         },
@@ -11091,9 +11157,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.5",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-            "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+            "version": "4.12.7",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+            "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11461,7 +11527,6 @@
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
             "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "bin": {
@@ -11553,9 +11618,9 @@
             ]
         },
         "node_modules/ip-address": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12027,9 +12092,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-            "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+            "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -12686,7 +12751,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
             "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -12701,7 +12765,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "bin": {
@@ -12715,7 +12778,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -12726,7 +12788,6 @@
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "dev": true,
             "license": "ISC",
             "optional": true,
             "bin": {
@@ -12737,7 +12798,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
             "engines": {
@@ -14317,9 +14377,9 @@
             "license": "MIT"
         },
         "node_modules/msgpackr": {
-            "version": "1.11.8",
-            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.8.tgz",
-            "integrity": "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==",
+            "version": "1.11.9",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
+            "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
             "license": "MIT",
             "optional": true,
             "optionalDependencies": {
@@ -14400,7 +14460,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
             "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -14418,7 +14477,6 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -15793,7 +15851,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -16419,7 +16476,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
             "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "optional": true,
             "engines": {
@@ -17372,9 +17428,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.31.3",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.3.tgz",
-            "integrity": "sha512-vX0eeI7oGIr79NLiJRWnK8SyxDjyiNOEanaQnHRNyb5ep8QcpD8QMDvrukdrxV4pV4AKjwUDfaypXnWHMC/65A==",
+            "version": "5.31.4",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.4.tgz",
+            "integrity": "sha512-lZppDyQx91VdS5zJvAyGkmwe+Mq6xY978BDUG2wRkWE+jkmUF5ti8cvOovFQoN5bvSFKCXVkyKEaU5ec3SJiRg==",
             "dev": true,
             "license": "MIT",
             "os": [
@@ -17413,9 +17469,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-            "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+            "version": "7.5.11",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+            "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -17476,9 +17532,9 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.17",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
-            "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+            "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -90,7 +90,6 @@
     },
     "overrides": {
         "rollup": "4.59.0",
-        "tar": "7.5.9",
         "vite": "7.1.11",
         "qs": "6.15.0",
         "@isaacs/brace-expansion": "5.0.1"


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2936

I used `npm update` instead of `npm install` to get the latest compatible versions of our packages. This ideally should cut down on some of the Snyk chatter.
