### PR TITLE
Hotfix: Update cf cli install -> DEVELOP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=8.12.0" | tar xzv -C $HOME/bin
+            curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v8&source=github" | tar xzv -C $HOME/bin
 
       - run:
           name: run deploy script


### PR DESCRIPTION
Updates `cf cli install` to use cloudfoundry.org rather than pivitol.io domain.