### PR TITLE
Feature/2924 - Updates to editing a failed submission

### DIFF
--- a/front-end/src/app/reports/report-list/abstract-form-list.component.ts
+++ b/front-end/src/app/reports/report-list/abstract-form-list.component.ts
@@ -67,7 +67,11 @@ export abstract class AbstractFormListComponent<T extends Report> extends TableL
   readonly rowActions: TableAction<T>[] = [
     new TableAction('Edit', this.editItem.bind(this), (report: T) => report.canEdit),
     new TableAction('Amend', this.amendReport.bind(this), (report: T) => report.canAmend),
-    new TableAction('Review', this.editItem.bind(this), (report: T) => !report.canEdit),
+    new TableAction(
+      'Review',
+      this.reviewItem.bind(this),
+      (report: T) => report.report_status !== ReportStatus.IN_PROGRESS,
+    ),
     new TableAction('Delete', this.confirmDelete.bind(this), (report: T) => report.can_delete),
     new TableAction('Unamend', this.unamendReport.bind(this), (report: T) => report.can_unamend),
     new TableAction('Download as .fec', this.download.bind(this)),
@@ -98,11 +102,15 @@ export abstract class AbstractFormListComponent<T extends Report> extends TableL
   }
 
   override async editItem(item: T): Promise<boolean> {
-    if (item.report_status && item.report_status !== ReportStatus.IN_PROGRESS) {
+    if (!item.canEdit) {
       return this.router.navigateByUrl(`/reports/${item.report_type.toLocaleLowerCase()}/submit/status/${item.id}`);
     }
 
     return this.router.navigateByUrl(`/reports/transactions/report/${item.id}/list`);
+  }
+
+  async reviewItem(item: T): Promise<boolean> {
+    return this.router.navigateByUrl(`/reports/${item.report_type.toLocaleLowerCase()}/submit/status/${item.id}`);
   }
 
   async download(report: T): Promise<void> {

--- a/front-end/src/app/reports/report-list/abstract-form-list.component.ts
+++ b/front-end/src/app/reports/report-list/abstract-form-list.component.ts
@@ -101,6 +101,14 @@ export abstract class AbstractFormListComponent<T extends Report> extends TableL
     });
   }
 
