### PR TITLE
Fixes enabling/disabling save button on transactions

### DIFF
--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
@@ -30,6 +30,7 @@ import { derivedAsync } from 'ngxtension/derived-async';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { MenuItem } from 'primeng/api';
 import { singleClickDisableAction } from 'app/store/single-click.actions';
+import { selectSingleClickDisabled } from 'app/store/single-click.selectors';
 
 @Component({
   selector: 'app-navigation-control',
@@ -83,7 +84,12 @@ export class NavigationControlComponent {
   ];
 
   // This could be a signal but the transaction data is getting updated out of sync
-  readonly isDisabled = () => !!this.navigationControl()?.disabledCondition(this.transaction());
+  readonly isDisabled = () => {
+    return (
+      this.store.selectSignal(selectSingleClickDisabled)() ||
+      !!this.navigationControl()?.disabledCondition(this.transaction())
+    );
+  };
   readonly controlType = ControlType;
   readonly type = computed(() => this.navigationControl().controlType);
 

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -80,8 +80,6 @@ export abstract class TransactionTypeBaseComponent extends FormComponent impleme
         const navigationEvent = cloneNavigationEvent(navEvent);
         this.handleNavigate(navigationEvent);
         this.store.dispatch(navigationEventClearAction());
-        // Hack until we can fix single click directive
-        this.store.dispatch(singleClickEnableAction());
       }
     });
   }


### PR DESCRIPTION
https://fecgov.atlassian.net/browse/FECFILE-3336
I started by removing the change this sprint that enables the button more than we want.  That got me to a place where we were [here](https://fecgov.atlassian.net/browse/FECFILE-3225?focusedCommentId=59686).  So we need to fix the situation where the "save | v" button is disabled when we click "save > clone" on a brand new transaction.   I added console statements and breakpoints to this situation and determined the directive was correctly getting to the point where it should enable the button https://github.com/fecgov/fecfile-web-app/blob/1828c885fc95b08d8229d4ceafd4543d81ba2634/front-end/src/app/shared/directives/single-click.directive.ts#L16-L19
I also printed out the value of https://github.com/fecgov/fecfile-web-app/blob/1828c885fc95b08d8229d4ceafd4543d81ba2634/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts#L86
both of these were correctly resolving to true.  That tells me that the state of the `selectSingleClickDisabled` selector is in fact correct, we're just not updating the button to reresolve it's state.

My fix is to add a selectSignal to isDisabled() on the navigation control component so that it's always taken into account.

To test this:
-  You can test the scenario again mentioned [here](https://fecgov.atlassian.net/browse/FECFILE-3225?focusedCommentId=59686) where we select "save > clone" on a new transaction.  It should result in the save button being enabled.
- Also, you can test that saving a new individual receipt immediately disables the save button after clicking so you cannot double click it to save two transactions
