### PR TITLE
FECFILE-3056: frontend cache and poller fixes

### DIFF
--- a/deploy-config/front-end-nginx-config/nginx.conf
+++ b/deploy-config/front-end-nginx-config/nginx.conf
@@ -26,7 +26,9 @@ http {
     set $nonce $request_id;
     set $frontend "{{env "FECFILE_APP_URL"}}";
     location = /index.html {
-      add_header Cache-Control no-cache;
+      add_header Cache-Control "no-cache, max-age=0, must-revalidate";
+      add_header Pragma "no-cache";
+      add_header Expires "0";
       add_header Access-Control-Allow-Origin null;
       add_header Reporting-Endpoints 'csp-endpoint="$frontend/csp-report"';
       add_header Content-Security-Policy "

--- a/front-end/src/app/shared/services/poller.service.spec.ts
+++ b/front-end/src/app/shared/services/poller.service.spec.ts
@@ -64,6 +64,26 @@ describe('PollerService', () => {
     });
   });
 
+  it('should detect new version when script tag includes nonce and dashed main filename', () => {
+    const mockHtmlResponse =
+      '<script src="main-HNSF5G6R.js" type="module" nonce="4291914bf6c68c9cea8164bd46b00c15"></script>';
+
+    vi.spyOn(document, 'getElementsByTagName').mockReturnValue([
+      {
+        src: 'http://localhost/main-OLDHASH.js',
+      },
+    ] as unknown as HTMLCollectionOf<Element>);
+
+    service.compareVersions('test-url');
+
+    const req = httpMock.expectOne('test-url');
+    req.flush(mockHtmlResponse, { status: 200, statusText: 'OK' });
+
+    service.isNewVersionAvailable$.subscribe((isAvailable) => {
+      expect(isAvailable).toBe(true);
+    });
+  });
+
   it('should handle error in version check', async () => {
     service.compareVersions('test-url');
 

--- a/front-end/src/app/shared/services/poller.service.ts
+++ b/front-end/src/app/shared/services/poller.service.ts
@@ -21,7 +21,7 @@ export class PollerService {
     try {
       const fetchedPage = await firstValueFrom(this.http.get(deploymentUrl, { responseType: 'text' }));
       const loadedText = fetchedPage as string;
-      const mainScriptRegex = /<script\s+src="(main\.[^"]+\.js)"\s+type="module"><\/script>/gim;
+      const mainScriptRegex = /<script[^>]*\bsrc="(main[-.][^"]+\.js)"[^>]*\btype="module"[^>]*><\/script>/im;
       const matchResponses = mainScriptRegex.exec(loadedText);
       const remoteMainScript = matchResponses && matchResponses.length > 0 ? matchResponses[1] : undefined;
 


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3056

Related PRs:
N/A

Description:
* Updates the regex used by the poller to correctly identify `main-[hash].js` files.
* Adds a unit test for the above.
* Updates `Cache-Control` header to include `max-age=0, must-revalidate` so that when Chrome resurrects a discarded tab is always revalidates rather than potentially using its cached `index.html`.