### PR TITLE
FECFILE-3079: Script to run frontend locally in nginx.

### DIFF
--- a/front-end/README.md
+++ b/front-end/README.md
@@ -1,14 +1,21 @@
-# FecEFile
+# FECfile+
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 6.0.8.
 
 ## Running locally
 
-To run local development environment if Django backend is also running locally at port 8080 run `npm run local`.
+The simplest way to run a local development server is to run `ng serve` or `npx -p @angular/cli ng serve`. You can then navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
-## Development server
+Alternatively, if you want to run the frontend through nginx using a production-like static build and CSP behavior you can run `./scripts/run-nginx-local.sh`
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Useful options:
+- `./scripts/run-nginx-local.sh --env=dev`
+- `./scripts/run-nginx-local.sh --env=stage`
+- `./scripts/run-nginx-local.sh --env=test`
+- `./scripts/run-nginx-local.sh --env=prod`
+- `./scripts/run-nginx-local.sh --api-url=http://localhost:8080/api/v1/ --port=4200`
+
+This command builds the Angular app, renders a local nginx config from `../deploy-config/front-end-nginx-config/nginx.conf`, and starts `nginx:alpine` with the built files mounted at `/usr/share/nginx/html/fecfile-web`.
 
 ## Code scaffolding
 

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -9,6 +9,7 @@ The simplest way to run a local development server is to run `ng serve` or `npx 
 Alternatively, if you want to run the frontend through nginx using a production-like static build and CSP behavior you can run `./scripts/run-nginx-local.sh`
 
 Useful options:
+
 - `./scripts/run-nginx-local.sh --env=dev`
 - `./scripts/run-nginx-local.sh --env=stage`
 - `./scripts/run-nginx-local.sh --env=test`

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -12,10 +12,7 @@ Useful options:
 
 - `./scripts/run-nginx-local.sh --help`
 - `./scripts/run-nginx-local.sh --watch`
-- `./scripts/run-nginx-local.sh --env=dev`
-- `./scripts/run-nginx-local.sh --env=stage`
-- `./scripts/run-nginx-local.sh --env=test`
-- `./scripts/run-nginx-local.sh --env=prod`
+- `./scripts/run-nginx-local.sh --env=[dev|stage|test|prod]`
 - `./scripts/run-nginx-local.sh --api-url=http://localhost:8080/api/v1/ --port=4200`
 
 This command builds the Angular app, renders a local nginx config from `../deploy-config/front-end-nginx-config/nginx.conf`, and starts `nginx:alpine` with the built files mounted at `/usr/share/nginx/html/fecfile-web`.

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -10,6 +10,8 @@ Alternatively, if you want to run the frontend through nginx using a production-
 
 Useful options:
 
+- `./scripts/run-nginx-local.sh --help`
+- `./scripts/run-nginx-local.sh --watch`
 - `./scripts/run-nginx-local.sh --env=dev`
 - `./scripts/run-nginx-local.sh --env=stage`
 - `./scripts/run-nginx-local.sh --env=test`

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -74,10 +74,6 @@ esac
 PUBLIC_PORT="$PORT"
 NGINX_PORT="$PORT"
 
-if [[ "$WATCH" == "1" ]]; then
-  NGINX_PORT="$((PORT + 10))"
-fi
-
 if [[ -z "$APP_URL" ]]; then
   APP_URL="http://localhost:$PUBLIC_PORT"
 fi
@@ -99,14 +95,17 @@ if [[ ! -f "$TEMPLATE_PATH" ]]; then
   exit 1
 fi
 
-if [[ "$WATCH" == "1" ]] && ! command -v inotifywait >/dev/null 2>&1; then
-  echo "--watch requires inotifywait (install inotify-tools)." >&2
-  exit 1
-fi
+if [[ "$WATCH" == "1" ]]; then
+  NGINX_PORT="$((PORT + 10))"
+  if ! command -v inotifywait >/dev/null 2>&1; then
+    echo "--watch requires inotifywait (install inotify-tools)." >&2
+    exit 1
+  fi
 
