### PR TITLE
Gets rid of update to disabled save button and reloads component instead

### DIFF
--- a/front-end/src/app/custom-route-reuse-strategy.ts
+++ b/front-end/src/app/custom-route-reuse-strategy.ts
@@ -12,7 +12,7 @@ export class CustomRouteReuseStrategy extends BaseRouteReuseStrategy {
     // which will return true, when we are navigating from the same component to itself
     let shouldReuse = super.shouldReuseRoute(future, current);
 
-    if (shouldReuse && current.data['noComponentReuse']) {
+    if (shouldReuse && (current.data['noComponentReuse'] || !!current.paramMap.get('clone'))) {
       shouldReuse = false;
     }
 

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
@@ -84,12 +84,7 @@ export class NavigationControlComponent {
   ];
 
   // This could be a signal but the transaction data is getting updated out of sync
-  readonly isDisabled = () => {
-    return (
-      this.store.selectSignal(selectSingleClickDisabled)() ||
-      !!this.navigationControl()?.disabledCondition(this.transaction())
-    );
-  };
+  readonly isDisabled = () => !!this.navigationControl()?.disabledCondition(this.transaction());
   readonly controlType = ControlType;
   readonly type = computed(() => this.navigationControl().controlType);
 

--- a/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
+++ b/front-end/src/app/shared/components/navigation-control/navigation-control.component.ts
@@ -30,7 +30,6 @@ import { derivedAsync } from 'ngxtension/derived-async';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { MenuItem } from 'primeng/api';
 import { singleClickDisableAction } from 'app/store/single-click.actions';
-import { selectSingleClickDisabled } from 'app/store/single-click.selectors';
 
 @Component({
   selector: 'app-navigation-control',


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3336

Related PRs: https://github.com/fecgov/fecfile-web-app/pull/4241

the related pr did address the issue from https://github.com/fecgov/fecfile-web-app/pull/4219 in a different way, and it did appear to make the button disabled.  It was still possible, however, to rapidly click the button and get multiple copies (the issue in FECFILE-3336).

This pr solves the problem https://github.com/fecgov/fecfile-web-app/pull/4219 was solving, without enabling the button prematurely. 

Please while testing this ensure that the following work:
Open a new transaction -> save & clone -> you should be able to save the clone transaction
Open a new transaction -> rapid click save -> only one transaction should be created