### PR TITLE
FECFILE-3107: Updated cypress and pinned uuid packages.

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -68,7 +68,7 @@
     "@typescript-eslint/parser": "8.57.2",
     "@vitest/coverage-v8": "^4.1.1",
     "axe-core": "^4.11.1",
-    "cypress": "15.13.0",
+    "cypress": "15.15.0",
     "cypress-axe": "^1.7.0",
     "cypress-mochawesome-reporter": "4.0.2",
     "cypress-network-idle": "~2.0.1",
@@ -86,7 +86,8 @@
   "overrides": {
     "rollup": "~4.59.0",
     "qs": "~6.15.0",
-    "@isaacs/brace-expansion": "~5.0.1"
+    "@isaacs/brace-expansion": "~5.0.1",
+    "uuid": "~11.1.1"
   },
   "browser": {
     "crypto": false


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3107

Related PRs:
None

We'll want to unpin uuid once cypress-mochawesome-reporter is updated; I'm not holding my breath, though, so I pinned it. Is that cool?