### PR TITLE
FECFILE-3294: Don't disassociate on reattr/redes

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.spec.ts
@@ -6,6 +6,7 @@ import { TransactionFormUtils } from './transaction-form.utils';
 import { SchETransaction, ScheduleETransactionTypes } from 'app/shared/models/sche-transaction.model';
 import { SubscriptionFormControl } from 'app/shared/utils/subscription-form-control';
 import { ScheduleFTransactionTypes, SchFTransaction } from 'app/shared/models/schf-transaction.model';
+import { getTestIndividualReceipt } from 'app/shared/utils/unit-test.utils';
 
 describe('FormUtils', () => {
   const t = new TransactionFormUtils();
@@ -67,6 +68,15 @@ describe('FormUtils', () => {
 
     const aggregateFormControl = form.get('aggregate_amount') as SubscriptionFormControl;
     expect(aggregateFormControl.value).toEqual(50);
+  });
+
+  it('should preserve report_ids on payload when linkedF3xId is not provided', () => {
+    const transaction = getTestIndividualReceipt();
+    transaction.report_ids = ['report-1'];
+
+    const payload = TransactionFormUtils.getPayloadTransaction(transaction, 'active-report', new FormGroup({}), []);
+
+    expect(payload.report_ids).toEqual(['report-1']);
   });
 });
 

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-form.utils.ts
@@ -357,6 +357,9 @@ export class TransactionFormUtils {
     const secondaryReportId = form.get('linkedF3xId')?.value;
     if (secondaryReportId) {
       payload['report_ids'] = [activeReportId, secondaryReportId];
+    } else if (!payload.report_ids?.length) {
+      // If the payload doesn't have any report_ids, defensively add the active report id to it
+      payload.report_ids = transaction.report_ids?.length ? [...transaction.report_ids] : [activeReportId];
     }
 
     return payload;

--- a/front-end/src/app/shared/services/transaction.service.spec.ts
+++ b/front-end/src/app/shared/services/transaction.service.spec.ts
@@ -255,14 +255,17 @@ describe('TransactionService', () => {
         SchATransaction.fromJSON({
           id: '1',
           transaction_type_identifier: ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
+          report_ids: ['report-1'],
         }),
         SchATransaction.fromJSON({
           id: '2',
           transaction_type_identifier: ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
+          report_ids: ['report-1'],
         }),
         SchATransaction.fromJSON({
           id: '3',
           transaction_type_identifier: ScheduleATransactionTypes.INDIVIDUAL_RECEIPT,
+          report_ids: ['report-1'],
         }),
       ];
 
@@ -274,6 +277,9 @@ describe('TransactionService', () => {
 
       const req = httpTestingController.expectOne(`${environment.apiUrl}/transactions/multisave/reattribution/`);
       expect(req.request.method).toEqual('PUT');
+      expect(req.request.body[0].report_ids).toEqual(['report-1']);
+      expect(req.request.body[1].report_ids).toEqual(['report-1']);
+      expect(req.request.body[2].report_ids).toEqual(['report-1']);
       req.flush(transactions.map((t) => t.id));
       httpTestingController.verify();
     });

--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
@@ -133,6 +133,34 @@ describe('ReattRedesUtils', () => {
         ReattRedesTypes.REATTRIBUTION_FROM,
       );
     });
+
+    it('should copy report_ids from TO transaction to originating transaction when missing', () => {
+      const reattributed = getTestIndividualReceipt();
+      reattributed.report_ids = undefined;
+      reattributed.reattribution_redesignation_tag = ReattRedesTypes.REATTRIBUTED;
+
+      const toTxn = getTestIndividualReceipt();
+      toTxn.report_ids = ['999'];
+      toTxn.reattribution_redesignation_tag = ReattRedesTypes.REATTRIBUTION_TO;
+      toTxn.reatt_redes = reattributed;
+
+      const [originating, to] = ReattRedesUtils.getPayloads(toTxn, false);
+
+      expect(originating.report_ids).toEqual(['999']);
+      expect(to.report_ids).toEqual(['999']);
+    });
+
+    it('should preserve report_ids for cloned originating transactions on pull-forward', () => {
+      const payload = testScheduleBTransaction();
+      payload.reattribution_redesignation_tag = ReattRedesTypes.REDESIGNATION_TO;
+      payload.report_ids = ['abc'];
+      payload.reatt_redes = RedesignatedUtils.overlayTransactionProperties(testScheduleBTransaction());
+
+      const [originating, to] = ReattRedesUtils.getPayloads(payload, true);
+
+      expect(originating.report_ids).toEqual(['abc']);
+      expect(to.report_ids).toEqual(['abc']);
+    });
   });
 
   describe('amountValidator', () => {

--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
@@ -97,7 +97,11 @@ export class ReattRedesUtils {
       reattRedes = payload.reatt_redes as SchATransaction | SchBTransaction;
     }
 
-    const reportIds = to.report_ids?.length ? [...to.report_ids] : reattRedes.report_ids?.length ? [...reattRedes.report_ids] : undefined;
+    const reportIds = to.report_ids?.length
+      ? [...to.report_ids]
+      : reattRedes.report_ids?.length
+        ? [...reattRedes.report_ids]
+        : undefined;
     if (reportIds?.length) {
       to.report_ids = reportIds;
       reattRedes.report_ids = reportIds;

--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
@@ -97,6 +97,12 @@ export class ReattRedesUtils {
       reattRedes = payload.reatt_redes as SchATransaction | SchBTransaction;
     }
 
+    const reportIds = to.report_ids?.length ? [...to.report_ids] : reattRedes.report_ids?.length ? [...reattRedes.report_ids] : undefined;
+    if (reportIds?.length) {
+      to.report_ids = reportIds;
+      reattRedes.report_ids = reportIds;
+    }
+
     return [reattRedes, to];
   }
 


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3294

Related PRs:
N/A

* Updated `getPayloads()` to check `to.report_ids` and `reattRedes.report_ids` for values and set both to those values.
* Updated `getPayloadTransaction()` to defensively set `report_ids` to `activeReportId` if `report_ids` is empty. This is not necessary for the fix and I'm not sure if it's a good idea -- maybe it'd be better to fail loudly if/when encountering another situation where `report_ids` is empty.
* Added some tests for the above.