### PR TITLE
[Sprint 88] FECFILE-3157: Avoid E2E assertion timeouts in F3X aggregation

### DIFF
--- a/front-end/cypress/e2e-extended/reports/f3x/aggregation-schedule-e.cy.ts
+++ b/front-end/cypress/e2e-extended/reports/f3x/aggregation-schedule-e.cy.ts
@@ -34,8 +34,7 @@ describe('Extended F3X Schedule E Aggregation', () => {
 
         F3XAggregationHelpers.openDisbursement(secondId);
         ContactLookup.getCandidate(result.candidateSenate, [], [], '#contact_2_lookup');
-        cy.blurActiveField();
-        F3XAggregationHelpers.assertCalendarYtdField('$50.00');
+        F3XAggregationHelpers.assertCalendarYtdAfterBlur('$50.00');
         F3XAggregationHelpers.clickSave();
 
         F3XAggregationHelpers.assertCalendarYtdFieldOnOpen(firstId, '$100.00');
@@ -72,9 +71,8 @@ describe('Extended F3X Schedule E Aggregation', () => {
         F3XAggregationHelpers.openDisbursement(secondId);
         PageUtils.selectDropdownSetValue('[inputid="electionType"]', 'G');
         F3XAggregationHelpers.clearAndType('#electionYear', `${currentYear}`);
-        cy.blurActiveField();
-        F3XAggregationHelpers.assertCalendarYtdField('$40.00');
         F3XAggregationHelpers.clickSave();
+        F3XAggregationHelpers.goToReport(result.report);
 
         F3XAggregationHelpers.assertCalendarYtdFieldOnOpen(firstId, '$80.00');
         F3XAggregationHelpers.clickSave();

--- a/front-end/cypress/e2e-extended/reports/f3x/aggregation-schedule-e.cy.ts
+++ b/front-end/cypress/e2e-extended/reports/f3x/aggregation-schedule-e.cy.ts
@@ -71,6 +71,7 @@ describe('Extended F3X Schedule E Aggregation', () => {
         F3XAggregationHelpers.openDisbursement(secondId);
         PageUtils.selectDropdownSetValue('[inputid="electionType"]', 'G');
         F3XAggregationHelpers.clearAndType('#electionYear', `${currentYear}`);
+        F3XAggregationHelpers.assertCalendarYtdAfterBlur('$40.00');
         F3XAggregationHelpers.clickSave();
         F3XAggregationHelpers.goToReport(result.report);
 

--- a/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
+++ b/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
@@ -882,14 +882,6 @@ export class F3XAggregationHelpers {
     this.assertAggregateField(expected);
   }
 
-  private static parseCurrencyToNumber(value: string): number {
-    const parsed = Number(value.replace(/[$,]/g, ''));
-    if (Number.isNaN(parsed)) {
-      throw new TypeError(`parseCurrencyToNumber: cannot parse "${value}"`);
-    }
-    return parsed;
-  }
-
   private static buildPreviousElectionQuery(transactionId: string, transaction: any): Record<string, string> | null {
     const disbursementDate = String(
       transaction?.['disbursement_date'] ??
@@ -965,29 +957,7 @@ export class F3XAggregationHelpers {
     expectedFormatted: string,
   ): Cypress.Chainable<void> {
     this.assertTransactionId(transactionId, 'assertCalendarYtdFieldOnOpen');
-    const expectedValue = this.parseCurrencyToNumber(expectedFormatted);
     const matchedAlias = 'CalendarYtdAggregateMatched';
-    const settleAttempts = 4;
-    const settleIntervalMs = 250;
-
-    const assertFieldWithSettle = (attempt: number): Cypress.Chainable<void> => {
-      return cy
-        .get('#calendar_ytd')
-        .invoke('val')
-        .then((rawValue) => {
-          const actual = String(rawValue ?? '').trim();
-          if (actual === expectedFormatted) {
-            return;
-          }
-
-          if (attempt >= settleAttempts) {
-            expect(actual, `calendar_ytd settle (${attempt + 1}/${settleAttempts + 1})`).to.equal(expectedFormatted);
-            return;
-          }
-
-          return cy.wait(settleIntervalMs).then(() => assertFieldWithSettle(attempt + 1));
-        }) as unknown as Cypress.Chainable<void>;
-    };
 
     return this.getTransaction(transactionId).then((transaction) => {
       const expectedQuery = this.buildPreviousElectionQuery(transactionId, transaction ?? {});
@@ -1011,12 +981,12 @@ export class F3XAggregationHelpers {
 
       if (!expectedQuery) {
         cy.log(`assertCalendarYtdFieldOnOpen fallback: missing query fields for txn=${transactionId}`);
-        return assertFieldWithSettle(0);
+        return cy.get('#calendar_ytd', { timeout: 15000 }).should('have.value', expectedFormatted);
       }
 
       return cy.wait(`@${matchedAlias}`).then(() => {
-        cy.log(`assertCalendarYtdFieldOnOpen matched request resolved: txn=${transactionId}, expected=${expectedValue}`);
-        return assertFieldWithSettle(0);
+        cy.log(`assertCalendarYtdFieldOnOpen matched request resolved: txn=${transactionId}`);
+        return cy.get('#calendar_ytd', { timeout: 15000 }).should('have.value', expectedFormatted);
       }) as unknown as Cypress.Chainable<void>;
     }) as unknown as Cypress.Chainable<void>;
   }

--- a/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
+++ b/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
@@ -267,6 +267,145 @@ export class F3XAggregationHelpers {
       .its('body');
   }
 
+  private static parseCurrencyToNumber(value: string): number {
+    const parsed = Number(value.replace(/[$,]/g, ''));
+    if (Number.isNaN(parsed)) {
+      throw new TypeError(`parseCurrencyToNumber: cannot parse "${value}"`);
+    }
+    return parsed;
+  }
+
+  private static buildPreviousElectionQuery(transactionId: string, transaction: any): Record<string, string> | null {
+    const disbursementDate = String(
+      transaction?.['disbursement_date'] ??
+        transaction?.['expenditure_date'] ??
+        transaction?.['date'] ??
+        transaction?.['dissemination_date'] ??
+        '',
+    );
+    const electionCode = String(transaction?.['election_code'] ?? '');
+    const candidateOffice = String(
+      transaction?.['candidate_office'] ??
+        transaction?.['so_candidate_office'] ??
+        transaction?.['payee_candidate_office'] ??
+        '',
+    );
+    const candidateState = String(
+      transaction?.['candidate_state'] ??
+        transaction?.['so_candidate_state'] ??
+        transaction?.['payee_candidate_state'] ??
+        '',
+    );
+    const candidateDistrict = String(
+      transaction?.['candidate_district'] ??
+        transaction?.['so_candidate_district'] ??
+        transaction?.['payee_candidate_district'] ??
+        '',
+    );
+
+    if (!disbursementDate || !electionCode || !candidateOffice) {
+      return null;
+    }
+
+    const query: Record<string, string> = {
+      transaction_id: transactionId,
+      aggregation_group: String(transaction?.['aggregation_group'] ?? 'INDEPENDENT_EXPENDITURE'),
+      date: disbursementDate,
+      election_code: electionCode,
+      candidate_office: candidateOffice,
+    };
+
+    if (candidateState) {
+      query['candidate_state'] = candidateState;
+    }
+    if (candidateDistrict) {
+      query['candidate_district'] = candidateDistrict;
+    }
+
+    return query;
+  }
+
+  private static queryValueMatches(actual: unknown, expected: string): boolean {
+    if (Array.isArray(actual)) {
+      return actual.some((value) => String(value) === expected);
+    }
+    return String(actual ?? '') === expected;
+  }
+
+  private static requestMatchesPreviousElectionQuery(
+    actualQuery: Record<string, unknown> | undefined,
+    expectedQuery: Record<string, string>,
+  ): boolean {
+    if (!actualQuery) {
+      return false;
+    }
+
+    return Object.entries(expectedQuery).every(([key, expected]) => {
+      return this.queryValueMatches(actualQuery[key], expected);
+    });
+  }
+
+  static waitForCalendarYtdByApi(
+    transactionId: string,
+    expectedFormatted: string,
+  ): Cypress.Chainable<void> {
+    this.assertTransactionId(transactionId, 'waitForCalendarYtdByApi');
+    const expectedValue = this.parseCurrencyToNumber(expectedFormatted);
+    const matchedAlias = 'CalendarYtdAggregateMatched';
+    const settleAttempts = 4;
+    const settleIntervalMs = 250;
+
+    const assertFieldWithSettle = (attempt: number): Cypress.Chainable<void> => {
+      return cy
+        .get('#calendar_ytd')
+        .invoke('val')
+        .then((rawValue) => {
+          const actual = String(rawValue ?? '').trim();
+          if (actual === expectedFormatted) {
+            return;
+          }
+
+          if (attempt >= settleAttempts) {
+            expect(actual, `calendar_ytd settle (${attempt + 1}/${settleAttempts + 1})`).to.equal(expectedFormatted);
+            return;
+          }
+
+          return cy.wait(settleIntervalMs).then(() => assertFieldWithSettle(attempt + 1));
+        }) as unknown as Cypress.Chainable<void>;
+    };
+
+    return this.getTransaction(transactionId).then((transaction) => {
+      const expectedQuery = this.buildPreviousElectionQuery(transactionId, transaction ?? {});
+
+      if (expectedQuery) {
+        cy.intercept(
+          {
+            method: 'GET',
+            pathname: /\/api\/v1\/transactions\/previous\/election\/$/,
+          },
+          (req) => {
+            const requestQuery = (req.query ?? {}) as Record<string, unknown>;
+            if (this.requestMatchesPreviousElectionQuery(requestQuery, expectedQuery)) {
+              req.alias = matchedAlias;
+            }
+          },
+        );
+      }
+
+      this.openDisbursement(transactionId);
+
+      if (!expectedQuery) {
+        cy.log(`waitForCalendarYtdByApi fallback: missing query fields for txn=${transactionId}`);
+        return assertFieldWithSettle(0);
+      }
+
+      return cy.wait(`@${matchedAlias}`).then(() => {
+        cy.log(`waitForCalendarYtdByApi matched request resolved: txn=${transactionId}, expected=${expectedValue}`);
+        return assertFieldWithSettle(0);
+      }) as unknown as Cypress.Chainable<void>;
+    }) as unknown as Cypress.Chainable<void>;
+  }
+
   static readLoanBalanceValueByApi(loanId: string): Cypress.Chainable<number> {
     this.assertTransactionId(loanId, 'readLoanBalanceValueByApi');
     return this.getTransaction(loanId).then((transaction) => {
@@ -883,8 +1022,7 @@ export class F3XAggregationHelpers {
   }
 
   static assertCalendarYtdFieldOnOpen(transactionId: string, expected: string): void {
-    this.openDisbursement(transactionId);
-    this.assertCalendarYtdField(expected);
+    this.waitForCalendarYtdByApi(transactionId, expected);
   }
 
   static assertScheduleEAggregateFieldOnOpen(transactionId: string, expected: string): void {

--- a/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
+++ b/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
@@ -267,145 +267,6 @@ export class F3XAggregationHelpers {
       .its('body');
   }
 
-  private static parseCurrencyToNumber(value: string): number {
-    const parsed = Number(value.replace(/[$,]/g, ''));
-    if (Number.isNaN(parsed)) {
-      throw new TypeError(`parseCurrencyToNumber: cannot parse "${value}"`);
-    }
-    return parsed;
-  }
-
-  private static buildPreviousElectionQuery(transactionId: string, transaction: any): Record<string, string> | null {
-    const disbursementDate = String(
-      transaction?.['disbursement_date'] ??
-        transaction?.['expenditure_date'] ??
-        transaction?.['date'] ??
-        transaction?.['dissemination_date'] ??
-        '',
-    );
-    const electionCode = String(transaction?.['election_code'] ?? '');
-    const candidateOffice = String(
-      transaction?.['candidate_office'] ??
-        transaction?.['so_candidate_office'] ??
-        transaction?.['payee_candidate_office'] ??
-        '',
-    );
-    const candidateState = String(
-      transaction?.['candidate_state'] ??
-        transaction?.['so_candidate_state'] ??
-        transaction?.['payee_candidate_state'] ??
-        '',
-    );
-    const candidateDistrict = String(
-      transaction?.['candidate_district'] ??
-        transaction?.['so_candidate_district'] ??
-        transaction?.['payee_candidate_district'] ??
-        '',
-    );
-
-    if (!disbursementDate || !electionCode || !candidateOffice) {
-      return null;
-    }
-
-    const query: Record<string, string> = {
-      transaction_id: transactionId,
-      aggregation_group: String(transaction?.['aggregation_group'] ?? 'INDEPENDENT_EXPENDITURE'),
-      date: disbursementDate,
-      election_code: electionCode,
-      candidate_office: candidateOffice,
-    };
-
-    if (candidateState) {
-      query['candidate_state'] = candidateState;
-    }
-    if (candidateDistrict) {
-      query['candidate_district'] = candidateDistrict;
-    }
-
-    return query;
-  }
-
-  private static queryValueMatches(actual: unknown, expected: string): boolean {
-    if (Array.isArray(actual)) {
-      return actual.some((value) => String(value) === expected);
-    }
-    return String(actual ?? '') === expected;
-  }
-
-  private static requestMatchesPreviousElectionQuery(
-    actualQuery: Record<string, unknown> | undefined,
-    expectedQuery: Record<string, string>,
-  ): boolean {
-    if (!actualQuery) {
-      return false;
-    }
-
-    return Object.entries(expectedQuery).every(([key, expected]) => {
-      return this.queryValueMatches(actualQuery[key], expected);
-    });
-  }
-
-  static waitForCalendarYtdByApi(
-    transactionId: string,
-    expectedFormatted: string,
-  ): Cypress.Chainable<void> {
-    this.assertTransactionId(transactionId, 'waitForCalendarYtdByApi');
-    const expectedValue = this.parseCurrencyToNumber(expectedFormatted);
-    const matchedAlias = 'CalendarYtdAggregateMatched';
-    const settleAttempts = 4;
-    const settleIntervalMs = 250;
-
-    const assertFieldWithSettle = (attempt: number): Cypress.Chainable<void> => {
-      return cy
-        .get('#calendar_ytd')
-        .invoke('val')
-        .then((rawValue) => {
-          const actual = String(rawValue ?? '').trim();
-          if (actual === expectedFormatted) {
-            return;
-          }
-
-          if (attempt >= settleAttempts) {
-            expect(actual, `calendar_ytd settle (${attempt + 1}/${settleAttempts + 1})`).to.equal(expectedFormatted);
-            return;
-          }
-
-          return cy.wait(settleIntervalMs).then(() => assertFieldWithSettle(attempt + 1));
-        }) as unknown as Cypress.Chainable<void>;
-    };
-
-    return this.getTransaction(transactionId).then((transaction) => {
-      const expectedQuery = this.buildPreviousElectionQuery(transactionId, transaction ?? {});
-
-      if (expectedQuery) {
-        cy.intercept(
-          {
-            method: 'GET',
-            pathname: /\/api\/v1\/transactions\/previous\/election\/$/,
-          },
-          (req) => {
-            const requestQuery = (req.query ?? {}) as Record<string, unknown>;
-            if (this.requestMatchesPreviousElectionQuery(requestQuery, expectedQuery)) {
-              req.alias = matchedAlias;
-            }
-          },
-        );
-      }
-
-      this.openDisbursement(transactionId);
-
-      if (!expectedQuery) {
-        cy.log(`waitForCalendarYtdByApi fallback: missing query fields for txn=${transactionId}`);
-        return assertFieldWithSettle(0);
-      }
-
-      return cy.wait(`@${matchedAlias}`).then(() => {
-        cy.log(`waitForCalendarYtdByApi matched request resolved: txn=${transactionId}, expected=${expectedValue}`);
-        return assertFieldWithSettle(0);
-      }) as unknown as Cypress.Chainable<void>;
-    }) as unknown as Cypress.Chainable<void>;
-  }
-
   static readLoanBalanceValueByApi(loanId: string): Cypress.Chainable<number> {
     this.assertTransactionId(loanId, 'readLoanBalanceValueByApi');
     return this.getTransaction(loanId).then((transaction) => {
@@ -1021,8 +882,143 @@ export class F3XAggregationHelpers {
     this.assertAggregateField(expected);
   }
 
-  static assertCalendarYtdFieldOnOpen(transactionId: string, expected: string): void {
-    this.waitForCalendarYtdByApi(transactionId, expected);
+  private static parseCurrencyToNumber(value: string): number {
+    const parsed = Number(value.replace(/[$,]/g, ''));
+    if (Number.isNaN(parsed)) {
+      throw new TypeError(`parseCurrencyToNumber: cannot parse "${value}"`);
+    }
+    return parsed;
+  }
+
+  private static buildPreviousElectionQuery(transactionId: string, transaction: any): Record<string, string> | null {
+    const disbursementDate = String(
+      transaction?.['disbursement_date'] ??
+        transaction?.['expenditure_date'] ??
+        transaction?.['date'] ??
+        transaction?.['dissemination_date'] ??
+        '',
+    );
+    const electionCode = String(transaction?.['election_code'] ?? '');
+    const candidateOffice = String(
+      transaction?.['candidate_office'] ??
+        transaction?.['so_candidate_office'] ??
+        transaction?.['payee_candidate_office'] ??
+        '',
+    );
+    const candidateState = String(
+      transaction?.['candidate_state'] ??
+        transaction?.['so_candidate_state'] ??
+        transaction?.['payee_candidate_state'] ??
+        '',
+    );
+    const candidateDistrict = String(
+      transaction?.['candidate_district'] ??
+        transaction?.['so_candidate_district'] ??
+        transaction?.['payee_candidate_district'] ??
+        '',
+    );
+
+    if (!disbursementDate || !electionCode || !candidateOffice) {
+      return null;
+    }
+
+    const query: Record<string, string> = {
+      transaction_id: transactionId,
+      aggregation_group: String(transaction?.['aggregation_group'] ?? 'INDEPENDENT_EXPENDITURE'),
+      date: disbursementDate,
+      election_code: electionCode,
+      candidate_office: candidateOffice,
+    };
+
+    if (candidateState) {
+      query['candidate_state'] = candidateState;
+    }
+    if (candidateDistrict) {
+      query['candidate_district'] = candidateDistrict;
+    }
+
+    return query;
+  }
+
+  private static queryValueMatches(actual: unknown, expected: string): boolean {
+    if (Array.isArray(actual)) {
+      return actual.some((value) => String(value) === expected);
+    }
+    return String(actual ?? '') === expected;
+  }
+
+  private static requestMatchesPreviousElectionQuery(
+    actualQuery: Record<string, unknown> | undefined,
+    expectedQuery: Record<string, string>,
+  ): boolean {
+    if (!actualQuery) {
+      return false;
+    }
+
+    return Object.entries(expectedQuery).every(([key, expected]) => {
+      return this.queryValueMatches(actualQuery[key], expected);
+    });
+  }
+
+  static assertCalendarYtdFieldOnOpen(
+    transactionId: string,
+    expectedFormatted: string,
+  ): Cypress.Chainable<void> {
+    this.assertTransactionId(transactionId, 'assertCalendarYtdFieldOnOpen');
+    const expectedValue = this.parseCurrencyToNumber(expectedFormatted);
+    const matchedAlias = 'CalendarYtdAggregateMatched';
+    const settleAttempts = 4;
+    const settleIntervalMs = 250;
+
+    const assertFieldWithSettle = (attempt: number): Cypress.Chainable<void> => {
+      return cy
+        .get('#calendar_ytd')
+        .invoke('val')
+        .then((rawValue) => {
+          const actual = String(rawValue ?? '').trim();
+          if (actual === expectedFormatted) {
+            return;
+          }
+
+          if (attempt >= settleAttempts) {
+            expect(actual, `calendar_ytd settle (${attempt + 1}/${settleAttempts + 1})`).to.equal(expectedFormatted);
+            return;
+          }
+
+          return cy.wait(settleIntervalMs).then(() => assertFieldWithSettle(attempt + 1));
+        }) as unknown as Cypress.Chainable<void>;
+    };
+
+    return this.getTransaction(transactionId).then((transaction) => {
+      const expectedQuery = this.buildPreviousElectionQuery(transactionId, transaction ?? {});
+
+      if (expectedQuery) {
+        cy.intercept(
+          {
+            method: 'GET',
+            pathname: /\/api\/v1\/transactions\/previous\/election\/$/,
+          },
+          (req) => {
+            const requestQuery = (req.query ?? {}) as Record<string, unknown>;
+            if (this.requestMatchesPreviousElectionQuery(requestQuery, expectedQuery)) {
+              req.alias = matchedAlias;
+            }
+          },
+        );
+      }
+
+      this.openDisbursement(transactionId);
+
+      if (!expectedQuery) {
+        cy.log(`assertCalendarYtdFieldOnOpen fallback: missing query fields for txn=${transactionId}`);
+        return assertFieldWithSettle(0);
+      }
+
+      return cy.wait(`@${matchedAlias}`).then(() => {
+        cy.log(`assertCalendarYtdFieldOnOpen matched request resolved: txn=${transactionId}, expected=${expectedValue}`);
+        return assertFieldWithSettle(0);
+      }) as unknown as Cypress.Chainable<void>;
+    }) as unknown as Cypress.Chainable<void>;
   }
 
   static assertScheduleEAggregateFieldOnOpen(transactionId: string, expected: string): void {

--- a/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
+++ b/front-end/cypress/e2e-extended/reports/f3x/f3x-aggregation.helpers.ts
@@ -600,7 +600,9 @@ export class F3XAggregationHelpers {
 
   static rowLinkById(tableRoot: string, transactionId: string): Cypress.Chainable<JQuery<HTMLElement>> {
     this.assertTransactionId(transactionId, 'rowLinkById');
-    return cy.get(`${tableRoot} a[href*="/list/${transactionId}"]`).first().should('exist');
+    const timeout = Number(Cypress.config('responseTimeout'));
+    cy.get(tableRoot, { timeout }).should('exist');
+    return cy.get(`${tableRoot} a[href*="/list/${transactionId}"]`, { timeout }).first().should('exist');
   }
 
   static rowById(tableRoot: string, transactionId: string): Cypress.Chainable<JQuery<HTMLTableRowElement>> {
@@ -882,113 +884,26 @@ export class F3XAggregationHelpers {
     this.assertAggregateField(expected);
   }
 
-  private static buildPreviousElectionQuery(transactionId: string, transaction: any): Record<string, string> | null {
-    const disbursementDate = String(
-      transaction?.['disbursement_date'] ??
-        transaction?.['expenditure_date'] ??
-        transaction?.['date'] ??
-        transaction?.['dissemination_date'] ??
-        '',
-    );
-    const electionCode = String(transaction?.['election_code'] ?? '');
-    const candidateOffice = String(
-      transaction?.['candidate_office'] ??
-        transaction?.['so_candidate_office'] ??
-        transaction?.['payee_candidate_office'] ??
-        '',
-    );
-    const candidateState = String(
-      transaction?.['candidate_state'] ??
-        transaction?.['so_candidate_state'] ??
-        transaction?.['payee_candidate_state'] ??
-        '',
-    );
-    const candidateDistrict = String(
-      transaction?.['candidate_district'] ??
-        transaction?.['so_candidate_district'] ??
-        transaction?.['payee_candidate_district'] ??
-        '',
-    );
-
-    if (!disbursementDate || !electionCode || !candidateOffice) {
-      return null;
-    }
-
-    const query: Record<string, string> = {
-      transaction_id: transactionId,
-      aggregation_group: String(transaction?.['aggregation_group'] ?? 'INDEPENDENT_EXPENDITURE'),
-      date: disbursementDate,
-      election_code: electionCode,
-      candidate_office: candidateOffice,
-    };
-
-    if (candidateState) {
-      query['candidate_state'] = candidateState;
-    }
-    if (candidateDistrict) {
-      query['candidate_district'] = candidateDistrict;
-    }
-
-    return query;
-  }
-
-  private static queryValueMatches(actual: unknown, expected: string): boolean {
-    if (Array.isArray(actual)) {
-      return actual.some((value) => String(value) === expected);
-    }
-    return String(actual ?? '') === expected;
-  }
-
-  private static requestMatchesPreviousElectionQuery(
-    actualQuery: Record<string, unknown> | undefined,
-    expectedQuery: Record<string, string>,
-  ): boolean {
-    if (!actualQuery) {
-      return false;
-    }
-
-    return Object.entries(expectedQuery).every(([key, expected]) => {
-      return this.queryValueMatches(actualQuery[key], expected);
-    });
-  }
-
   static assertCalendarYtdFieldOnOpen(
     transactionId: string,
     expectedFormatted: string,
   ): Cypress.Chainable<void> {
     this.assertTransactionId(transactionId, 'assertCalendarYtdFieldOnOpen');
-    const matchedAlias = 'CalendarYtdAggregateMatched';
-
-    return this.getTransaction(transactionId).then((transaction) => {
-      const expectedQuery = this.buildPreviousElectionQuery(transactionId, transaction ?? {});
-
-      if (expectedQuery) {
-        cy.intercept(
-          {
-            method: 'GET',
-            pathname: /\/api\/v1\/transactions\/previous\/election\/$/,
-          },
-          (req) => {
-            const requestQuery = (req.query ?? {}) as Record<string, unknown>;
-            if (this.requestMatchesPreviousElectionQuery(requestQuery, expectedQuery)) {
-              req.alias = matchedAlias;
-            }
-          },
-        );
-      }
-
-      this.openDisbursement(transactionId);
-
-      if (!expectedQuery) {
-        cy.log(`assertCalendarYtdFieldOnOpen fallback: missing query fields for txn=${transactionId}`);
-        return cy.get('#calendar_ytd', { timeout: 15000 }).should('have.value', expectedFormatted);
-      }
-
-      return cy.wait(`@${matchedAlias}`).then(() => {
-        cy.log(`assertCalendarYtdFieldOnOpen matched request resolved: txn=${transactionId}`);
-        return cy.get('#calendar_ytd', { timeout: 15000 }).should('have.value', expectedFormatted);
-      }) as unknown as Cypress.Chainable<void>;
+    const alias = `CalendarYtdAggregate_${transactionId}`;
+    cy.intercept(
+      { method: 'GET', pathname: /\/api\/v1\/transactions\/previous\/election\/$/, query: { transaction_id: transactionId }, times: 1 },
+    ).as(alias);
+    this.openDisbursement(transactionId);
+    return cy.wait(`@${alias}`).then(() => {
+      return cy.get('#calendar_ytd').should('have.value', expectedFormatted);
     }) as unknown as Cypress.Chainable<void>;
+  }
+
+  static assertCalendarYtdAfterBlur(expectedFormatted: string): Cypress.Chainable<void> {
+    const responseTimeout = Number(Cypress.config('responseTimeout'));
+    cy.blurActiveField();
+    cy.waitForNetworkIdle(1000);
+    return cy.get('#calendar_ytd', { timeout: responseTimeout }).should('have.value', expectedFormatted) as unknown as Cypress.Chainable<void>;
   }
 
   static assertScheduleEAggregateFieldOnOpen(transactionId: string, expected: string): void {

--- a/front-end/cypress/e2e-smoke/pages/pageUtils.ts
+++ b/front-end/cypress/e2e-smoke/pages/pageUtils.ts
@@ -394,10 +394,13 @@ export class PageUtils {
   }
 
   static switchCommittee(committeeId: string) {
+    cy.intercept('POST', `http://localhost:8080/api/v1/committees/${committeeId}/activate/`).as('ActivateCommittee');
     cy.intercept('GET', 'http://localhost:8080/api/v1/committee-members/').as('GetCommitteeMembers');
     cy.visit('/login/select-committee');
     cy.get('.committee-list .committee-info').get(`[id="${committeeId}"]`).click();
+    cy.wait('@ActivateCommittee');
     cy.wait('@GetCommitteeMembers'); // Wait for the guard request to resolve
+    cy.location('pathname', { timeout: 20000 }).should('not.include', '/login/select-committee');
     cy.wait(1000);
     this.enterSecondCommitteeEmailIfneeded();
   }


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3157

Related PRs:
N/A

* Updated `assertCalendarYtdFieldOnOpen` to use pattern already found in `waitForLoanBalanceRestoreByApi`
* Removed a flaky intermediary assertion -- we already assert the begin and end state
* Retrieve cypress configured `responseTimeout` and use it rather than default `defaultCommandTimeout` when waiting for data that arrives after a backend-driven refresh, not a straight DOM render.