### PR TITLE
Get rid of wierd error message flashing

### DIFF
--- a/front-end/src/app/shared/components/calendar/calendar.component.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.ts
@@ -49,18 +49,13 @@ export class CalendarComponent {
 
     if (control) {
       const currentValue = this.datePicker().el.nativeElement.children[0].value;
-
-      if ((currentValue && currentValue === 'MM/DD/YYYY') || currentValue.replaceAll(/[_/]/g, '') === '') {
-        control.setValue(null);
-      } else {
-        const date = new Date(currentValue);
-        if (date instanceof Date && !Number.isNaN(date.getTime())) {
-          const isDifferentDate = !(control.value instanceof Date) || control.value.getTime() !== date.getTime();
-          if (isDifferentDate) {
-            control.setValue(date);
-            control.markAsTouched();
-            control.updateValueAndValidity();
-          }
+      const date = new Date(currentValue);
+      if (date instanceof Date && !Number.isNaN(date.getTime())) {
+        const isDifferentDate = !(control.value instanceof Date) || control.value.getTime() !== date.getTime();
+        if (isDifferentDate) {
+          control.setValue(date);
+          control.markAsTouched();
+          control.updateValueAndValidity();
         }
       }
     }

--- a/front-end/src/app/shared/utils/schema.utils.ts
+++ b/front-end/src/app/shared/utils/schema.utils.ts
@@ -213,7 +213,12 @@ export class SchemaUtils {
             result['exclusiveMax'] = { exclusiveMax: error.params['limit'] };
           }
           if (error.keyword === 'pattern') {
-            result['pattern'] = { requiredPattern: error.params['pattern'] };
+            if (
+              error.params['pattern'] === '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' &&
+              form.get(property)?.value === 'MM/DD/YYYY'
+            )
+              result['required'] = true;
+            else result['pattern'] = { requiredPattern: error.params['pattern'] };
           }
           if (error.keyword === 'enum') {
             result['pattern'] = { requiredPattern: `Allowed values: ${error.params['allowedValues'].join(', ')}` };


### PR DESCRIPTION
@dheitzer as I was testing your changes (which definitely resolved the issue of the required message) I noticed there was some wierd flashing on that where it would ever so briefly flash the pattern message before the required message showed up. This PR would resolve that problem by tweaking the pattern check in schema to override this particular instance to be marked as required. This makes it so we don't need that second value write which leads to the rapid switch validation error message.