### PR TITLE
feature/3115 - Use directive to override the registerOnChange to force MM/DD/YYYY to be treated as null before it hits the validation step.

### DIFF
--- a/front-end/src/app/shared/components/calendar/calendar.component.html
+++ b/front-end/src/app/shared/components/calendar/calendar.component.html
@@ -3,8 +3,6 @@
   <p-datepicker
     #datepicker
     appendTo="body"
-    (onClose)="validateDate()"
-    (onBlur)="validateDate()"
     [showOnFocus]="false"
     [inputId]="fieldName()"
     [name]="fieldName()"
@@ -19,6 +17,7 @@
     pInputMask="99/99/9999"
     slotChar="MM/DD/YYYY"
     dataType="string"
+    appDateSanitizer
   >
     <ng-template pTemplate="header">
       <div class="flex justify-content-between p-2 border-bottom-1 border-300">

--- a/front-end/src/app/shared/components/calendar/calendar.component.spec.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.spec.ts
@@ -51,23 +51,6 @@ describe('CalendarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initialize form control with "submit" update strategy', () => {
-    expect(component.control()!.updateOn).toBe('blur');
-  });
-
-  it('should mark control as touched and update value on updateValue', () => {
-    const control = component.control()!;
-    control.setValue(new Date('01/01/2019'));
-
-    const inputElement = component.datePicker().el.nativeElement.children[0];
-    inputElement.value = '01/01/2020';
-
-    component.validateDate();
-
-    expect(component.control()!.touched).toBe(true);
-    expect(component.control()!.value).toEqual(new Date('01/01/2020'));
-  });
-
   it('should increment the year and update the view when delta is 1', () => {
     const event = new Event('click');
     const datePicker = component.datePicker();

--- a/front-end/src/app/shared/components/calendar/calendar.component.ts
+++ b/front-end/src/app/shared/components/calendar/calendar.component.ts
@@ -1,17 +1,24 @@
-import { Component, computed, effect, input, viewChild } from '@angular/core';
+import { Component, computed, input, viewChild } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { DateUtils } from 'app/shared/utils/date.utils';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
 import { ButtonModule } from 'primeng/button';
 import { DatePicker } from 'primeng/datepicker';
 import { InputMaskModule } from 'primeng/inputmask';
 import { ErrorMessagesComponent } from '../error-messages/error-messages.component';
+import { DateSanitizerDirective } from './date-sanitize.directive';
 
 @Component({
   selector: 'app-calendar',
   templateUrl: './calendar.component.html',
   styleUrl: './calendar.component.scss',
-  imports: [DatePicker, ReactiveFormsModule, ErrorMessagesComponent, InputMaskModule, ButtonModule],
+  imports: [
+    DatePicker,
+    ReactiveFormsModule,
+    ErrorMessagesComponent,
+    InputMaskModule,
+    ButtonModule,
+    DateSanitizerDirective,
+  ],
 })
 export class CalendarComponent {
   readonly form = input.required<FormGroup>();
@@ -22,50 +29,7 @@ export class CalendarComponent {
   readonly requiredErrorMessage = input('This is a required field.');
   readonly datePicker = viewChild.required(DatePicker);
   readonly invalidFormatMessage = input('This date does not follow the correct format, e.g. 01/01/2020');
-
-  readonly control = computed(() => {
-    const field = this.fieldName();
-    const control = this.form()?.get(field);
-    if (!control) return undefined;
-
-    return control as SubscriptionFormControl;
-  });
-
-  constructor() {
-    effect(() => {
-      const control = this.control();
-      const value = control?.value;
-      if (value && typeof value === 'string' && value.length === 10 && !value.includes('D')) {
-        const date = DateUtils.parseDate(value);
-
-        if (date) {
-          control.setValue(date, { emitEvent: false });
-        }
-      }
-    });
-  }
-
-  validateDate() {
-    const control = this.control();
-
-    if (control) {
-      const currentValue = this.datePicker().el.nativeElement.children[0].value;
-
-      if ((currentValue && currentValue === 'MM/DD/YYYY') || currentValue.replaceAll(/[_/]/g, '') === '') {
-        control.setValue(null);
-      } else {
-        const date = new Date(currentValue);
-        if (date instanceof Date && !Number.isNaN(date.getTime())) {
-          const isDifferentDate = !(control.value instanceof Date) || control.value.getTime() !== date.getTime();
-          if (isDifferentDate) {
-            control.setValue(date);
-            control.markAsTouched();
-            control.updateValueAndValidity();
-          }
-        }
-      }
-    }
-  }
+  readonly control = computed(() => this.form().get(this.fieldName()) as SubscriptionFormControl);
 
   onYearChange(event: Event, delta: -1 | 1) {
     const datePicker = this.datePicker();

--- a/front-end/src/app/shared/components/calendar/date-sanitize.directive.spec.ts
+++ b/front-end/src/app/shared/components/calendar/date-sanitize.directive.spec.ts
@@ -1,0 +1,75 @@
+import { NgControl } from '@angular/forms';
+import { DateSanitizerDirective, DSN } from './date-sanitize.directive';
+import { DateUtils } from 'app/shared/utils/date.utils';
+import { TestBed } from '@angular/core/testing';
+
+describe('DateSanitizerDirective', () => {
+  let capturedSanitizerFn: (value: DSN) => void;
+  const mockValueAccessor = {
+    registerOnChange: vi.fn((fn: (val: DSN) => void) => {
+      capturedSanitizerFn = fn;
+    }),
+  };
+
+  const mockOriginalUpdateFn = vi.fn();
+  const emitFromUI = (value: DSN) => capturedSanitizerFn(value);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DateSanitizerDirective,
+        {
+          provide: NgControl,
+          useValue: { valueAccessor: mockValueAccessor },
+        },
+      ],
+    });
+
+    TestBed.inject(DateSanitizerDirective);
+    mockValueAccessor.registerOnChange(mockOriginalUpdateFn);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should sanitize placeholder text "MM/DD/YYYY" to null', () => {
+    emitFromUI('MM/DD/YYYY');
+    expect(mockOriginalUpdateFn).toHaveBeenCalledWith(null);
+  });
+
+  it('should sanitize empty strings to null', () => {
+    emitFromUI('');
+    expect(mockOriginalUpdateFn).toHaveBeenCalledWith(null);
+  });
+
+  it('should call DateUtils.parseDate for complete date strings', () => {
+    const rawValue = '01/01/2024';
+    const parsedDate = new Date(2024, 0, 1);
+    const spy = vi.spyOn(DateUtils, 'parseDate').mockReturnValue(parsedDate);
+
+    emitFromUI(rawValue);
+
+    expect(spy).toHaveBeenCalledWith(rawValue);
+    expect(mockOriginalUpdateFn).toHaveBeenCalledWith(parsedDate);
+  });
+
+  it('should pass through values containing mask placeholders (M, D, Y)', () => {
+    const partialValue = '01/DD/YYYY';
+    const spy = vi.spyOn(DateUtils, 'parseDate');
+
+    emitFromUI(partialValue);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(mockOriginalUpdateFn).toHaveBeenCalledWith(partialValue);
+  });
+
+  it('should return original value if parsing fails', () => {
+    const invalidValue = '99/99/9999';
+    vi.spyOn(DateUtils, 'parseDate').mockReturnValue(null);
+
+    emitFromUI(invalidValue);
+
+    expect(mockOriginalUpdateFn).toHaveBeenCalledWith(invalidValue);
+  });
+});

