### PR TITLE
feature/735 - Make Conduit Earmark Out count as deposited/undeposited, but hide the selector.

### DIFF
--- a/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.html
+++ b/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.html
@@ -30,16 +30,19 @@
         />
       </div>
     } @else {
-      <div class="col-3 pl-0">
-        <p-selectButton
-          #memoCode
-          inputId="memo_code"
-          [formControlName]="templateMap['memo_code']"
-          [options]="memoCodeMapOptions()"
-          optionLabel="label"
-          optionValue="value"
-        />
-      </div>
+      @if (!memoControl.disabled) {
+        <div class="col-3 pl-0">
+          <p-selectButton
+            #memoCode
+            inputId="memo_code"
+            [formControlName]="templateMap['memo_code']"
+            [options]="memoCodeMapOptions()"
+            optionLabel="label"
+            optionValue="value"
+          />
+        </div>
+      }
+
       <div class="col-12 pl-0">
         @if (memoControl.value) {
           <span class="pi pi-check memo-item-check" pTooltip="{{ memoItemHelpText() }}"></span>

--- a/front-end/src/app/shared/models/transaction-types/common-types/CONDUIT_EARMARK_OUT.model.ts
+++ b/front-end/src/app/shared/models/transaction-types/common-types/CONDUIT_EARMARK_OUT.model.ts
@@ -14,4 +14,8 @@ export abstract class CONDUIT_EARMARK_OUT extends SchBTransactionType {
   override formTitle = undefined;
   override footer = undefined;
   override contactTitle = 'Contact';
+  override memoCodeMap = {
+    true: 'Undeposited',
+    false: 'Deposited',
+  };
 }


### PR DESCRIPTION
Issue [FECFILE-735](https://fecgov.atlassian.net/browse/FECFILE-735)

Updated so both Step 1 and Step 2 will show the UNDEPOSITED text in the popup. As a side effect this changed the memo item of Step 2 to be similar to Step 1. This is actually closer to the end goal.