### PR TITLE
Fix issue with second date input not grabbing first input

### DIFF
--- a/front-end/src/app/shared/components/calendar/calendar.component.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.ts
@@ -49,8 +49,7 @@ export class CalendarComponent {
     const control = this.control();
 
     if (control) {
-      const inputElement = document.getElementById(this.fieldName()) as HTMLInputElement;
-      const currentValue = inputElement?.value;
+      const currentValue = this.datePicker().el.nativeElement.children[0].value;
 
       if ((!currentValue && currentValue !== 'MM/DD/YYYY') || currentValue.replaceAll(/[_/]/g, '') === '') {
         control.setValue(null);


### PR DESCRIPTION
Fixes an issue with the calendar where it was grabbing the first transaction date when trying to convert string to date of the second transaction in a double transaction.