### PR TITLE
[RELEASE/Sprint-84] feature/2966 - Fix a few validation issues related to strings being used for dates

### DIFF
--- a/front-end/src/app/shared/components/calendar/calendar.component.html
+++ b/front-end/src/app/shared/components/calendar/calendar.component.html
@@ -3,9 +3,8 @@
   <p-datepicker
     #datepicker
     appendTo="body"
-    (onFocus)="calendarOpened = true"
-    (onClose)="validateDate(false)"
-    (onBlur)="validateDate(calendarOpened)"
+    (onClose)="validateDate()"
+    (onBlur)="validateDate()"
     [inputId]="fieldName()"
     [name]="fieldName()"
     [formControl]="control()!"

--- a/front-end/src/app/shared/components/calendar/calendar.component.spec.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.spec.ts
@@ -55,19 +55,11 @@ describe('CalendarComponent', () => {
     expect(component.control()!.updateOn).toBe('blur');
   });
 
-  it('should toggle calendarOpened on validateDate', () => {
-    component.validateDate(true);
-    expect(component.calendarOpened).toBe(true);
-
-    component.validateDate(false);
-    expect(component.calendarOpened).toBe(false);
-  });
-
   it('should mark control as touched and update value on updateValue', () => {
     const dateString = '01/01/2020';
     const expectedDate = new Date(dateString);
     component.control()?.setValue(expectedDate);
-    component.validateDate(false);
+    component.validateDate();
 
     expect(component.control()!.touched).toBe(true);
     expect(component.control()!.value).toEqual(expectedDate);

--- a/front-end/src/app/shared/components/calendar/calendar.component.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.ts
@@ -23,7 +23,6 @@ export class CalendarComponent {
   readonly datePicker = viewChild.required(DatePicker);
   readonly invalidFormatMessage = input('This date does not follow the correct format, e.g. 01/01/2020');
 
-  calendarOpened = false;
   readonly control = computed(() => {
     const field = this.fieldName();
     const control = this.form()?.get(field);
@@ -46,15 +45,14 @@ export class CalendarComponent {
     });
   }
 
-  validateDate(calendarUpdate: boolean) {
-    this.calendarOpened = calendarUpdate;
+  validateDate() {
     const control = this.control();
 
-    if (!this.calendarOpened && control) {
+    if (control) {
       const inputElement = document.getElementById(this.fieldName()) as HTMLInputElement;
       const currentValue = inputElement?.value;
 
-      if ((!currentValue && currentValue !== 'MM/DD/YYYY') || currentValue.replace(/[_/]/g, '') === '') {
+      if ((!currentValue && currentValue !== 'MM/DD/YYYY') || currentValue.replaceAll(/[_/]/g, '') === '') {
         control.setValue(null);
       } else {
         const date = new Date(currentValue);

--- a/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.ts
+++ b/front-end/src/app/shared/components/inputs/memo-code/memo-code.component.ts
@@ -92,7 +92,12 @@ export class MemoCodeInputComponent extends BaseInputComponent implements OnInit
 
         return { activeDate, isDisbursement };
       }),
-      distinctUntilChanged((prev, curr) => prev.activeDate?.getTime() === curr.activeDate?.getTime()),
+      distinctUntilChanged((prev, curr) => {
+        const prevDate = prev.activeDate;
+        const currDate = curr.activeDate;
+        if (prevDate instanceof Date && currDate instanceof Date) return prevDate.getTime() === currDate.getTime();
+        return false;
+      }),
     );
 
     this.memoControl = this.form.get(this.templateMap.memo_code) as SubscriptionFormControl<boolean>;
@@ -157,14 +162,14 @@ export class MemoCodeInputComponent extends BaseInputComponent implements OnInit
     return date >= coverageFromDate && date <= coverageThroughDate;
   }
 
-  updateMemoItemWithDate(date: Date | null | undefined) {
+  updateMemoItemWithDate(date: Date | null | undefined | string) {
     const coverageFromDate = this.coverageFromDate();
     const coverageThrough = this.coverageThroughDate();
     if (!this.transactionType()?.doMemoCodeDateCheck || !coverageFromDate || !coverageThrough) {
       return;
     }
 
-    if (!date || this.isMemoDateWithinCoverage(date, coverageFromDate, coverageThrough)) {
+    if (!date || !(date instanceof Date) || this.isMemoDateWithinCoverage(date, coverageFromDate, coverageThrough)) {
       this.clearOutOfDateRequirement();
       return;
     }

--- a/front-end/src/app/shared/pipes/fec-date.pipe.ts
+++ b/front-end/src/app/shared/pipes/fec-date.pipe.ts
@@ -3,7 +3,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 @Pipe({ name: 'fecDate' })
 export class FecDatePipe implements PipeTransform {
   transform(value: Date | undefined | null): string {
-    if (!value) return '';
+    if (!(value instanceof Date)) return '';
     return new Intl.DateTimeFormat('en-US', {
       month: '2-digit',
       day: '2-digit',

--- a/front-end/src/app/shared/services/transaction.service.ts
+++ b/front-end/src/app/shared/services/transaction.service.ts
@@ -35,7 +35,7 @@ export class TransactionService {
     contact_1_id: string,
     action_date: Date | string,
   ): Promise<number | null> {
-    const date = action_date ? formatDate(action_date, 'yyyy-MM-dd', 'en-US') : '';
+    const date = this.getActionDateString(action_date);
 
     return this.fetchPreviousAggregate(
       transaction,
@@ -75,7 +75,7 @@ export class TransactionService {
     expenditure_date: Date | string,
     general_election_year: string | undefined,
   ): Promise<number | null> {
-    const date = expenditure_date ? formatDate(expenditure_date, 'yyyy-MM-dd', 'en-US') : '';
+    const date = this.getActionDateString(expenditure_date);
     const contact_2_id = contact2Id ?? '';
 
     return this.fetchPreviousAggregate(
@@ -153,15 +153,17 @@ export class TransactionService {
     return payload;
   }
 
-  private getActionDateString(
-    disbursement_date: string | Date | undefined,
-    dissemination_date: string | Date | undefined,
-  ): string {
+  private readonly dateRegex = /^\d{2}\/\d{2}\/\d{4}$/;
+  private isValidFormat(dateStr: string): boolean {
+    return this.dateRegex.test(dateStr);
+  }
+
+  private getActionDateString(date1: string | Date | undefined, date2?: string | Date | undefined): string {
     let actionDateString: string = '';
-    if (disbursement_date !== '')
-      actionDateString = disbursement_date ? formatDate(disbursement_date, 'yyyy-MM-dd', 'en-US') : '';
-    if (actionDateString.length === 0 && dissemination_date !== '') {
-      actionDateString = dissemination_date ? formatDate(dissemination_date, 'yyyy-MM-dd', 'en-US') : '';
+    if (date1 && (date1 instanceof Date || this.isValidFormat(date1)))
+      actionDateString = date1 ? formatDate(date1, 'yyyy-MM-dd', 'en-US') : '';
+    if (actionDateString.length === 0 && date2 && (date2 instanceof Date || this.isValidFormat(date2))) {
+      actionDateString = date2 ? formatDate(date2, 'yyyy-MM-dd', 'en-US') : '';
     }
     return actionDateString;
   }

--- a/front-end/src/app/shared/utils/date.utils.ts
+++ b/front-end/src/app/shared/utils/date.utils.ts
@@ -21,8 +21,8 @@ export class DateUtils {
    * @param {Date} date
    * @returns {string} mm/dd/yyyy formatted date string
    */
-  public static convertDateToSlashFormat(date: Date | null | undefined): string {
-    if (!date) {
+  public static convertDateToSlashFormat(date: Date | null | undefined | string): string {
+    if (!(date instanceof Date)) {
       return '';
     }
     return new Intl.DateTimeFormat('en-US', {
@@ -42,12 +42,12 @@ export class DateUtils {
     const parts = dateStr.split('-');
     if (parts.length !== 3) return null;
 
-    const year = parseInt(parts[0], 10);
-    const month = parseInt(parts[1], 10) - 1;
-    const day = parseInt(parts[2], 10);
+    const year = Number.parseInt(parts[0], 10);
+    const month = Number.parseInt(parts[1], 10) - 1;
+    const day = Number.parseInt(parts[2], 10);
 
     const date = new Date(year, month, day);
-    return isNaN(date.getTime()) ? null : date;
+    return Number.isNaN(date.getTime()) ? null : date;
   }
 
   /**
@@ -70,6 +70,6 @@ export class DateUtils {
     if (!dateString) return null;
     const date = new Date(dateString);
     // Check if the date is valid
-    return isNaN(date.getTime()) ? null : date;
+    return Number.isNaN(date.getTime()) ? null : date;
   }
 }


### PR DESCRIPTION
Issue [FECFILE-2966](https://fecgov.atlassian.net/browse/FECFILE-2966)

This fixes a few of the wonky validation issues we were having. All of our validations were built with the date being either a date object or null/undefined. However, now they can be strings which are then turned into dates if possible. There were a few things crashing when they received a string like "04/01/20YY" I added some checks to make sure the string being passed is a full date string.
I also fixed an issue where the invalid date format was briefly displaying when the format was correct.