+  async goToReport(item: T): Promise<boolean> {
+    if (item.report_status === ReportStatus.IN_PROGRESS) {
+      return this.router.navigateByUrl(`/reports/transactions/report/${item.id}/list`);
+    } else {
+      return this.router.navigateByUrl(`/reports/${item.report_type.toLocaleLowerCase()}/submit/status/${item.id}`);
+    }
+  }
+
   override async editItem(item: T): Promise<boolean> {
     if (!item.canEdit) {
       return this.router.navigateByUrl(`/reports/${item.report_type.toLocaleLowerCase()}/submit/status/${item.id}`);

--- a/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.html
+++ b/front-end/src/app/reports/report-list/form1m-list/form1m-list.component.html
@@ -1,4 +1,4 @@
-<app-shared-templates (reportNameClick)="this.editItem($event)" />
+<app-shared-templates (reportNameClick)="this.goToReport($event)" />
 <div [hidden]="items().length === 0">
   <app-table
     [(first)]="first"

--- a/front-end/src/app/reports/report-list/form24-list/form24-list.component.html
+++ b/front-end/src/app/reports/report-list/form24-list/form24-list.component.html
@@ -1,4 +1,4 @@
-<app-shared-templates (reportNameClick)="this.editItem($event)" />
+<app-shared-templates (reportNameClick)="this.goToReport($event)" />
 <div [hidden]="items().length === 0">
   <app-table
     [(first)]="first"

--- a/front-end/src/app/reports/report-list/form24-list/form24-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form24-list/form24-list.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Form24ListComponent } from './form24-list.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { Router } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { provideMockStore } from '@ngrx/store/testing';
 import { FormTypeDialogComponent } from 'app/reports/form-type-dialog/form-type-dialog.component';
 import { ApiService } from 'app/shared/services/api.service';
@@ -13,8 +13,9 @@ import { DialogModule, Dialog } from 'primeng/dialog';
 import { TableModule } from 'primeng/table';
 import { ToolbarModule } from 'primeng/toolbar';
 import { ReportListComponent } from '../report-list.component';
-import { ReportTypes, Form24 } from 'app/shared/models';
+import { ReportTypes, Form24, ReportStatus } from 'app/shared/models';
 import { ScannedActionsSubject } from '@ngrx/store';
+import { ROUTES } from 'app/routes';
 
 describe('Form24ListComponent', () => {
   let component: Form24ListComponent;
@@ -32,6 +33,7 @@ describe('Form24ListComponent', () => {
         MessageService,
         ApiService,
         ScannedActionsSubject,
+        provideRouter(ROUTES),
         provideMockStore(testMockStore()),
       ],
     }).compileComponents();
@@ -48,10 +50,15 @@ describe('Form24ListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('edit a F24 should go to F24 edit page', () => {
+  it('edit a F24 should go to F24 edit page', async () => {
     const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    const item: Form24 = Form24.fromJSON({ id: '99', report_type: ReportTypes.F24 });
-    component.editItem(item);
+    const item: Form24 = Form24.fromJSON({
+      id: '99',
+      report_type: ReportTypes.F24,
+      report_status: ReportStatus.IN_PROGRESS,
+    });
+    expect(item.canEdit).toBe(true);
+    await component.editItem(item);
     expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/99/list');
   });
 });

--- a/front-end/src/app/reports/report-list/form3-list/form3-list.component.html
+++ b/front-end/src/app/reports/report-list/form3-list/form3-list.component.html
@@ -1,4 +1,4 @@
-<app-shared-templates (reportNameClick)="this.editItem($event)" />
+<app-shared-templates (reportNameClick)="this.goToReport($event)" />
 <div [hidden]="items().length === 0">
   <app-table
     [(first)]="first"

--- a/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.html
+++ b/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.html
@@ -1,4 +1,4 @@
-<app-shared-templates (reportNameClick)="this.editItem($event)" />
+<app-shared-templates (reportNameClick)="this.goToReport($event)" />
 <div [hidden]="items().length === 0">
   <app-table
     [(first)]="first"

--- a/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.spec.ts
+++ b/front-end/src/app/reports/report-list/form3x-list/form3x-list.component.spec.ts
@@ -20,6 +20,35 @@ import { ReportListComponent } from '../report-list.component';
 import { Form3XListComponent } from './form3x-list.component';
 import { ROUTES } from 'app/routes';
 
+function getStatusLink(report: Form3X): string {
+  return `/reports/f3x/submit/status/${report.id}`;
+}
+
+function getListLink(report: Form3X): string {
+  return `/reports/transactions/report/${report.id}/list`;
+}
+
+const successForm = Form3X.fromJSON({
+  id: 'success_id',
+  report_type: ReportTypes.F3X,
+  report_status: ReportStatus.SUBMIT_SUCCESS,
+});
+const pendingForm = Form3X.fromJSON({
+  id: 'pending_id',
+  report_type: ReportTypes.F3X,
+  report_status: ReportStatus.SUBMIT_PENDING,
+});
+const inprogForm = Form3X.fromJSON({
+  id: 'inprog_id',
+  report_type: ReportTypes.F3X,
+  report_status: ReportStatus.IN_PROGRESS,
+});
+const failureForm = Form3X.fromJSON({
+  id: 'failure_id',
+  report_type: ReportTypes.F3X,
+  report_status: ReportStatus.SUBMIT_FAILURE,
+});
+
 describe('Form3XListComponent', () => {
   let component: Form3XListComponent;
   let fixture: ComponentFixture<Form3XListComponent>;
@@ -84,64 +113,28 @@ describe('Form3XListComponent', () => {
     expect(item.id).toBe(undefined);
   });
 
-  it('#editItem should route properly for report_status undefined', async () => {
-    const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
-    component.editItem({
-      id: '777',
-      report_type: ReportTypes.F3X,
-      report_status: undefined,
-    } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/777/list');
-  });
-
   it('#editItem should route properly for in-progress report', async () => {
     const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
-    component.editItem({
-      id: '777',
-      report_type: ReportTypes.F3X,
-      report_status: ReportStatus.IN_PROGRESS,
-    } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/777/list');
+    await component.editItem(inprogForm);
+    expect(navigateSpy).toHaveBeenCalledWith(getListLink(inprogForm));
   });
 
   it('#editItem should route properly for report with submission pending', async () => {
     const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
-    component.editItem({
-      id: '777',
-      report_type: ReportTypes.F3X,
-      report_status: ReportStatus.SUBMIT_PENDING,
-    } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/submit/status/777');
+    await component.editItem(pendingForm);
+    expect(navigateSpy).toHaveBeenCalledWith(getStatusLink(pendingForm));
   });
 
   it('#editItem should route properly for report with submission success', async () => {
     const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
-    component.editItem({
-      id: '777',
-      report_type: ReportTypes.F3X,
-      report_status: ReportStatus.SUBMIT_SUCCESS,
-    } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/submit/status/777');
+    await component.editItem(successForm);
+    expect(navigateSpy).toHaveBeenCalledWith(getStatusLink(successForm));
   });
 
   it('#editItem should route properly for report with submission failure', async () => {
     const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    await component.editItem({ id: '888', report_type: ReportTypes.F3X, report_status: undefined } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
-    component.editItem({
-      id: '777',
-      report_type: ReportTypes.F3X,
-      report_status: ReportStatus.SUBMIT_FAILURE,
-    } as Form3X);
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/f3x/submit/status/777');
+    await component.editItem(failureForm);
+    expect(navigateSpy).toHaveBeenCalledWith(getListLink(failureForm));
   });
 
   it('#amend should hit service', async () => {
@@ -159,12 +152,10 @@ describe('Form3XListComponent', () => {
   });
   it('#onActionClick should route properly', async () => {
     const navigateSpy = vi.spyOn(router, 'navigateByUrl');
-    await component.editItem({
-      id: '888',
-      report_type: ReportTypes.F3X,
-    } as Form3X);
-
-    expect(navigateSpy).toHaveBeenCalledWith('/reports/transactions/report/888/list');
+    await component.goToReport(inprogForm);
+    expect(navigateSpy).toHaveBeenCalledWith(getListLink(inprogForm));
+    await component.goToReport(failureForm);
+    expect(navigateSpy).toHaveBeenCalledWith(getStatusLink(failureForm));
   });
 
   it('#onDownload should open download panel properly', async () => {

--- a/front-end/src/app/reports/report-list/form99-list/form99-list.component.html
+++ b/front-end/src/app/reports/report-list/form99-list/form99-list.component.html
@@ -1,4 +1,4 @@
-<app-shared-templates (reportNameClick)="this.editItem($event)" />
+<app-shared-templates (reportNameClick)="this.goToReport($event)" />
 <div [hidden]="items().length === 0">
   <app-table
     [(first)]="first"

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list.component.ts
@@ -2,7 +2,7 @@ import { Component, computed, inject, signal, viewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { selectActiveReport } from 'app/store/active-report.selectors';
-import { Report, ReportStatus, ReportTypes } from 'app/shared/models/reports/report.model';
+import { Report, ReportTypes } from 'app/shared/models/reports/report.model';
 
 import { TransactionReceiptsComponent } from './transaction-receipts/transaction-receipts.component';
 import { TransactionDisbursementsComponent } from './transaction-disbursements/transaction-disbursements.component';
@@ -49,10 +49,7 @@ export class TransactionListComponent {
       'Add a receipt',
       this.createTransactions.bind(this, 'receipt'),
       (report: Report) => {
-        return (
-          report.report_status === ReportStatus.IN_PROGRESS &&
-          [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type)
-        );
+        return [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type);
       },
       () => true,
     ),
@@ -60,10 +57,7 @@ export class TransactionListComponent {
       'Add a disbursement',
       this.createTransactions.bind(this, 'disbursement'),
       (report: Report) => {
-        return (
-          report.report_status === ReportStatus.IN_PROGRESS &&
-          [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type)
-        );
+        return [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type);
       },
       () => true,
     ),
@@ -71,10 +65,7 @@ export class TransactionListComponent {
       'Add loans and debts',
       this.createTransactions.bind(this, 'loans-and-debts'),
       (report: Report) => {
-        return (
-          report.report_status === ReportStatus.IN_PROGRESS &&
-          [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type)
-        );
+        return [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type);
       },
       () => true,
     ),
@@ -82,10 +73,7 @@ export class TransactionListComponent {
       'Add other transactions',
       this.createTransactions.bind(this, 'other-transactions'),
       (report: Report) => {
-        return (
-          report.report_status === ReportStatus.IN_PROGRESS &&
-          [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type)
-        );
+        return [ReportTypes.F3, ReportTypes.F3X].includes(report.report_type);
       },
       () => false,
     ),
@@ -93,7 +81,7 @@ export class TransactionListComponent {
       'Add an independent expenditure',
       this.createF24Transactions.bind(this),
       (report: Report) => {
-        return report.report_status === ReportStatus.IN_PROGRESS && report.report_type === ReportTypes.F24;
+        return report.report_type === ReportTypes.F24;
       },
       () => true,
     ),


### PR DESCRIPTION
Issue: [FECFILE-2924](https://fecgov.atlassian.net/browse/FECFILE-2924)

Fixes 
- the Add Transaction button not having any options.
- Failed reports now have Edit -> list page and review -> status page
- Clicking failed report link goes to status page.