### PR TITLE
FECFILE-3182: frontend-error-log messages logged as ERROR instead of INFO

### DIFF
--- a/deploy-config/front-end-nginx-config/nginx.conf
+++ b/deploy-config/front-end-nginx-config/nginx.conf
@@ -9,8 +9,8 @@ http {
   log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent';
   log_format csp_log_format escape=json '{"log":"csp-report", "body":"$request_body"}';
   log_format frontend_error_log_format escape=json
-    '{"log":"frontend-error", "time":"$time_iso8601",'
-    '"remote_addr":"$remote_addr", "body":"$request_body"}';
+    '{"log":"frontend-error", "time":"$time_iso8601", '
+    '"remote_addr":"$remote_addr", "body":"$request_body", "level":"error"}';
   access_log /dev/stdout cloudfoundry;
   default_type application/octet-stream;
   include mime.types;


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3182

Related PRs:
N/A

Thankfully, this little tweak is sufficient for Kibana to log it as ERROR even when it shows up in `access_log`.