-if [[ "$WATCH" == "1" ]] && ! command -v npx >/dev/null 2>&1; then
-  echo "--watch requires npx to run BrowserSync." >&2
-  exit 1
+  if ! command -v npx >/dev/null 2>&1; then
+    echo "--watch requires npx to run BrowserSync." >&2
+    exit 1
+  fi
 fi
 
 DIST_DIR="$FRONTEND_DIR/dist/fecfile-web"

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -25,6 +25,9 @@ CYPRESS_PASSWORD="${CYPRESS_PASSWORD:-test}"
 WATCH="0"
 CONTAINER_NAME="fecfile-nginx-local"
 LOGS_PID=""
+BROWSER_SYNC_PID=""
+PUBLIC_PORT=""
+NGINX_PORT=""
 
 usage() {
   cat <<'EOF'
@@ -32,7 +35,7 @@ Usage: ./scripts/run-nginx-local.sh [options]
 
 Options:
   --env=<dev|stage|test|prod|local>  Angular build target (default: local)
-  --port=<port>                       Nginx listen port (default: 4200)
+  --port=<port>                       Browser-facing port (default: 4200)
   --api-url=<url>                     API origin or API URL for CSP connect-src (default: http://localhost:8080)
   --app-url=<url>                     Frontend URL for report endpoint (default: http://localhost:<port>)
   --watch                             Watch frontend files and rebuild on changes
@@ -72,8 +75,15 @@ case "$TARGET_ENV" in
     ;;
 esac
 
+PUBLIC_PORT="$PORT"
+NGINX_PORT="$PORT"
+
+if [[ "$WATCH" == "1" ]]; then
+  NGINX_PORT="$((PORT + 10))"
+fi
+
 if [[ -z "$APP_URL" ]]; then
-  APP_URL="http://localhost:$PORT"
+  APP_URL="http://localhost:$PUBLIC_PORT"
 fi
 
 if [[ "$API_URL" =~ ^https?://[^/]+ ]]; then
@@ -98,11 +108,19 @@ if [[ "$WATCH" == "1" ]] && ! command -v inotifywait >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ "$WATCH" == "1" ]] && ! command -v npx >/dev/null 2>&1; then
+  echo "--watch requires npx to run BrowserSync." >&2
+  exit 1
+fi
+
 DIST_DIR="$FRONTEND_DIR/dist/fecfile-web"
 CONTAINER_NAME="${CONTAINER_NAME}-${PORT}"
 
 cleanup() {
   rm -f "$TMP_CONF"
+  if [[ -n "$BROWSER_SYNC_PID" ]]; then
+    kill "$BROWSER_SYNC_PID" >/dev/null 2>&1 || true
+  fi
   if [[ -n "$LOGS_PID" ]]; then
     kill "$LOGS_PID" >/dev/null 2>&1 || true
   fi
@@ -126,17 +144,49 @@ render_nginx_config() {
   echo "Rendering Nginx config to $TMP_CONF ..."
   sed \
     -e "/^daemon off;/d" \
-    -e "s|{{port}}|$PORT|g" \
+    -e "s|{{port}}|$NGINX_PORT|g" \
     -e "s|{{env \"FECFILE_APP_URL\"}}|$APP_URL|g" \
     -e "s|{{env \"FECFILE_API_URL\"}}|$CSP_API_ORIGIN|g" \
     -e "s|root fecfile-web;|root /usr/share/nginx/html/fecfile-web;|g" \
     "$TEMPLATE_PATH" > "$TMP_CONF"
+
+  if [[ "$WATCH" == "1" ]]; then
+    local script_src_replacement="script-src 'self' 'nonce-\$nonce' http://localhost:$PUBLIC_PORT 'unsafe-inline';"
+    local connect_src_replacement="connect-src 'self' $CSP_API_ORIGIN http://localhost:$PUBLIC_PORT ws://localhost:$PUBLIC_PORT;"
+    local browser_sync_script
+    browser_sync_script='sub_filter '\''</body>'\'' '\''<script nonce="$nonce" async src="http://localhost:'"$PUBLIC_PORT"'/browser-sync/browser-sync-client.js"></script></body>'\'';'
+
+    sed -i \
+      -e "s|script-src 'self' 'nonce-\\\$nonce';|$script_src_replacement|" \
+      -e "s|connect-src 'self' $CSP_API_ORIGIN;|$connect_src_replacement|" \
+      "$TMP_CONF"
+
+    sed -i "/sub_filter web_app_nonce \\\$nonce;/a\\
+      $browser_sync_script" "$TMP_CONF"
+  fi
+}
+
+start_browser_sync() {
+  echo "Starting BrowserSync on http://localhost:$PUBLIC_PORT ..."
+  NODE_OPTIONS="--insecure-http-parser" npx -y browser-sync start \
+    --proxy "http://127.0.0.1:$NGINX_PORT" \
+    --port "$PUBLIC_PORT" \
+    --no-open \
+    --no-ui \
+    --no-snippet >/dev/null 2>&1 &
+  BROWSER_SYNC_PID="$!"
+}
+
+trigger_browser_reload() {
+  # Reload only after a successful rebuild to avoid serving stale chunks.
+  npx -y browser-sync reload --port "$PUBLIC_PORT" >/dev/null 2>&1 || \
+    echo "Warning: BrowserSync reload trigger failed." >&2
 }
 
 start_nginx() {
   local mode="$1"
 
-  echo "Starting Nginx in $mode mode on http://localhost:$PORT ..."
+  echo "Starting Nginx in $mode mode on http://localhost:$NGINX_PORT ..."
   if [[ "$mode" == "watch" ]]; then
     docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
     local docker_opt="-d"
@@ -146,7 +196,7 @@ start_nginx() {
   fi
 
   docker run $docker_opt --rm --name "$CONTAINER_NAME" \
-    -p "$PORT:$PORT" \
+    -p "$NGINX_PORT:$NGINX_PORT" \
     -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
     -e "FEC_API=$FEC_API" \
     -e "FEC_API_KEY=$FEC_API_KEY" \
@@ -157,17 +207,19 @@ start_nginx() {
     nginx:alpine >/dev/null
 
   if [[ "$mode" == "watch" ]]; then
+    start_browser_sync
     docker logs -f "$CONTAINER_NAME" &
     LOGS_PID="$!"
 
     echo "Watching for changes under $FRONTEND_DIR/src ..."
-    echo "Press Ctrl+C to stop."
+    echo "Open http://localhost:$PUBLIC_PORT and press Ctrl+C to stop."
     while inotifywait -r -e modify,create,delete,move \
       --exclude '(^|/)(dist|node_modules|\.git)(/|$)' \
       "$FRONTEND_DIR/src" "$FRONTEND_DIR/angular.json" "$FRONTEND_DIR/tsconfig.app.json" "$FRONTEND_DIR/tsconfig.json" >/dev/null 2>&1; do
       echo "Change detected. Rebuilding..."
       if build_frontend; then
         echo "Rebuild complete."
+        trigger_browser_reload
       else
         echo "Rebuild failed. Nginx is still serving the last successful build." >&2
       fi

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
+TEMPLATE_PATH="$REPO_ROOT/deploy-config/front-end-nginx-config/nginx.conf"
+TMP_CONF="${TMPDIR:-/tmp}/fecfile-nginx-local.conf"
+
+cleanup() {
+  rm -f "$TMP_CONF"
+}
+
+trap cleanup EXIT
+
+PORT="4200"
+TARGET_ENV="local"
+API_URL="http://localhost:8080"
+APP_URL=""
+DJANGO_SECRET_KEY="${DJANGO_SECRET_KEY:-If_using_test_db_use_secret_key_in_cloud.gov}"
+FEC_API="${FEC_API:-https://api.open.fec.gov/v1/}"
+FEC_API_KEY="${FEC_API_KEY:-DEMO_KEY}"
+CYPRESS_COMMITTEE_ID="${CYPRESS_COMMITTEE_ID:-C99999999}"
+CYPRESS_PASSWORD="${CYPRESS_PASSWORD:-test}"
+
+usage() {
+  cat <<'EOF'
+Usage: npm run start:nginx-local -- [options]
+
+Options:
+  --env=<dev|stage|test|prod|local>  Angular build target (default: local)
+  --port=<port>                       Nginx listen port (default: 4200)
+  --api-url=<url>                     API origin or API URL for CSP connect-src (default: http://localhost:8080)
+  --app-url=<url>                     Frontend URL for report endpoint (default: http://localhost:<port>)
+  -h, --help                          Show this help text
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --env=*) TARGET_ENV="${arg#*=}" ;;
+    --port=*) PORT="${arg#*=}" ;;
+    --api-url=*) API_URL="${arg#*=}" ;;
+    --app-url=*) APP_URL="${arg#*=}" ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+case "$TARGET_ENV" in
+  local) BUILD_SCRIPT="build-local" ;;
+  dev) BUILD_SCRIPT="build-dev" ;;
+  stage) BUILD_SCRIPT="build-stage" ;;
+  test) BUILD_SCRIPT="build-test" ;;
+  prod) BUILD_SCRIPT="build-prod" ;;
+  *)
+    echo "Invalid --env value: $TARGET_ENV" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+if [[ -z "$APP_URL" ]]; then
+  APP_URL="http://localhost:$PORT"
+fi
+
+if [[ "$API_URL" =~ ^https?://[^/]+ ]]; then
+  CSP_API_ORIGIN="${BASH_REMATCH[0]}"
+else
+  echo "--api-url must start with http:// or https://" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to run local Nginx." >&2
+  exit 1
+fi
+
+if [[ ! -f "$TEMPLATE_PATH" ]]; then
+  echo "Nginx template not found at $TEMPLATE_PATH" >&2
+  exit 1
+fi
+
+echo "Building frontend using npm run $BUILD_SCRIPT ..."
+cd "$FRONTEND_DIR"
+npm run "$BUILD_SCRIPT"
+
+DIST_DIR="$FRONTEND_DIR/dist/fecfile-web"
+if [[ ! -f "$DIST_DIR/index.html" ]]; then
+  echo "Build output not found at $DIST_DIR" >&2
+  exit 1
+fi
+
+echo "Rendering Nginx config to $TMP_CONF ..."
+sed \
+  -e "/^daemon off;/d" \
+  -e "s|{{port}}|$PORT|g" \
+  -e "s|{{env \"FECFILE_APP_URL\"}}|$APP_URL|g" \
+  -e "s|{{env \"FECFILE_API_URL\"}}|$CSP_API_ORIGIN|g" \
+  -e "s|root fecfile-web;|root /usr/share/nginx/html/fecfile-web;|g" \
+  "$TEMPLATE_PATH" > "$TMP_CONF"
+
+echo "Starting Nginx on http://localhost:$PORT ..."
+echo "Press Ctrl+C to stop."
+docker run --rm \
+  -p "$PORT:$PORT" \
+  -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
+  -e "FEC_API=$FEC_API" \
+  -e "FEC_API_KEY=$FEC_API_KEY" \
+  -e "CYPRESS_COMMITTEE_ID=$CYPRESS_COMMITTEE_ID" \
+  -e "CYPRESS_PASSWORD=$CYPRESS_PASSWORD" \
+  -v "$DIST_DIR:/usr/share/nginx/html/fecfile-web:ro" \
+  -v "$TMP_CONF:/etc/nginx/nginx.conf:ro" \
+  nginx:alpine

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -114,13 +114,14 @@ CONTAINER_NAME="${CONTAINER_NAME}-${PORT}"
 
 cleanup() {
   rm -f "$TMP_CONF"
-  if [[ -n "$BROWSER_SYNC_PID" ]]; then
-    kill "$BROWSER_SYNC_PID" >/dev/null 2>&1 || true
-  fi
-  if [[ -n "$LOGS_PID" ]]; then
-    kill "$LOGS_PID" >/dev/null 2>&1 || true
-  fi
   if [[ "$WATCH" == "1" ]]; then
+    if [[ -n "$BROWSER_SYNC_PID" ]]; then
+      kill "$BROWSER_SYNC_PID" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$LOGS_PID" ]]; then
+      kill "$LOGS_PID" >/dev/null 2>&1 || true
+    fi
+
     docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
   fi
 }

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -22,16 +22,20 @@ FEC_API="${FEC_API:-https://api.open.fec.gov/v1/}"
 FEC_API_KEY="${FEC_API_KEY:-DEMO_KEY}"
 CYPRESS_COMMITTEE_ID="${CYPRESS_COMMITTEE_ID:-C99999999}"
 CYPRESS_PASSWORD="${CYPRESS_PASSWORD:-test}"
+WATCH="0"
+CONTAINER_NAME="fecfile-nginx-local"
+LOGS_PID=""
 
 usage() {
   cat <<'EOF'
-Usage: npm run start:nginx-local -- [options]
+Usage: ./scripts/run-nginx-local.sh [options]
 
 Options:
   --env=<dev|stage|test|prod|local>  Angular build target (default: local)
   --port=<port>                       Nginx listen port (default: 4200)
   --api-url=<url>                     API origin or API URL for CSP connect-src (default: http://localhost:8080)
   --app-url=<url>                     Frontend URL for report endpoint (default: http://localhost:<port>)
+  --watch                             Watch frontend files and rebuild on changes
   -h, --help                          Show this help text
 EOF
 }
@@ -42,6 +46,7 @@ for arg in "$@"; do
     --port=*) PORT="${arg#*=}" ;;
     --api-url=*) API_URL="${arg#*=}" ;;
     --app-url=*) APP_URL="${arg#*=}" ;;
+    --watch) WATCH="1" ;;
     -h|--help)
       usage
       exit 0
