### PR TITLE
Patch/3303-2

### DIFF
--- a/front-end/src/app/shared/services/transaction-list-unassociated.service.ts
+++ b/front-end/src/app/shared/services/transaction-list-unassociated.service.ts
@@ -7,15 +7,16 @@ import { TransactionListService } from './transaction-list.service';
   providedIn: 'root',
 })
 export class UnassociatedTransactionListService extends TransactionListService {
-  override async getTableData(_pageNumber = 1, ordering = '', _params: QueryParams = {}): Promise<ListRestResponse> {
-    if (!ordering) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override async getTableData(pageNumber = 1, ordering = '', params: QueryParams = {}): Promise<ListRestResponse> {
+    /*if (!ordering) {
       ordering = 'line_label,created';
     }
     if (ordering === '-line_label,created') {
       ordering = '-line_label,-created';
     }
 
-    /*const response = await this.apiService.get<ListRestResponse>(
+    const response = await this.apiService.get<ListRestResponse>(
       `/transactions/list/unassociated/?page=${pageNumber}&ordering=${ordering}`,
       params,
     );

--- a/front-end/src/app/shared/services/transaction-list-unassociated.service.ts
+++ b/front-end/src/app/shared/services/transaction-list-unassociated.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { ListRestResponse } from '../models';
-import { TransactionListRecord } from '../models/transaction-list-record.model';
 import { QueryParams } from './api.service';
 import { TransactionListService } from './transaction-list.service';
 
@@ -8,7 +7,7 @@ import { TransactionListService } from './transaction-list.service';
   providedIn: 'root',
 })
 export class UnassociatedTransactionListService extends TransactionListService {
-  override async getTableData(pageNumber = 1, ordering = '', params: QueryParams = {}): Promise<ListRestResponse> {
+  override async getTableData(_pageNumber = 1, ordering = '', _params: QueryParams = {}): Promise<ListRestResponse> {
     if (!ordering) {
       ordering = 'line_label,created';
     }
@@ -16,12 +15,21 @@ export class UnassociatedTransactionListService extends TransactionListService {
       ordering = '-line_label,-created';
     }
 
-    const response = await this.apiService.get<ListRestResponse>(
+    /*const response = await this.apiService.get<ListRestResponse>(
       `/transactions/list/unassociated/?page=${pageNumber}&ordering=${ordering}`,
       params,
     );
     response.results = response.results.map((item) => TransactionListRecord.fromJSON(item));
     response.pageNumber = pageNumber;
-    return response;
+    return response;*/
+
+    // Stubbing out the return for the moment, since the tables aren't yet configured for real use
+    return {
+      count: 0,
+      next: '',
+      previous: '',
+      pageNumber: 1,
+      results: [],
+    };
   }
 }

--- a/front-end/src/app/unassociated-transaction-list/unassociated-transaction-list.component.scss
+++ b/front-end/src/app/unassociated-transaction-list/unassociated-transaction-list.component.scss
@@ -6,10 +6,7 @@
   }
 
   .p-tab {
-    padding-top: 0px;
-    padding-left: 0px;
-    padding-right: 0px;
-    padding-bottom: 8px;
+    padding: 0px 0px 8px 0px;
   }
 
   .p-tablist-active-bar {
@@ -24,10 +21,7 @@
   }
 
   .p-tabpanels {
-    padding-top: 32px;
-    padding-bottom: 0px;
-    padding-left: 0px;
-    padding-right: 0px;
+    padding: 32px 0px 0px 0px;
   }
 
   .tab-description {

--- a/front-end/src/app/unassociated-transaction-list/unassociated-transaction-receipts/unassociated-transaction-receipts.component.ts
+++ b/front-end/src/app/unassociated-transaction-list/unassociated-transaction-receipts/unassociated-transaction-receipts.component.ts
@@ -1,10 +1,11 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, Signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { UnassociatedTransactionListService } from 'app/shared/services/transaction-list-unassociated.service';
 import { TransactionReceiptsComponent } from 'app/reports/transactions/transaction-list/transaction-receipts/transaction-receipts.component';
-import { TableComponent } from '../../shared/components/table/table.component';
+import { ColumnDefinition, TableComponent } from '../../shared/components/table/table.component';
 import { TableActionsButtonComponent } from '../../shared/components/table-actions-button/table-actions-button.component';
 import { LabelPipe } from 'app/shared/pipes/label.pipe';
+import { TransactionListRecord } from 'app/shared/models/transaction-list-record.model';
 
 @Component({
   selector: 'app-unassociated-transaction-receipts',
@@ -17,4 +18,27 @@ import { LabelPipe } from 'app/shared/pipes/label.pipe';
 })
 export class UnassociatedTransactionReceiptsComponent extends TransactionReceiptsComponent {
   override readonly itemService = inject(UnassociatedTransactionListService);
+
+  override readonly columns: Signal<ColumnDefinition<TransactionListRecord>[]> = computed(() => [
+    this.buildLineColumn(),
+    this.buildTypeColumn(this.typeBodyTpl()),
+    this.buildNameColumn(),
+    this.buildDateColumn(),
+    {
+      field: 'memo_code',
+      header: 'Memo',
+      sortable: true,
+      cssClass: 'memo-column',
+      pipes: ['memoCode'],
+    },
+    this.buildAmountColumn(),
+    this.buildTransactionIdColumn(),
+    this.buildAssociatedWithColumn(),
+    {
+      field: '',
+      header: 'Actions',
+      cssClass: 'actions-column',
+      bodyTpl: this.actionsBodyTpl(),
+    },
+  ]);
 }


### PR DESCRIPTION
- Disables the request to the unassociated transaction endpoint for now.
- Removes the Aggregate column on the unassociated receipts table.
- Updates CSS in accordance with @sasha-dresden and @danguyf 's feedback

Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3303

Related PRs:
