### PR TITLE
correct warning condition

### DIFF
--- a/front-end/src/app/layout/layout.component.html
+++ b/front-end/src/app/layout/layout.component.html
@@ -76,7 +76,7 @@
   <button (click)="toggleSidebar()">Toggle Sidebar</button>
 }
 
-@if (!layoutControls().useServiceUnavailableLoginBanner && serviceAvailable() !== false) {
+@if (!layoutControls().useServiceUnavailableLoginBanner && serviceAvailable() !== true) {
   <app-dialog
     aria-labelledby="dialog-title"
     title="We've detected a problem"


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2014

<img width="807" height="836" alt="image" src="https://github.com/user-attachments/assets/9fe28ca6-df5d-4347-8715-edabdb268cb7" />

After logging in, the api-down warning comes up when the api is available.  there was a last minute boolean edit that wasn't quite right.  tested locally and it's working:
<img width="1434" height="903" alt="image" src="https://github.com/user-attachments/assets/353ccf5d-4c60-4dee-a6b3-865917eae71e" />