@@ -88,34 +93,97 @@ if [[ ! -f "$TEMPLATE_PATH" ]]; then
   exit 1
 fi
 
-echo "Building frontend using npm run $BUILD_SCRIPT ..."
-cd "$FRONTEND_DIR"
-npm run "$BUILD_SCRIPT"
-
-DIST_DIR="$FRONTEND_DIR/dist/fecfile-web"
-if [[ ! -f "$DIST_DIR/index.html" ]]; then
-  echo "Build output not found at $DIST_DIR" >&2
+if [[ "$WATCH" == "1" ]] && ! command -v inotifywait >/dev/null 2>&1; then
+  echo "--watch requires inotifywait (install inotify-tools)." >&2
   exit 1
 fi
 
-echo "Rendering Nginx config to $TMP_CONF ..."
-sed \
-  -e "/^daemon off;/d" \
-  -e "s|{{port}}|$PORT|g" \
-  -e "s|{{env \"FECFILE_APP_URL\"}}|$APP_URL|g" \
-  -e "s|{{env \"FECFILE_API_URL\"}}|$CSP_API_ORIGIN|g" \
-  -e "s|root fecfile-web;|root /usr/share/nginx/html/fecfile-web;|g" \
-  "$TEMPLATE_PATH" > "$TMP_CONF"
+DIST_DIR="$FRONTEND_DIR/dist/fecfile-web"
+CONTAINER_NAME="${CONTAINER_NAME}-${PORT}"
 
