### PR TITLE
feature/3048 - Fix console log error

### DIFF
--- a/front-end/src/app/reports/shared/print-preview/print-preview.component.ts
+++ b/front-end/src/app/reports/shared/print-preview/print-preview.component.ts
@@ -138,7 +138,7 @@ export class PrintPreviewComponent extends DestroyerComponent implements OnInit 
         this.pollPrintStatus();
       }
     } catch (error) {
-      console.error('Error fetching report:', error);
+      if (this.componentAlive) console.error('Error fetching report:', error);
     }
   }
 

--- a/front-end/src/app/reports/shared/print-preview/print-preview.component.ts
+++ b/front-end/src/app/reports/shared/print-preview/print-preview.component.ts
@@ -134,7 +134,10 @@ export class PrintPreviewComponent extends DestroyerComponent implements OnInit 
       const report = await this.reportService.get(this.report.id!);
       this.updatePrintStatus(report);
       await new Promise((resolve) => setTimeout(resolve, this.pollingTime));
-      if (!report.webprint_submission?.fec_status || report.webprint_submission?.fec_status === 'PROCESSING') {
+      if (
+        this.componentAlive &&
+        (!report.webprint_submission?.fec_status || report.webprint_submission?.fec_status === 'PROCESSING')
+      ) {
         this.pollPrintStatus();
       }
     } catch (error) {

--- a/front-end/src/app/shared/components/destroyer.component.ts
+++ b/front-end/src/app/shared/components/destroyer.component.ts
@@ -6,7 +6,9 @@ import { Subject } from 'rxjs';
 })
 export abstract class DestroyerComponent implements OnDestroy {
   destroy$ = new Subject<undefined>();
+  protected componentAlive = true;
   ngOnDestroy(): void {
+    this.componentAlive = false;
     this.destroy$.next(undefined);
     this.destroy$.complete();
   }


### PR DESCRIPTION
Issue [FECFILE-3048](https://fecgov.atlassian.net/browse/FECFILE-3048)

I was able to track down the issue to the PrintPreview component. The issue was that that the polling for the print status was happening as the component was being destroyed and there was a bit of randomness that if the component got destroyed right as it was attempting to do something it would fail and try and to log the error but everything was being torn down around it so the RPC was closed before it had a chance to log. I updated our destroyer component to keep track of component on destroy status to stop the log from happening (which would prevent the specific test failure) and also updated the polling logic so it would stop polling when the component is destroyed rather than erroring out.