### PR TITLE
FECFILE-3311: Add CLEAN flag to force running npm ci.

### DIFF
--- a/front-end/docker-compose.yml
+++ b/front-end/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       BUILD_SCRIPT: ${BUILD_SCRIPT:-build-local}
       PORT: ${PORT:-4200}
       WATCH: ${WATCH:-0}
+      CLEAN: ${CLEAN:-0}
       LIKE_PROD: ${LIKE_PROD:-0}
       API_URL: ${API_URL:-http://localhost:8080}
       APP_URL: ${APP_URL:-http://localhost:4200}

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -10,6 +10,7 @@
     "local_aot": "npx @angular/cli ng serve --configuration=local --aot",
     "local_aot_memory": "npx --node-options='--max-old-space-size=4000' -y -p @angular/cli ng serve --configuration=local --aot",
     "local:up": "bash -lc 'trap \"docker compose down --volumes --remove-orphans; rm -rf .tmp\" EXIT INT TERM;docker compose up'",
+    "local:up:clean": "bash -lc 'trap \"docker compose down --volumes --remove-orphans; rm -rf .tmp\" EXIT INT TERM;CLEAN=1 docker compose up'",
     "local:watch:up": "bash -lc 'trap \"docker compose --profile watch down --volumes --remove-orphans; rm -rf .tmp\" EXIT INT TERM; WATCH=1 docker compose --profile watch up'",
     "local:down": "bash -lc 'docker compose down --volumes --remove-orphans; rm -rf .tmp'",
     "local:watch:down": "bash -lc 'docker compose --profile watch down --volumes --remove-orphans; rm -rf .tmp'",

--- a/front-end/scripts/compose-build-render.sh
+++ b/front-end/scripts/compose-build-render.sh
@@ -46,10 +46,12 @@ cleanup() {
 
 trap cleanup EXIT
 
-mkdir -p "$FRONTEND_DIR/.tmp"
-if [[ "$HOST_UID" != "0" ]]; then
-  # immediately chown .tmp to host user
-  chown -R $HOST_UID:$HOST_GID "$FRONTEND_DIR/.tmp" 2>/dev/null || true
+if [[ "$MODE" == "$PREPARE_MODE" ]]; then
+  # create and chown .tmp during prepare only
+  mkdir -p "$FRONTEND_DIR/.tmp"
+  if [[ "$HOST_UID" != "0" ]]; then
+    chown -R $HOST_UID:$HOST_GID "$FRONTEND_DIR/.tmp" 2>/dev/null || true
+  fi
 fi
 
 if [[ "$MODE" == "$PREPARE_MODE" ]]; then
@@ -114,7 +116,9 @@ APP_URL="$APP_URL" \
 NGINX_CONF_PATH="$NGINX_CONF_PATH" \
 "$SCRIPT_DIR/render-nginx-local-config.sh"
 
-chmod -R a+w "$FRONTEND_DIR/.tmp"
+if [[ "$MODE" == "$PREPARE_MODE" ]]; then
+  chmod -R a+w "$FRONTEND_DIR/.tmp"
+fi
 
 if [[ "$MODE" == "$REBUILD_MODE" ]]; then
   echo "Rebuild complete."

--- a/front-end/scripts/compose-build-render.sh
+++ b/front-end/scripts/compose-build-render.sh
@@ -17,6 +17,7 @@ fi
 BUILD_SCRIPT="${BUILD_SCRIPT:-build-local}"
 PORT="${PORT:-4200}"
 WATCH="${WATCH:-0}"
+CLEAN="${CLEAN:-0}"
 LIKE_PROD="${LIKE_PROD:-0}"
 API_URL="${API_URL:-http://localhost:8080}"
 APP_URL="${APP_URL:-http://localhost:${PORT}}"
@@ -79,6 +80,11 @@ BUILD_LOG_PATH="$(mktemp "$FRONTEND_DIR/.tmp/build.output.XXXXXX.log")"
 if [[ "$MODE" == "$PREPARE_MODE" ]]; then
   echo "Building frontend using npm run $BUILD_SCRIPT ..."
 
+  if [[ "$CLEAN" == "1" ]]; then
+    echo "CLEAN requested. Running npm ci to clean install dependencies..."
+    npm ci
+  fi
+
   if npm run "$BUILD_SCRIPT" 2>&1 | tee "$BUILD_LOG_PATH"; then
     :
   else
@@ -88,14 +94,6 @@ if [[ "$MODE" == "$PREPARE_MODE" ]]; then
   fi
 else
   echo "Change detected. Rebuilding..."
-  npm run "$BUILD_SCRIPT"
-fi
-
-if npm run "$BUILD_SCRIPT" 2>&1 | tee "$BUILD_LOG_PATH"; then
-  :
-else
-  echo "Initial build failed. Running npm ci and then retrying build..."
-  npm ci
   npm run "$BUILD_SCRIPT"
 fi
 


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3311

Related PRs:
N/A

I also added a fix for an issue I was seeing where the browser reload signal was sent early (and in error) before the build was complete and then again (correctly) when the build completed.  This was because we were creating `.tmp/` and `chown`ing it at the start of every rebuild when that only needed to happen during the initial preparation.