-echo "Starting Nginx on http://localhost:$PORT ..."
-echo "Press Ctrl+C to stop."
-docker run --rm \
-  -p "$PORT:$PORT" \
-  -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
-  -e "FEC_API=$FEC_API" \
-  -e "FEC_API_KEY=$FEC_API_KEY" \
-  -e "CYPRESS_COMMITTEE_ID=$CYPRESS_COMMITTEE_ID" \
-  -e "CYPRESS_PASSWORD=$CYPRESS_PASSWORD" \
-  -v "$DIST_DIR:/usr/share/nginx/html/fecfile-web:ro" \
-  -v "$TMP_CONF:/etc/nginx/nginx.conf:ro" \
-  nginx:alpine
+cleanup() {
+  rm -f "$TMP_CONF"
+  if [[ -n "$LOGS_PID" ]]; then
+    kill "$LOGS_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$WATCH" == "1" ]]; then
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+}
+
+build_frontend() {
+  echo "Building frontend using npm run $BUILD_SCRIPT ..."
+  cd "$FRONTEND_DIR"
+  npm run "$BUILD_SCRIPT"
+
+  if [[ ! -f "$DIST_DIR/index.html" ]]; then
+    echo "Build output not found at $DIST_DIR" >&2
+    exit 1
+  fi
+}
+
+render_nginx_config() {
+  echo "Rendering Nginx config to $TMP_CONF ..."
+  sed \
+    -e "/^daemon off;/d" \
+    -e "s|{{port}}|$PORT|g" \
+    -e "s|{{env \"FECFILE_APP_URL\"}}|$APP_URL|g" \
+    -e "s|{{env \"FECFILE_API_URL\"}}|$CSP_API_ORIGIN|g" \
+    -e "s|root fecfile-web;|root /usr/share/nginx/html/fecfile-web;|g" \
+    "$TEMPLATE_PATH" > "$TMP_CONF"
+}
+
+start_nginx_foreground() {
+  echo "Starting Nginx on http://localhost:$PORT ..."
+  echo "Press Ctrl+C to stop."
+  docker run --rm \
+    -p "$PORT:$PORT" \
+    -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
+    -e "FEC_API=$FEC_API" \
+    -e "FEC_API_KEY=$FEC_API_KEY" \
+    -e "CYPRESS_COMMITTEE_ID=$CYPRESS_COMMITTEE_ID" \
+    -e "CYPRESS_PASSWORD=$CYPRESS_PASSWORD" \
+    -v "$DIST_DIR:/usr/share/nginx/html/fecfile-web:ro" \
+    -v "$TMP_CONF:/etc/nginx/nginx.conf:ro" \
+    nginx:alpine
+}
+
+start_nginx_watch_mode() {
+  echo "Starting Nginx watch mode on http://localhost:$PORT ..."
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker run -d --rm --name "$CONTAINER_NAME" \
+    -p "$PORT:$PORT" \
+    -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
+    -e "FEC_API=$FEC_API" \
+    -e "FEC_API_KEY=$FEC_API_KEY" \
+    -e "CYPRESS_COMMITTEE_ID=$CYPRESS_COMMITTEE_ID" \
+    -e "CYPRESS_PASSWORD=$CYPRESS_PASSWORD" \
+    -v "$DIST_DIR:/usr/share/nginx/html/fecfile-web:ro" \
+    -v "$TMP_CONF:/etc/nginx/nginx.conf:ro" \
+    nginx:alpine >/dev/null
+
+  docker logs -f "$CONTAINER_NAME" &
+  LOGS_PID="$!"
+
+  echo "Watching for changes under $FRONTEND_DIR/src ..."
+  echo "Press Ctrl+C to stop."
+  while inotifywait -r -e modify,create,delete,move \
+    --exclude '(^|/)(dist|node_modules|\.git)(/|$)' \
+    "$FRONTEND_DIR/src" "$FRONTEND_DIR/angular.json" "$FRONTEND_DIR/tsconfig.app.json" "$FRONTEND_DIR/tsconfig.json" >/dev/null 2>&1; do
+    echo "Change detected. Rebuilding..."
+    if build_frontend; then
+      echo "Rebuild complete."
+    else
+      echo "Rebuild failed. Nginx is still serving the last successful build." >&2
+    fi
+  done
+}
+
+build_frontend
+render_nginx_config
+
+if [[ "$WATCH" == "1" ]]; then
+  start_nginx_watch_mode
+else
+  start_nginx_foreground
+fi

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -7,10 +7,6 @@ REPO_ROOT="$(cd "$FRONTEND_DIR/.." && pwd)"
 TEMPLATE_PATH="$REPO_ROOT/deploy-config/front-end-nginx-config/nginx.conf"
 TMP_CONF="${TMPDIR:-/tmp}/fecfile-nginx-local.conf"
 
