### PR TITLE
use new fec_report_id variable

### DIFF
--- a/front-end/src/app/shared/models/reports/report.model.ts
+++ b/front-end/src/app/shared/models/reports/report.model.ts
@@ -23,7 +23,7 @@ export abstract class Report extends BaseModel {
   submitAlertText =
     'Are you sure you want to submit this form electronically? Please note that you cannot undo this action. Any changes needed will need to be filed as an amended report.';
   report_version: string | undefined; // Tracks amendment versions
-  report_id: string | undefined; // FEC assigned report ID
+  fec_report_id: string | undefined; // FEC assigned report ID
   confirmation_email_1: string | undefined;
   confirmation_email_2: string | undefined;
   @Type(() => UploadSubmission)


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3148

Related PRs: [API](https://github.com/fecgov/fecfile-web-api/pull/2058)

Addresses two main issues.

One is the bug identified in the ticket. The issue was that we were setting ther report id in the .fec to whatever the last report id was, so for amendment 1 the report id in the .fec was the one that came back with the new filing. For the second and onward, EFO wants the report id to still be the original and not the new id of the previous amendment. Now, when the response comes back from the EFO API, we only set the fec_report_id if it's the first filing, and not on amendments. (note about fec_report_id below)

This came about when we fixed a previous bug https://fecgov.atlassian.net/browse/FECFILE-2853. Fixing this bug broke that ticket's solution, so we had to come up with a different one. The fix is to keep a key to the previous submission record so that if the user unamends, it'll just set the upload submission record to the previous.

I also deprecated report.report_id which i think is a candidate for most confusing variable name. it's been replaced by fec_report_id to differentiate it with the uuid of the report in fecfile+.