### PR TITLE
[E2E] FECFILE-2963: f1m submit report after validating memo text

### DIFF
--- a/front-end/cypress/e2e-smoke/F1M/f1m-affiliation.cy.ts
+++ b/front-end/cypress/e2e-smoke/F1M/f1m-affiliation.cy.ts
@@ -103,7 +103,7 @@ describe('Manage reports', () => {
       }
 
       PageUtils.clickButton('Save and continue', '[data-cy="save-cancel-actions"]:visible');
-      cy.get('[data-cy="print-preview"]').should('exist');
+      cy.get('[data-cy="print-preview"]').should('be.visible');
 
       PageUtils.clickSidebarSection('SIGN & SUBMIT');
       PageUtils.shouldNotHaveSidebarItem('Report Status');
@@ -117,7 +117,8 @@ describe('Manage reports', () => {
       // Verify it is still there when we go back to the page
       PageUtils.clickSidebarSection('REVIEW A REPORT');
       PageUtils.clickSidebarItem('Add a report level memo');
-      cy.get('[id="text4000"]').should('have.value', memoText);
+      cy.get('[id="text4000"]:visible').should('have.value', memoText);
+      PageUtils.clickButton('Save & continue', '[data-cy="report-level-memo-actions"]:visible');
 
       // Submit report and verify report status link now available
       PageUtils.clickSidebarSection('SIGN & SUBMIT');

--- a/front-end/cypress/e2e-smoke/F1M/f1m-affiliation.cy.ts
+++ b/front-end/cypress/e2e-smoke/F1M/f1m-affiliation.cy.ts
@@ -113,6 +113,9 @@ describe('Manage reports', () => {
       const memoText = faker.lorem.sentence({ min: 1, max: 4 });
       ReportLevelMemoPage.enterFormData(memoText);
       PageUtils.clickButton('Save & continue', '[data-cy="report-level-memo-actions"]:visible');
+      // Verify we've landed on the submit report page before checking
+      // back on the memo page
+      cy.get('#submit-report-container').should('exist');
 
       // Verify it is still there when we go back to the page
       PageUtils.clickSidebarSection('REVIEW A REPORT');
@@ -120,7 +123,6 @@ describe('Manage reports', () => {
       cy.get('[id="text4000"]:visible').should('have.value', memoText);
 
       // Submit report and verify report status link now available
-      // PageUtils.clickSidebarSection and .clickSidebarItem modified to assert visibility too
       PageUtils.clickSidebarSection('SIGN & SUBMIT');
       PageUtils.clickSidebarItem('Submit report');
       PageUtils.submitReportForm();

--- a/front-end/cypress/e2e-smoke/F1M/f1m-affiliation.cy.ts
+++ b/front-end/cypress/e2e-smoke/F1M/f1m-affiliation.cy.ts
@@ -118,9 +118,9 @@ describe('Manage reports', () => {
       PageUtils.clickSidebarSection('REVIEW A REPORT');
       PageUtils.clickSidebarItem('Add a report level memo');
       cy.get('[id="text4000"]:visible').should('have.value', memoText);
-      PageUtils.clickButton('Save & continue', '[data-cy="report-level-memo-actions"]:visible');
 
       // Submit report and verify report status link now available
+      // PageUtils.clickSidebarSection and .clickSidebarItem modified to assert visibility too
       PageUtils.clickSidebarSection('SIGN & SUBMIT');
       PageUtils.clickSidebarItem('Submit report');
       PageUtils.submitReportForm();

--- a/front-end/cypress/e2e-smoke/pages/contactListPage.ts
+++ b/front-end/cypress/e2e-smoke/pages/contactListPage.ts
@@ -15,10 +15,13 @@ export class ContactListPage {
   }
 
   static openAddContactDialog() {
-    // look into why this needs to be clicked twice
-    PageUtils.clickButton('Add contact', '#button-contacts-new:enabled', true);
-    PageUtils.clickButton('Add contact', '#button-contacts-new:enabled', true);
-    cy.get('[data-cy="contact-dialog"]:visible').should('exist');
+    cy.get('[data-cy="contact-dialog"]:visible').should('not.exist');
+    cy.get('#button-contacts-new:enabled')
+      .should('be.visible')
+      .click();
+    cy.get('[data-cy="contact-dialog"]:visible')
+      .should('exist')
+      .and('contain', 'Add Contact');
   }
 
   static enterFormData(formData: ContactFormData, excludeContactType = false, alias = '') {

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -96,15 +96,8 @@ export class PageUtils {
   }
 
   static clickSidebarSection(section: string) {
-    cy.contains('p-panelmenu .p-panelmenu-header', section)
-      .closest('.p-panelmenu-panel')
-      .find('.p-panelmenu-header')
-      .as('sectionHeader');
-
-    cy.get('@sectionHeader')
-      .click().then(() => {
-        cy.get('@sectionHeader').should('have.attr', 'data-p-highlight', 'true');
-      });
+    cy.get('p-panelmenu').contains(section).parent().as('section');
+    cy.get('@section').click();
   }
 
   static clickSidebarItem(menuItem: string) {
@@ -153,7 +146,7 @@ export class PageUtils {
     cy.get(alias)
       .contains('button', name)
       .first()
-      .click();
+      .click({ force });
   }
 
   static dateToString(date: Date) {

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -96,13 +96,20 @@ export class PageUtils {
   }
 
   static clickSidebarSection(section: string) {
-    cy.get('p-panelmenu').contains(':visible',section).parent().as('section');
-    cy.get('@section').should('be.visible').click();
+    cy.contains('p-panelmenu .p-panelmenu-header', section)
+      .closest('.p-panelmenu-panel')
+      .find('.p-panelmenu-header')
+      .as('sectionHeader');
+
+    cy.get('@sectionHeader')
+      .click().then(() => {
+        cy.get('@sectionHeader').should('have.attr', 'data-p-highlight', 'true');
+      });
   }
 
   static clickSidebarItem(menuItem: string) {
     cy.get('p-panelmenu').contains('a:visible', menuItem).as('menuItem');
-    cy.get('@menuItem').should('be.visible').click();
+    cy.get('@menuItem').click();
   }
 
   static shouldHaveSidebarItem(menuItem: string) {
@@ -144,7 +151,7 @@ export class PageUtils {
   static clickButton(name: string, alias = '', force = false) {
     alias = PageUtils.getAlias(alias);
     cy.get(alias)
-      .contains('button:visible', name)
+      .contains('button', name)
       .first()
       .click();
   }
@@ -251,6 +258,7 @@ export class PageUtils {
     cy.intercept('POST', 'http://localhost:8080/api/v1/web-services/submit-to-fec/').as('SubmitReport');
     const alias = PageUtils.getAlias('');
     PageUtils.urlCheck('/submit');
+    cy.contains('h1', 'Submit report').should('be.visible');
     PageUtils.enterValue('#treasurer_last_name', 'TEST');
     PageUtils.enterValue('#treasurer_first_name', 'TEST');
     PageUtils.enterValue('#filingPassword', 'filing!Passw0rd');

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -96,13 +96,13 @@ export class PageUtils {
   }
 
   static clickSidebarSection(section: string) {
-    cy.get('p-panelmenu').contains(section).parent().as('section');
-    cy.get('@section').click();
+    cy.get('p-panelmenu').contains(':visible',section).parent().as('section');
+    cy.get('@section').should('be.visible').click();
   }
 
   static clickSidebarItem(menuItem: string) {
-    cy.get('p-panelmenu').contains('a', menuItem).as('menuItem');
-    cy.get('@menuItem').click();
+    cy.get('p-panelmenu').contains('a:visible', menuItem).as('menuItem');
+    cy.get('@menuItem').should('be.visible').click();
   }
 
   static shouldHaveSidebarItem(menuItem: string) {
@@ -144,9 +144,9 @@ export class PageUtils {
   static clickButton(name: string, alias = '', force = false) {
     alias = PageUtils.getAlias(alias);
     cy.get(alias)
-      .contains('button', name)
+      .contains('button:visible', name)
       .first()
-      .click({ force });
+      .click();
   }
 
   static dateToString(date: Date) {

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -95,14 +95,21 @@ export class PageUtils {
     cy.get('body').find('.p-datepicker-year').contains(year.toString()).should('be.visible').click({ force: true });
   }
 
-  static clickSidebarSection(section: string) {
-    cy.get('p-panelmenu').contains(section).parent().as('section');
-    cy.get('@section').click();
+  static clickSidebarSection(section: string) {  
+    cy.contains('p-panelmenu .p-panelmenu-header', section)
+      .closest('.p-panelmenu-panel')
+      .find('.p-panelmenu-header')
+      .as('sectionHeader');
+
+    cy.get('@sectionHeader')
+      .click().then(() => {
+        cy.get('@sectionHeader').should('have.attr', 'data-p-highlight', 'true');
+      });
   }
 
   static clickSidebarItem(menuItem: string) {
     cy.get('p-panelmenu').contains('a', menuItem).as('menuItem');
-    cy.get('@menuItem').click();
+    cy.get('@menuItem').click({ force: true });
   }
 
   static shouldHaveSidebarItem(menuItem: string) {

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -108,7 +108,7 @@ export class PageUtils {
   }
 
   static clickSidebarItem(menuItem: string) {
-    cy.get('p-panelmenu').contains('a:visible', menuItem).as('menuItem');
+    cy.get('p-panelmenu').contains('a', menuItem).as('menuItem');
     cy.get('@menuItem').click();
   }
 


### PR DESCRIPTION
Ticket link: [FECFILE-2963](https://fecgov.atlassian.net/browse/FECFILE-2963)

updated helpers in PageUtils for clicking sidebar sections and items for visibility checks (as well as section expansion validation), and then added a header assertion before proceeding w/ the submission flow

UPDATE: passing
<img width="1599" height="245" alt="image" src="https://github.com/user-attachments/assets/b15e68e2-d27a-4401-b2a9-cef8ca88f34f" />