-cleanup() {
-  rm -f "$TMP_CONF"
-}
-
 trap cleanup EXIT
 
 PORT="4200"

--- a/front-end/scripts/run-nginx-local.sh
+++ b/front-end/scripts/run-nginx-local.sh
@@ -133,25 +133,19 @@ render_nginx_config() {
     "$TEMPLATE_PATH" > "$TMP_CONF"
 }
 
-start_nginx_foreground() {
-  echo "Starting Nginx on http://localhost:$PORT ..."
-  echo "Press Ctrl+C to stop."
-  docker run --rm \
-    -p "$PORT:$PORT" \
-    -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
-    -e "FEC_API=$FEC_API" \
-    -e "FEC_API_KEY=$FEC_API_KEY" \
-    -e "CYPRESS_COMMITTEE_ID=$CYPRESS_COMMITTEE_ID" \
-    -e "CYPRESS_PASSWORD=$CYPRESS_PASSWORD" \
-    -v "$DIST_DIR:/usr/share/nginx/html/fecfile-web:ro" \
-    -v "$TMP_CONF:/etc/nginx/nginx.conf:ro" \
-    nginx:alpine
-}
+start_nginx() {
+  local mode="$1"
 
-start_nginx_watch_mode() {
-  echo "Starting Nginx watch mode on http://localhost:$PORT ..."
-  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-  docker run -d --rm --name "$CONTAINER_NAME" \
+  echo "Starting Nginx in $mode mode on http://localhost:$PORT ..."
+  if [[ "$mode" == "watch" ]]; then
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    local docker_opt="-d"
+  else
+    echo "Press Ctrl+C to stop."
+    local docker_opt=""
+  fi
+
+  docker run $docker_opt --rm --name "$CONTAINER_NAME" \
     -p "$PORT:$PORT" \
     -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" \
     -e "FEC_API=$FEC_API" \
@@ -162,28 +156,30 @@ start_nginx_watch_mode() {
     -v "$TMP_CONF:/etc/nginx/nginx.conf:ro" \
     nginx:alpine >/dev/null
 
-  docker logs -f "$CONTAINER_NAME" &
-  LOGS_PID="$!"
+  if [[ "$mode" == "watch" ]]; then
+    docker logs -f "$CONTAINER_NAME" &
+    LOGS_PID="$!"
 
-  echo "Watching for changes under $FRONTEND_DIR/src ..."
-  echo "Press Ctrl+C to stop."
-  while inotifywait -r -e modify,create,delete,move \
-    --exclude '(^|/)(dist|node_modules|\.git)(/|$)' \
-    "$FRONTEND_DIR/src" "$FRONTEND_DIR/angular.json" "$FRONTEND_DIR/tsconfig.app.json" "$FRONTEND_DIR/tsconfig.json" >/dev/null 2>&1; do
-    echo "Change detected. Rebuilding..."
-    if build_frontend; then
-      echo "Rebuild complete."
-    else
-      echo "Rebuild failed. Nginx is still serving the last successful build." >&2
-    fi
-  done
+    echo "Watching for changes under $FRONTEND_DIR/src ..."
+    echo "Press Ctrl+C to stop."
+    while inotifywait -r -e modify,create,delete,move \
+      --exclude '(^|/)(dist|node_modules|\.git)(/|$)' \
+      "$FRONTEND_DIR/src" "$FRONTEND_DIR/angular.json" "$FRONTEND_DIR/tsconfig.app.json" "$FRONTEND_DIR/tsconfig.json" >/dev/null 2>&1; do
+      echo "Change detected. Rebuilding..."
+      if build_frontend; then
+        echo "Rebuild complete."
+      else
+        echo "Rebuild failed. Nginx is still serving the last successful build." >&2
+      fi
+    done
+  fi
 }
 
 build_frontend
 render_nginx_config
 
 if [[ "$WATCH" == "1" ]]; then
-  start_nginx_watch_mode
+  start_nginx watch
 else
-  start_nginx_foreground
+  start_nginx foreground
 fi


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3079

Related PRs:
N/A

Run the script (assuming you are already in `frontend/`) with `./scripts/run-nginx-local.sh`.

There are many command line arguments available. The defaults are sufficient for running the frontend locally on port 4200 like `ng serve`.

If you run `./scripts/run-nginx-local.sh --watch` it will run in watch mode where it watches for edits to frontend files and when detected rebuilds the app and sends a signal to the browser to reload -- just like `ng serve`!

