### PR TITLE
patch/3225 - Add a fix to make sure save button is enabled on clone

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -80,6 +80,8 @@ export abstract class TransactionTypeBaseComponent extends FormComponent impleme
         const navigationEvent = cloneNavigationEvent(navEvent);
         this.handleNavigate(navigationEvent);
         this.store.dispatch(navigationEventClearAction());
+        // Hack until we can fix single click directive
+        this.store.dispatch(singleClickEnableAction());
       }
     });
   }


### PR DESCRIPTION
Issue [FECFILE-3225](https://fecgov.atlassian.net/browse/FECFILE-3225)

Fixes a bug where sometimes when cloning from a new transaction the save button is disabled. This is due to an underlying issue with our single click directive which should be addressed in a different ticket.