### PR TITLE
[Sprint 93] feature/3328 - Memo code should not be optional when status of memo control is disabled.

### DIFF
--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.spec.ts
@@ -589,13 +589,26 @@ describe('TransactionTypeBaseComponent', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should return optional label if memo not required', async () => {
+    it('should return optional label if memo not required and control is not disabled', async () => {
       fixture.detectChanges();
       if (!component.transactionType) throw new Error('Bad test');
-      component.form.get(component.transactionType?.templateMap.memo_code)?.clearValidators();
+      const memoControl = component.form.get(component.transactionType?.templateMap.memo_code)!;
+      memoControl.clearValidators();
+      memoControl.enable();
       const spy = vi.spyOn(TransactionFormUtils, 'isMemoCodeReadOnly').mockReturnValue(false);
       const res = await firstValueFrom(component.getMemoHasOptional$(component.form, component.transactionType));
       expect(res).toEqual(true);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not return optional label if memo not required and control is disabled', async () => {
+      fixture.detectChanges();
+      if (!component.transactionType) throw new Error('Bad test');
+      const memoControl = component.form.get(component.transactionType?.templateMap.memo_code)!;
+      memoControl.clearValidators();
+      const spy = vi.spyOn(TransactionFormUtils, 'isMemoCodeReadOnly').mockReturnValue(false);
+      const res = await firstValueFrom(component.getMemoHasOptional$(component.form, component.transactionType));
+      expect(res).toEqual(false);
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
+++ b/front-end/src/app/shared/components/transaction-type-base/transaction-type-base.component.ts
@@ -10,7 +10,7 @@ import { LabelUtils, PrimeOptions } from 'app/shared/utils/label.utils';
 import { getContactTypeOptions } from 'app/shared/utils/transaction-type-properties';
 import { SchemaUtils } from 'app/shared/utils/schema.utils';
 import { MessageService, SelectItem, ToastMessageOptions } from 'primeng/api';
-import { map, Observable, of, startWith, takeUntil } from 'rxjs';
+import { map, merge, Observable, of, startWith, takeUntil } from 'rxjs';
 import { ContactIdMapType, TransactionContactUtils } from './transaction-contact.utils';
 import { TransactionFormUtils } from './transaction-form.utils';
 import { ReattRedesUtils } from 'app/shared/utils/reatt-redes/reatt-redes.utils';
@@ -335,9 +335,9 @@ export abstract class TransactionTypeBaseComponent extends FormComponent impleme
   getMemoHasOptional$(form: FormGroup, transactionType: TransactionType): Observable<boolean> {
     const memoControl = form.get(transactionType?.templateMap.memo_code);
     if (TransactionFormUtils.isMemoCodeReadOnly(transactionType) || !memoControl) return of(false);
-    return memoControl.valueChanges.pipe(
-      map(() => !memoControl.hasValidator(Validators.requiredTrue)),
-      startWith(true),
+    return merge(memoControl.valueChanges, memoControl.statusChanges).pipe(
+      startWith(null),
+      map(() => !memoControl.disabled && !memoControl.hasValidator(Validators.requiredTrue)),
       takeUntil(this.destroy$),
     );
   }


### PR DESCRIPTION
Issue [FECFILE-3328](https://fecgov.atlassian.net/browse/FECFILE-3328)