--- a/front-end/src/app/shared/components/calendar/date-sanitize.directive.ts
+++ b/front-end/src/app/shared/components/calendar/date-sanitize.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, inject } from '@angular/core';
+import { NgControl } from '@angular/forms';
+import { DateUtils } from 'app/shared/utils/date.utils';
+
+export type DSN = Date | string | null;
+
+@Directive({
+  selector: 'p-datepicker[appDateSanitizer]',
+})
+export class DateSanitizerDirective {
+  private readonly ngControl = inject(NgControl);
+  constructor() {
+    const accessor = this.ngControl?.valueAccessor;
+    if (!accessor) return;
+    const originalRegisterOnChange = accessor.registerOnChange.bind(accessor);
+    accessor.registerOnChange = (fn: (value: DSN) => void) => {
+      originalRegisterOnChange((value: DSN) => {
+        if (value === 'MM/DD/YYYY' || !value) {
+          return fn(null);
+        }
+
+        if (typeof value === 'string' && value.length === 10 && !/[MDY]/.test(value)) {
+          const parsedDate = DateUtils.parseDate(value);
+          return fn(parsedDate || value);
+        }
+
+        return fn(value);
+      });
+    };
+  }
+}


### PR DESCRIPTION
Issue [FECFILE-3115](https://fecgov.atlassian.net/browse/FECFILE-3115)