### PR TITLE
Patch/3301 - Fix Reattribution from previous report not showing in dropdown

### DIFF
--- a/front-end/cypress/e2e-smoke/F3X/reattributions.cy.ts
+++ b/front-end/cypress/e2e-smoke/F3X/reattributions.cy.ts
@@ -8,6 +8,8 @@ import { ContactLookup } from '../pages/contactLookup';
 import { ReportListPage } from '../pages/reportListPage';
 import { buildScheduleA } from '../requests/library/transactions';
 import { makeTransaction } from '../requests/methods';
+import { F3X_Q2, F3X_Q3 } from '../requests/library/reports';
+import { TransactionListPage } from '../pages/f3xTransactionListPage';
 
 const reattributeData: ScheduleFormData = {
   amount: 100.55,
@@ -61,6 +63,20 @@ describe('Reattributions', () => {
     });
   });
   // Test disabled until a mock is set up for submitting a report.
-  xit('should test reattributing a Schedule A in a submitted report', () => {
+  it('should test reattributing a Schedule A in a submitted report', () => {
+    DataSetup({ individual: true, candidate: true, reports: [F3X_Q2, F3X_Q3] }).then((result: any) => {
+      const receipt = buildScheduleA('INDIVIDUAL_RECEIPT', 100.55, `${currentYear}-04-12`, result.individual, result.report);
+      makeTransaction(receipt, () => {
+        cy.intercept('POST', '**/api/v1/web-services/submit-to-fec/**').as('SubmitToFec');
+        ReportListPage.goToReportSubmitPage(result.report, 'f3x');
+        cy.get('#userCertified').check()
+        cy.get('input[type="password"]').type('your_secure_password')
+        cy.get('#form button[type="submit"]:enabled').click();
+        TransactionDetailPage.clickConfirmContactUpdate();
+        cy.wait('@SubmitToFec')
+        ReportListPage.gotToReportTransactionListPage(result.report);
+        TransactionListPage.assertTransactionActionExists('Individual Receipt','Reattribute')
+      });
+    });
   });
 });

--- a/front-end/cypress/e2e-smoke/pages/reportListPage.ts
+++ b/front-end/cypress/e2e-smoke/pages/reportListPage.ts
@@ -126,6 +126,10 @@ export class ReportListPage {
     );
   }
 
+  static goToReportSubmitPage(reportId: string, formType: string) {
+    cy.visit(`/reports/${formType}/submit/${reportId}`);
+  }
+
   private static checkReportTransactionListPageLoaded(
     reportId: string,
     includeReceipts = true,

--- a/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
+++ b/front-end/src/app/reports/transactions/transaction-list/transaction-list-table-base.component.ts
@@ -177,7 +177,7 @@ export abstract class TransactionListTableBaseComponent
     new TableAction(
       'Reattribute',
       this.createReattribution.bind(this),
-      (transaction: TransactionListRecord) => this.reportIsEditable() && ReattRedesUtils.canReattribute(transaction),
+      (transaction: TransactionListRecord) => ReattRedesUtils.canReattribute(transaction),
       () => true,
     ),
     new TableAction(

--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.spec.ts
@@ -65,6 +65,14 @@ describe('ReattRedesUtils', () => {
       limitTxn.contribution_amount = 100;
       expect(ReattRedesUtils.canReattribute(asListRecord(limitTxn))).toBe(false);
     });
+
+    it('should block reattribution for transactions that are themselves reattributions', () => {
+      const individual_receipt = getTestIndividualReceipt();
+      individual_receipt.reattribution_redesignation_tag = ReattRedesTypes.REATTRIBUTION_FROM;
+      expect(ReattRedesUtils.canReattribute(asListRecord(individual_receipt))).toBe(false);
+      individual_receipt.reattribution_redesignation_tag = ReattRedesTypes.REATTRIBUTION_TO;
+      expect(ReattRedesUtils.canReattribute(asListRecord(individual_receipt))).toBe(false);
+    });
   });
 
   describe('overlayForms', () => {

--- a/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
+++ b/front-end/src/app/shared/utils/reatt-redes/reatt-redes.utils.ts
@@ -46,6 +46,10 @@ export class ReattRedesUtils {
     return (
       !transaction.parent_transaction_id &&
       transaction.transactionType.isReattributable &&
+      !ReattRedesUtils.isReattRedes(transaction, [
+        ReattRedesTypes.REATTRIBUTION_FROM,
+        ReattRedesTypes.REATTRIBUTION_TO,
+      ]) &&
       !ReattRedesUtils.isAtAmountLimit(transaction)
     );
   }


### PR DESCRIPTION
Issue [FECFILE-3301](https://fecgov.atlassian.net/browse/FECFILE-3301)

Issue was that the reattribute action item should not have been blocked by the reports editable status.
Added an e2e test as well.
You won't be able to save the reattribution for the same problem that exists for redesignation on [FECFILE-3302](https://fecgov.atlassian.net/browse/FECFILE-3302)