### PR TITLE
feature/2965 - Change password autocomplete to off

### DIFF
--- a/front-end/src/app/reports/submission-workflow/submit-report.component.html
+++ b/front-end/src/app/reports/submission-workflow/submit-report.component.html
@@ -135,7 +135,7 @@
         formControlName="filingPassword"
         [feedback]="false"
         [toggleMask]="true"
-        autocomplete="new-password"
+        autocomplete="off"
       />
       <app-error-messages [form]="form" fieldName="filingPassword" [formSubmitted]="formSubmitted" />
       <a [href]="psaIndex" target="_blank" rel="noopener" class="font-gandhi w-max text-sm pt-1">


### PR DESCRIPTION
Issue [FECFILE-2965](https://fecgov.atlassian.net/browse/FECFILE-2965)

Changed the password autocomplete to "off". This allowed me to select the password from a list of saved passwords and when doing so _only_ populated the password field and nothing else. This worked for me in chrome and firefox. Interestingly, if I saved the password the first time I entered it, it keyed off of the EMAIL #1 field which makes a bit more sense. And would autopopulate the password based off that field, only running into issues when my saved password had a different associated email.