### PR TITLE
feature/3058 - Fix text overflow issue on Create Committee Account card

### DIFF
--- a/front-end/src/app/committee/create-committee/create-committee.component.html
+++ b/front-end/src/app/committee/create-committee/create-committee.component.html
@@ -1,11 +1,11 @@
-<div class="flex create-committee-columns">
-  <div class="col-6 left-side">
+<div class="flex">
+  <div class="col-6">
     <h1>Create an account</h1>
     <hr type="solid" />
 
     <img src="assets/img/Create-an-account.png" draggable="false" alt="Users review a chart" />
   </div>
-  <div class="col-6 right-side">
+  <div class="col-6">
     <div class="go-back">
       <a routerLink="/login/select-committee"><i class="pi pi-angle-left"></i> GO BACK</a>
     </div>
@@ -30,13 +30,13 @@
           </ng-template>
         </p-button>
       </p-inputGroup>
-      <p class="search-examples font-karla mt-1">Examples: C00431445, C00343509</p>
+      <p class="font-italic font-karla mt-1">Examples: C00431445, C00343509</p>
     </div>
     @if (selectedCommittee || unableToCreateAccount) {
       <div class="right-side-box">
         <h2 class="m-0">Result</h2>
         @if (selectedCommittee) {
-          <div class="committee-card">
+          <div class="fec-card">
             <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg" />
             <div class="committee-info">
               <h3>{{ selectedCommittee.name }}</h3>
@@ -55,13 +55,13 @@
           </div>
         }
         @if (unableToCreateAccount) {
-          <div class="committee-card unable-card">
-            <div class="unable-excl-img">
-              <img alt="Exclamation mark" src="assets/img/exclamation.svg" />
-            </div>
+          <div class="fec-card vertical-card">
+            <svg alt="Exclamation mark" width="94" height="95">
+              <use href="assets/img/exclamation.svg"></use>
+            </svg>
             <div class="unable-verbiage">
-              <p class="unable-verbiage-p1">Unable to create account</p>
-              <p class="unable-verbiage-p2">CONTACT FECFILE+ TECHNICAL SUPPORT FOR HELP</p>
+              <span class="text-2xl">Unable to create account</span>
+              <span class="small-text">CONTACT FECFILE+ TECHNICAL SUPPORT FOR HELP</span>
             </div>
           </div>
         }

--- a/front-end/src/app/committee/create-committee/create-committee.component.scss
+++ b/front-end/src/app/committee/create-committee/create-committee.component.scss
@@ -1,16 +1,5 @@
-.create-committee-columns {
-  display: flex;
-  flex-direction: row;
-}
 .go-back {
   padding-bottom: 25px;
-}
-
-.left-side {
-  flex-direction: column;
-}
-.right-side {
-  flex-direction: column;
 }
 
 :host ::ng-deep {
@@ -62,37 +51,17 @@ app-dialog p {
   margin-bottom: 1em;
 }
 
-.committee-card {
-  margin: 20px 3px;
-  padding: 20px 10px;
-  display: flex;
-  flex-direction: row;
-  background-color: #ffffff;
-  box-shadow: 0 0 4px 0px #d1d1d1;
-  cursor: pointer;
-}
-.unable-card {
-  height: 200px;
-  flex-direction: column;
-}
-.unable-excl-img {
-  align-self: center;
-}
 .unable-verbiage {
-  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  & > span {
+    text-align: center;
+    font-family: var(--karla-bold);
+  }
 }
-.unable-verbiage-p1 {
-  text-align: center;
-  font-family: var(--karla-bold);
-  font-size: x-large;
-  line-height: normal;
-  margin-bottom: 10px;
-}
-.unable-verbiage-p2 {
-  text-align: center;
-  font-family: var(--karla-bold);
+.small-text {
   font-size: small;
-  line-height: normal;
 }
 .committee-info {
   padding-left: 10px;
@@ -111,8 +80,4 @@ app-dialog p {
   padding: 15px 25px;
   border-radius: 5px;
   margin-bottom: 30px;
-}
-
-.search-examples {
-  font-style: italic;
 }

--- a/front-end/src/app/committee/select-committee/select-committee.component.html
+++ b/front-end/src/app/committee/select-committee/select-committee.component.html
@@ -1,16 +1,16 @@
 <div class="flex select-committee-columns">
-  <div class="col-6 left-side">
+  <div class="col-6">
     <h1>Get started now</h1>
     <span class="h5">LET'S FILE YOUR FEC REPORT WITH FECFILE+...</span>
     <hr type="solid" />
 
     <img src="assets/img/Get started now.jpg" draggable="false" alt="Workers checking a monitor" />
   </div>
-  <div class="col-6 right-side">
+  <div class="col-6">
     <div class="select-committee-box">
       <h2>Select a committee account</h2>
       @if (activeCommittees().length === 0) {
-        <div class="committee-card empty-card">
+        <div class="fec-card vertical-card">
           <svg alt="Magnifying lens" width="95" height="95">
             <use href="assets/img/magnifying_lens.svg"></use>
           </svg>
@@ -19,7 +19,7 @@
       } @else if (activeCommittees().length) {
         <div class="committee-list">
           @for (committee of activeCommittees(); track committee) {
-            <div id="{{ committee.id }}" class="committee-card" (click)="activateCommittee(committee)">
+            <div id="{{ committee.id }}" class="fec-card" (click)="activateCommittee(committee)">
               <img alt="Document with magnifying lens" src="assets/img/document-with-lens.svg" />
               <div class="committee-info">
                 <h3>

--- a/front-end/src/app/committee/select-committee/select-committee.component.scss
+++ b/front-end/src/app/committee/select-committee/select-committee.component.scss
@@ -1,31 +1,9 @@
-.committee-card {
-  margin: 20px 3px;
-  padding: 20px 10px;
-  display: flex;
-  flex-direction: row;
-  background-color: #ffffff;
-  box-shadow: 0 0 4px 0px #d1d1d1;
-  cursor: pointer;
-}
-.empty-card {
-  height: 200px;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-}
-
 .empty-verbiage {
   text-align: center;
   font-size: x-large;
   line-height: 1.14;
 }
 
-.left-side {
-  flex-direction: column;
-}
-.right-side {
-  flex-direction: column;
-}
 .select-committee-box {
   display: flex;
   background-color: #f1f1f1;

--- a/front-end/src/styles.scss
+++ b/front-end/src/styles.scss
@@ -893,3 +893,20 @@ p-accordion-content[data-p-active='false'] > div.p-accordioncontent-content {
   overflow: hidden;
   transition: height 0.3s ease-in-out;
 }
+
+.fec-card {
+  margin: 20px 3px;
+  padding: 20px 10px;
+  display: flex;
+  flex-direction: row;
+  background-color: #ffffff;
+  box-shadow: 0 0 4px 0px #d1d1d1;
+  cursor: pointer;
+}
+
+.vertical-card {
+  min-height: fit-content;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}


### PR DESCRIPTION
Issue [[FECFILE-3058](https://fecgov.atlassian.net/browse/FECFILE-3058)]( and clean up some of the style classes)

Underlying issue was that the height of the card was being forced to 200px so when content exceeded limit it would overflow. We actually had a similar issue on the Select Committee Account screen (though it was less obvious there cause you had to go much smaller for it to be noticeable) where the SVG would shrink to make sure things fit in the 200px limit. 
I updated the styling on both so they utilize the same styling class and fixed the height issue so it will be sized to fit the content. Will now look decent at any screen width. 
I also got rid of a couple dead styles. (For example create-committee-columns wasn't doing anything, we already had it styled as flex and the default is flex-row)