### PR TITLE
[E2E] cy.blurActiveField()

### DIFF
--- a/front-end/cypress/e2e-smoke/F24/f24.helpers.ts
+++ b/front-end/cypress/e2e-smoke/F24/f24.helpers.ts
@@ -38,7 +38,7 @@ export function createIndependentExpenditureOnForm24(
     'date_signed',
   );
   if (blurBeforeSave) {
-    PageUtils.blurActiveField();
+    cy.blurActiveField();
   }
   TransactionDetailPage.clickSave();
   cy.location('pathname').should('include', `/reports/transactions/report/${reportId}/list`);


### PR DESCRIPTION
Ticket link: [FECFILE-2807](https://fecgov.atlassian.net/browse/FECFILE-2807)

Related PRs: https://github.com/fecgov/fecfile-web-app/pull/3712

either got overwritten during merge or an extra tab stroke (auto-suggest keybind) which changed the new command cy.blurActiveField() in `f24.helpers.ts` to the old PageUtils.blurActiveField()
