### PR TITLE
FECFILE-3169: disable F3 (but not F3X) transaction links

### DIFF
--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -70,7 +70,7 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
 
   readonly isF3X = computed(() => this.report().report_type === ReportTypes.F3X);
   readonly isF3 = computed(() => this.report().report_type === ReportTypes.F3);
-  readonly disableTransactionLinks = computed(() => this.isF3();
+  readonly disableTransactionLinks = computed(() => this.isF3() && !this.isF3X());
 
   readonly transactionGroups: Signal<Array<{ label: string; transactionTypes: Set<TransactionTypes> }>> = computed(
     () => CategoryPicker.get(this.category()) ?? [],

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -70,7 +70,7 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
 
   readonly isF3X = computed(() => this.report().report_type === ReportTypes.F3X);
   readonly isF3 = computed(() => this.report().report_type === ReportTypes.F3);
-  readonly disableTransactionLinks = computed(() => this.isF3() && !this.isF3X());
+  readonly disableTransactionLinks = computed(() => this.isF3());
 
   readonly transactionGroups: Signal<Array<{ label: string; transactionTypes: Set<TransactionTypes> }>> = computed(
     () => CategoryPicker.get(this.category()) ?? [],

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -72,7 +72,9 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
   readonly isF3 = computed(() => this.report().report_type === ReportTypes.F3);
   readonly disableTransactionLinks = computed(() => this.isF3() || this.isF3X());
 
-  readonly transactionGroups = computed(() => CategoryPicker.get(this.category()) ?? []);
+  readonly transactionGroups: Signal<Array<{ label: string; transactionTypes: Set<TransactionTypes> }>> = computed(
+    () => CategoryPicker.get(this.category()) ?? [],
+  );
 
   constructor() {
     super();

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -70,6 +70,7 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
 
   readonly isF3X = computed(() => this.report().report_type === ReportTypes.F3X);
   readonly isF3 = computed(() => this.report().report_type === ReportTypes.F3);
+  readonly disableTransactionLinks = computed(() => this.isF3() || this.isF3X());
 
   readonly transactionGroups = computed(() => CategoryPicker.get(this.category()) ?? []);
 
@@ -150,7 +151,7 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
   });
 
   isTransactionDisabled(transactionTypeIdentifier: string): boolean {
-    return !getTransactionTypeClass(transactionTypeIdentifier);
+    return this.disableTransactionLinks() || !getTransactionTypeClass(transactionTypeIdentifier);
   }
 
   showTransaction(transactionTypeIdentifier: string): boolean {

--- a/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-type-picker/transaction-type-picker.component.ts
@@ -70,7 +70,7 @@ export class TransactionTypePickerComponent extends DestroyerComponent {
 
   readonly isF3X = computed(() => this.report().report_type === ReportTypes.F3X);
   readonly isF3 = computed(() => this.report().report_type === ReportTypes.F3);
-  readonly disableTransactionLinks = computed(() => this.isF3() || this.isF3X());
+  readonly disableTransactionLinks = computed(() => this.isF3();
 
   readonly transactionGroups: Signal<Array<{ label: string; transactionTypes: Set<TransactionTypes> }>> = computed(
     () => CategoryPicker.get(this.category()) ?? [],


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3169

Related PRs:
N/A

We already had an `isTransactionDisabled`, sweet!