### PR TITLE
HOTFIX: Ignore unused enums.

### DIFF
--- a/front-end/knip.json
+++ b/front-end/knip.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
+  "ignoreIssues": {
+    "src/app/shared/models/transaction-type.model.ts": ["enumMembers"]
+  },
   "ignoreDependencies": [
     "primeflex",
     "primeicons",


### PR DESCRIPTION
Ticket link:
N/A

Related PRs:
N/A

Latest knip (used by circlecli and locally via `npx knip`) has gone from 5.88.1 to 6.0.1 and now complains:
````
Unused exported enum members (2)
SYSTEM_GENERATED  PurposeDescriptionLabelSuffix  src/app/shared/models/transaction-type.model.ts:246:3
OPTIONAL          PurposeDescriptionLabelSuffix  src/app/shared/models/transaction-type.model.ts:248:3
````
because we use all three enum members internally but only one externally.

We are updating knip to ignore this specific issue in this specific file.  Separately, this enum will be switched to a const in develop and that fix will be deployed through normal channels.