### PR TITLE
Cleanup isCloneable so it doesn't need to pull in TransactionTypeUtils

### DIFF
--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -5,7 +5,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { environment } from '../../../environments/environment';
 import { AggregationGroups, Transaction } from '../models/transaction.model';
 import { SchATransaction, ScheduleATransactionTypes } from '../models/scha-transaction.model';
-import { testMockStore } from '../utils/unit-test.utils';
+import { getTestIndividualReceipt, getTestTransactionByType, testMockStore } from '../utils/unit-test.utils';
 import { TransactionService } from './transaction.service';
 import { TransactionTypeUtils } from '../utils/transaction-type.utils';
 import { HTTP_INTERCEPTORS, HttpStatusCode, provideHttpClient } from '@angular/common/http';
@@ -235,29 +235,16 @@ describe('TransactionService', () => {
 
   describe('isCloneable', () => {
     it('should return true only for clone-eligible transactions', () => {
-      expect(
-        service.isCloneable({
-          transaction_type_identifier: ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
-        }),
-      ).toBe(true);
-      expect(
-        service.isCloneable({
-          transaction_type_identifier: ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
-          parent_transaction_id: '10',
-        }),
-      ).toBe(false);
-      expect(
-        service.isCloneable({
-          transaction_type_identifier: ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
-          reatt_redes_id: 'original-id',
-          reattribution_redesignation_tag: 'REATTRIBUTED',
-        }),
-      ).toBe(false);
-      expect(
-        service.isCloneable({
-          transaction_type_identifier: ScheduleATransactionTypes.EARMARK_RECEIPT,
-        }),
-      ).toBe(false);
+      let individualReceipt = getTestIndividualReceipt();
+      expect(service.isCloneable(individualReceipt)).toBe(true);
+      individualReceipt.parent_transaction_id = '10';
+      expect(service.isCloneable(individualReceipt)).toBe(false);
+      individualReceipt = getTestIndividualReceipt();
+      individualReceipt.reatt_redes_id = 'original-id';
+      individualReceipt.reattribution_redesignation_tag = 'REATTRIBUTED';
+      expect(service.isCloneable(individualReceipt)).toBe(false);
+      const earmarkReceipt = getTestTransactionByType(ScheduleATransactionTypes.EARMARK_RECEIPT);
+      expect(service.isCloneable(earmarkReceipt)).toBe(false);
       expect(service.isCloneable(undefined)).toBe(false);
     });
   });

--- a/front-end/src/app/shared/utils/transaction-clone.utils.spec.ts
+++ b/front-end/src/app/shared/utils/transaction-clone.utils.spec.ts
@@ -1,4 +1,4 @@
-import { getTestIndividualReceipt } from './unit-test.utils';
+import { getTestIndividualReceipt, getTestTransactionByType } from './unit-test.utils';
 import { ScheduleATransactionTypes } from '../models/scha-transaction.model';
 import { isCloneable, resetCloneCoreFields, resetCloneMemoText } from './transaction-clone.utils';
 
@@ -55,11 +55,8 @@ describe('transaction-clone.utils', () => {
 
   describe('isCloneable', () => {
     it('should reject multi-entry transaction types', () => {
-      expect(
-        isCloneable({
-          transaction_type_identifier: ScheduleATransactionTypes.EARMARK_RECEIPT,
-        }),
-      ).toBe(false);
+      const transaction = getTestTransactionByType(ScheduleATransactionTypes.EARMARK_RECEIPT);
+      expect(isCloneable(transaction)).toBe(false);
     });
   });
 });

--- a/front-end/src/app/shared/utils/transaction-clone.utils.ts
+++ b/front-end/src/app/shared/utils/transaction-clone.utils.ts
@@ -1,9 +1,9 @@
 import { MemoText } from '../models/memo-text.model';
-import { cloneInstance, ScheduleTransaction, Transaction, TransactionTypes } from '../models/transaction.model';
-import { TransactionTypeUtils } from './transaction-type.utils';
+import type { TransactionType } from '../models/transaction-type.model';
+import { cloneInstance, ScheduleTransaction, Transaction } from '../models/transaction.model';
 
 export type CloneEligibilityTransaction = {
-  transaction_type_identifier: string | undefined;
+  transactionType: TransactionType;
   parent_transaction_id?: string;
   loan_id?: string;
   debt_id?: string;
@@ -56,23 +56,10 @@ export function resetCloneMemoText(
   clone.memo_text_id = undefined;
 }
 
-function isCloneableTransactionType(
-  transactionTypeIdentifier: string | undefined,
-): transactionTypeIdentifier is TransactionTypes {
-  if (!transactionTypeIdentifier) {
-    return false;
-  }
-
-  const transactionType = TransactionTypeUtils.factory(transactionTypeIdentifier);
-
-  return transactionType.isCloneableTransactionType && !transactionType.dependentChildTransactionTypes?.length;
-}
-
 export function isCloneable(transaction: CloneEligibilityTransaction | undefined): boolean {
-  if (!transaction) return false;
-
   return (
-    isCloneableTransactionType(transaction.transaction_type_identifier) &&
+    !!transaction?.transactionType.isCloneableTransactionType &&
+    !transaction.transactionType.dependentChildTransactionTypes?.length &&
     !transaction.parent_transaction_id &&
     !transaction.loan_id &&
     !transaction.debt_id &&
@@ -82,15 +69,10 @@ export function isCloneable(transaction: CloneEligibilityTransaction | undefined
 }
 
 export function buildClonedTransaction(source: ScheduleTransaction, reportId: string): Transaction {
-  if (!source.transaction_type_identifier) {
-    throw new Error('FECfile+: Cannot clone a transaction without a transaction_type_identifier.');
-  }
   if (!isCloneable(source)) {
     throw new Error(`FECfile+: This transaction (${source.transaction_type_identifier}) is not eligible for cloning.`);
   }
-
-  const transactionType = TransactionTypeUtils.factory(source.transaction_type_identifier);
-  const clone = transactionType.getNewTransaction();
+  const clone = source.transactionType.getNewTransaction();
   const sourceCopy = cloneInstance(source);
 
   if (sourceCopy) {
@@ -148,7 +130,7 @@ export function buildClonedTransaction(source: ScheduleTransaction, reportId: st
 
   resetCloneMemoText(clone, reportId);
 
-  clone.setMetaProperties(transactionType);
+  clone.setMetaProperties(source.transactionType);
 
   return clone;
 }


### PR DESCRIPTION
I really like what you'd done with setting up isCloneableTransactionType. Here's a slight update to the TransactionCloneUtils so you won't have any dependency on the TransactinTypeUtils, since you're passing in either a Transaction or TransactionListRecord, both of which should have a fully formed TransactionType already attached.